### PR TITLE
fix(ContentRepository): handle null createdAt in saveImage method

### DIFF
--- a/src/main/java/edens/zac/portfolio/backend/dao/ContentRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/ContentRepository.java
@@ -400,7 +400,7 @@ public class ContentRepository extends BaseDao {
       MapSqlParameterSource contentParams =
           createParameterSource()
               .addValue("contentType", ContentType.IMAGE.name())
-              .addValue("createdAt", entity.getCreatedAt())
+              .addValue("createdAt", entity.getCreatedAt() != null ? entity.getCreatedAt() : now)
               .addValue("updatedAt", entity.getUpdatedAt() != null ? entity.getUpdatedAt() : now);
 
       Long contentId = insertAndReturnId(contentSql, "id", contentParams);

--- a/src/main/java/edens/zac/portfolio/backend/services/ImageProcessingService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/ImageProcessingService.java
@@ -375,7 +375,9 @@ public class ImageProcessingService {
       }
     }
 
-    // No duplicate found: create new entity
+    // No duplicate found: create new entity.
+    // createdAt is sourced from EXIF createDate when present; ContentRepository.saveImage
+    // falls back to upload time when EXIF createDate is absent (e.g. film scans).
     ContentImageEntity entity =
         ContentImageEntity.builder()
             .contentType(ContentType.IMAGE)

--- a/src/test/java/edens/zac/portfolio/backend/services/ImageProcessingServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/ImageProcessingServiceTest.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -199,6 +200,30 @@ class ImageProcessingServiceTest {
     assertEquals(ImageProcessingService.DedupeAction.CREATE, result.action());
     // Should never attempt dedupe lookup
     verify(contentRepository, never()).findByOriginalFilenameAndCaptureDate(any(), any());
+  }
+
+  @Test
+  void savePreparedImageWithDedupe_create_passesNullCreatedAtToDao_whenExifCreateDateAbsent() {
+    // Regression for film scans: no EXIF DateTimeOriginal means
+    // parseExifDateToLocalDateTime(null) returns null. The service hands a null createdAt
+    // to ContentRepository.saveImage, which is responsible for falling back to upload time
+    // so the NOT NULL constraint on content.created_at is satisfied.
+    ImageProcessingService.PreparedImageData prepared =
+        createPreparedImageData("film_scan.jpg", null, LocalDateTime.now());
+    when(imageMetadataExtractor.parseExifDateToLocalDateTime(null)).thenReturn(null);
+
+    ContentImageEntity savedEntity = createContentImageEntity();
+    when(contentRepository.saveImage(any(ContentImageEntity.class))).thenReturn(savedEntity);
+
+    ImageProcessingService.DedupeResult result =
+        imageProcessingService.savePreparedImageWithDedupe(prepared, "Film Scan");
+
+    ArgumentCaptor<ContentImageEntity> captor = ArgumentCaptor.forClass(ContentImageEntity.class);
+    verify(contentRepository).saveImage(captor.capture());
+    assertNull(
+        captor.getValue().getCreatedAt(),
+        "absent EXIF createDate -> null entity.createdAt -> DAO fills with upload time");
+    assertEquals(ImageProcessingService.DedupeAction.CREATE, result.action());
   }
 
   // Helper methods


### PR DESCRIPTION
Updated ContentRepository to use the current time as a fallback for createdAt when it is null. Enhanced comments in ImageProcessingService to clarify the source of createdAt for new entities. Added a regression test to ensure that null createdAt is correctly passed to the DAO, allowing it to default to upload time when EXIF data is absent.