### PR TITLE
feat(gallery): add configurable secure cookie attribute for gallery a…

### DIFF
--- a/src/main/java/edens/zac/portfolio/backend/controller/prod/CollectionControllerProd.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/prod/CollectionControllerProd.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
@@ -49,6 +50,15 @@ public class CollectionControllerProd {
   private final ClientGalleryAuthService clientGalleryAuthService;
   private final CollectionService collectionService;
   private final ClientGalleryAccessLimiter accessLimiter;
+
+  /**
+   * Whether the per-gallery access cookie is set with the {@code Secure} attribute. Always {@code
+   * true} in production; the {@code dev} profile overrides this to {@code false} so the gate is
+   * unlockable over plain {@code http://localhost} (browsers refuse Secure cookies on insecure
+   * origins, which silently breaks the cookie-driven gate).
+   */
+  @Value("${app.gallery-access.cookie-secure:true}")
+  private boolean galleryCookieSecure;
 
   /**
    * Get all collections with basic info (paginated).
@@ -173,9 +183,12 @@ public class CollectionControllerProd {
   /**
    * Validate client gallery access with password.
    *
-   * <p>On success, sets a {@code gallery_access_<slug>} HttpOnly+Secure+SameSite=Strict cookie
-   * carrying the HMAC access token. The cookie is sent automatically by the browser on subsequent
-   * GET /collections/{slug} requests, so the access token never needs to be exposed to JavaScript.
+   * <p>On success, sets a {@code gallery_access_<slug>} HttpOnly+SameSite=Strict cookie carrying
+   * the HMAC access token. The {@code Secure} attribute is governed by {@code
+   * app.gallery-access.cookie-secure} (default {@code true}; overridden to {@code false} by the
+   * {@code dev} profile to support plain-http localhost). The cookie is sent automatically by the
+   * browser on subsequent GET /collections/{slug} requests, so the access token never needs to be
+   * exposed to JavaScript.
    *
    * <p>Rate-limited per {@code (ip, slug)} pair via {@link ClientGalleryAccessLimiter} (default 5
    * attempts / 15 min). Returns 429 once the limit is exceeded.
@@ -212,7 +225,7 @@ public class CollectionControllerProd {
     ResponseCookie cookie =
         ResponseCookie.from(cookieName(slug), token)
             .httpOnly(true)
-            .secure(true)
+            .secure(galleryCookieSecure)
             .sameSite("Strict")
             .path("/")
             .maxAge(GALLERY_COOKIE_MAX_AGE)

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,6 @@
+# Dev profile overrides. Activated via SPRING_PROFILES_ACTIVE=dev.
+
+# Localhost runs over plain http, so the gallery access cookie cannot carry the
+# Secure flag (browsers silently drop Secure cookies on insecure origins, which
+# locks the gate after a successful password submit).
+app.gallery-access.cookie-secure=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -76,6 +76,13 @@ app.contact.rate-limit-per-hour=500
 app.contact.rate-limit-per-email-per-hour=5
 
 #----------------------------------------#
+# Client gallery access cookie
+# Production must keep cookie-secure=true. The dev profile overrides this to false
+# so the gate can be unlocked over plain http://localhost (browsers reject Secure
+# cookies on insecure origins). Override via env if running TLS locally.
+app.gallery-access.cookie-secure=${GALLERY_COOKIE_SECURE:true}
+
+#----------------------------------------#
 # Email (AWS SES v2)
 # Disabled by default — flip to true once SES domain + from-address verification land.
 email.enabled=${EMAIL_ENABLED:false}

--- a/src/test/java/edens/zac/portfolio/backend/controller/prod/CollectionControllerProdTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/prod/CollectionControllerProdTest.java
@@ -40,6 +40,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -63,6 +64,11 @@ class CollectionControllerProdTest {
   void setUp() {
     objectMapper = new ObjectMapper();
     objectMapper.findAndRegisterModules();
+
+    // @Value-injected fields are not populated by Mockito's @InjectMocks. Mirror the
+    // production default (Secure=true) so the existing cookie().secure(true) assertion
+    // covers the prod profile; a separate test below pins the dev-profile path.
+    ReflectionTestUtils.setField(contentCollectionController, "galleryCookieSecure", true);
 
     mockMvc =
         MockMvcBuilders.standaloneSetup(contentCollectionController)
@@ -390,6 +396,38 @@ class CollectionControllerProdTest {
         .andExpect(cookie().path("gallery_access_test-client-gallery", "/"))
         .andExpect(cookie().maxAge("gallery_access_test-client-gallery", 24 * 60 * 60))
         // SameSite is not exposed via cookie() matchers; check the raw header
+        .andExpect(header().string("Set-Cookie", containsString("SameSite=Strict")));
+  }
+
+  @Test
+  @DisplayName(
+      "POST /collections/{slug}/access in dev profile (cookie-secure=false) should omit Secure attr")
+  void validateClientGalleryAccess_devProfile_shouldOmitSecureCookieAttribute() throws Exception {
+    // Localhost runs over plain http; browsers silently reject Secure cookies on
+    // insecure origins, which would lock the gate after a successful submit. The
+    // dev profile flips app.gallery-access.cookie-secure to false to keep the
+    // cookie storable. Production must keep Secure on (covered by the test above).
+    ReflectionTestUtils.setField(contentCollectionController, "galleryCookieSecure", false);
+
+    PasswordRequest passwordRequest = new PasswordRequest("correct-password");
+    when(accessLimiter.allow(anyString(), eq("test-client-gallery"))).thenReturn(true);
+    when(clientGalleryAuthService.validateClientGalleryAccess(
+            eq("test-client-gallery"), eq("correct-password")))
+        .thenReturn(true);
+    when(clientGalleryAuthService.generateAccessToken(eq("test-client-gallery")))
+        .thenReturn("hmac-token|1234567890");
+
+    mockMvc
+        .perform(
+            post("/api/read/collections/test-client-gallery/access")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(passwordRequest)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.hasAccess", is(true)))
+        .andExpect(cookie().exists("gallery_access_test-client-gallery"))
+        .andExpect(cookie().httpOnly("gallery_access_test-client-gallery", true))
+        .andExpect(cookie().secure("gallery_access_test-client-gallery", false))
+        .andExpect(header().string("Set-Cookie", not(containsString("Secure"))))
         .andExpect(header().string("Set-Cookie", containsString("SameSite=Strict")));
   }
 


### PR DESCRIPTION
…ccess

- Introduced a new property `app.gallery-access.cookie-secure` to control the Secure attribute of the gallery access cookie, defaulting to true in production and set to false in the dev profile to support local development over HTTP.
- Updated `CollectionControllerProd` to utilize this property for setting the Secure flag on cookies.
- Added corresponding configuration in `application-dev.properties` and `application.properties`.
- Enhanced tests in `CollectionControllerProdTest` to validate behavior under both production and dev profiles regarding the Secure attribute of the cookie.