### PR TITLE
feat(downloads): support format=original for image + collection ZIP

### DIFF
--- a/src/main/java/edens/zac/portfolio/backend/controller/prod/ContentDownloadControllerProd.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/prod/ContentDownloadControllerProd.java
@@ -2,7 +2,7 @@ package edens.zac.portfolio.backend.controller.prod;
 
 import edens.zac.portfolio.backend.config.GalleryAccessCookies;
 import edens.zac.portfolio.backend.entity.CollectionEntity;
-import edens.zac.portfolio.backend.entity.ContentImageEntity;
+import edens.zac.portfolio.backend.model.DownloadResolution;
 import edens.zac.portfolio.backend.services.ClientGalleryAuthService;
 import edens.zac.portfolio.backend.services.CollectionService;
 import edens.zac.portfolio.backend.services.ContentService;
@@ -12,7 +12,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import lombok.RequiredArgsConstructor;
@@ -35,24 +34,22 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 
 /**
- * Authenticated download endpoints for client galleries. Streams WebP-only assets directly from S3
- * to the response so memory stays flat regardless of gallery size.
+ * Authenticated download endpoints for client galleries. Streams assets directly from S3 to the
+ * response so memory stays flat regardless of gallery size.
+ *
+ * <p>This controller stays thin: format/field selection, fallback rules, and filename/MIME
+ * decisions all live in {@link ContentService}. The controller is responsible only for HTTP
+ * concerns -- parsing parameters, the gallery-access cookie auth gate, and S3 streaming.
  *
  * <p>Endpoints:
  *
  * <ul>
  *   <li>{@code GET /api/read/content/images/{id}/download?format=web} -- single image WebP
- *   <li>{@code GET /api/read/collections/{slug}/download?format=web} -- ZIP of every WebP in the
- *       collection
+ *   <li>{@code GET /api/read/content/images/{id}/download?format=original} -- single image JPEG
+ *   <li>{@code GET /api/read/collections/{slug}/download?format=web} -- ZIP of every WebP
+ *   <li>{@code GET /api/read/collections/{slug}/download?format=original} -- ZIP of full-res JPEGs
+ *       (per-image fallback to WebP when no original is stored)
  * </ul>
- *
- * <p>Both endpoints check the per-slug access cookie when the parent collection has a {@code
- * galleryPassword}. The cookie helpers live in {@link
- * edens.zac.portfolio.backend.config.GalleryAccessCookies} so cookie identity stays in lockstep
- * with the rate-limiter key.
- *
- * <p>{@code format=original} is rejected with {@code 400} for now -- only the WebP variant is
- * exposed to clients in v1.
  */
 @Slf4j
 @RequiredArgsConstructor
@@ -68,9 +65,6 @@ public class ContentDownloadControllerProd {
   @Value("${aws.portfolio.s3.bucket}")
   private String bucketName;
 
-  @Value("${cloudfront.domain}")
-  private String cloudfrontDomain;
-
   // ---------------------------------------------------------------------------
   //  Image download
   // ---------------------------------------------------------------------------
@@ -80,12 +74,6 @@ public class ContentDownloadControllerProd {
       @PathVariable Long id,
       @RequestParam(defaultValue = "web") String format,
       HttpServletRequest request) {
-    if (!"web".equalsIgnoreCase(format)) {
-      log.debug("Rejecting image download (id={}) with unsupported format={}", id, format);
-      return ResponseEntity.badRequest().build();
-    }
-
-    ContentImageEntity image = contentService.findImageById(id);
 
     // Auth gate: enforce only when a parent collection is password-protected.
     Optional<CollectionEntity> parentCollection = contentService.findCollectionForImage(id);
@@ -97,20 +85,17 @@ public class ContentDownloadControllerProd {
       }
     }
 
-    String s3Key = extractS3Key(image.getImageUrlWeb());
-    if (s3Key == null) {
-      log.error("Image {} has no resolvable S3 key (url={})", id, image.getImageUrlWeb());
-      return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
-    }
-
-    GetObjectRequest s3Req = GetObjectRequest.builder().bucket(bucketName).key(s3Key).build();
+    DownloadResolution resolution = contentService.resolveImageDownload(id, format);
+    GetObjectRequest s3Req =
+        GetObjectRequest.builder().bucket(bucketName).key(resolution.s3Key()).build();
     ResponseInputStream<GetObjectResponse> stream = s3Client.getObject(s3Req);
-    String filename = sanitizeFilename(image.getOriginalFilename(), id, ".webp");
 
     ResponseEntity.BodyBuilder builder =
         ResponseEntity.ok()
-            .contentType(MediaType.parseMediaType("image/webp"))
-            .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"");
+            .contentType(MediaType.parseMediaType(resolution.contentType()))
+            .header(
+                HttpHeaders.CONTENT_DISPOSITION,
+                "attachment; filename=\"" + resolution.filename() + "\"");
     Long contentLength = stream.response().contentLength();
     if (contentLength != null && contentLength > 0L) {
       builder = builder.contentLength(contentLength);
@@ -129,12 +114,6 @@ public class ContentDownloadControllerProd {
       HttpServletRequest request,
       HttpServletResponse response)
       throws IOException {
-    if (!"web".equalsIgnoreCase(format)) {
-      log.debug("Rejecting collection download (slug={}) with unsupported format={}", slug, format);
-      response.sendError(
-          HttpStatus.BAD_REQUEST.value(), "Unsupported format. Only 'web' is supported in v1.");
-      return;
-    }
 
     CollectionEntity collection = collectionService.findEntityBySlug(slug);
 
@@ -145,41 +124,34 @@ public class ContentDownloadControllerProd {
       return;
     }
 
-    List<ContentImageEntity> images = contentService.findImagesForCollection(collection.getId());
+    List<DownloadResolution> entries =
+        contentService.resolveCollectionDownloadEntries(collection.getId(), format);
 
-    String zipName = sanitizeFilename(collection.getSlug(), collection.getId(), ".zip");
+    String zipName = contentService.collectionZipFilename(collection.getSlug(), collection.getId());
     response.setContentType("application/zip");
     response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + zipName + "\"");
 
     try (ZipOutputStream zos = new ZipOutputStream(response.getOutputStream())) {
       int seq = 0;
-      for (ContentImageEntity image : images) {
-        String s3Key = extractS3Key(image.getImageUrlWeb());
-        if (s3Key == null) {
-          log.warn(
-              "Skipping image {} in ZIP (no resolvable S3 key, url={})",
-              image.getId(),
-              image.getImageUrlWeb());
-          continue;
-        }
-        String entryName = sanitizeFilename(image.getOriginalFilename(), image.getId(), ".webp");
+      for (DownloadResolution entry : entries) {
         // Defensive against duplicate names within a ZIP (S3 keys are unique, original_filenames
         // are not). Prefix with a sequence number so ZipOutputStream never throws on duplicates.
-        GetObjectRequest s3Req = GetObjectRequest.builder().bucket(bucketName).key(s3Key).build();
+        GetObjectRequest s3Req =
+            GetObjectRequest.builder().bucket(bucketName).key(entry.s3Key()).build();
         try (ResponseInputStream<GetObjectResponse> in = s3Client.getObject(s3Req)) {
-          ZipEntry entry = new ZipEntry(String.format("%03d_%s", seq++, entryName));
-          zos.putNextEntry(entry);
+          ZipEntry zipEntry = new ZipEntry(String.format("%03d_%s", seq++, entry.filename()));
+          zos.putNextEntry(zipEntry);
           in.transferTo(zos);
           zos.closeEntry();
         } catch (SdkException e) {
           // Per-image failure must not corrupt the rest of the ZIP. Write a placeholder so the
           // recipient sees something is missing without us tearing down the whole download.
           log.warn(
-              "Failed to fetch S3 object for ZIP entry (imageId={}, key={}): {}",
-              image.getId(),
-              s3Key,
+              "Failed to fetch S3 object for ZIP entry (key={}): {}",
+              entry.s3Key(),
               e.getMessage());
-          ZipEntry errorEntry = new ZipEntry(String.format("%03d_%s.error.txt", seq++, entryName));
+          ZipEntry errorEntry =
+              new ZipEntry(String.format("%03d_%s.error.txt", seq++, entry.filename()));
           zos.putNextEntry(errorEntry);
           zos.write(
               ("Could not include this image: " + e.getClass().getSimpleName())
@@ -189,54 +161,6 @@ public class ContentDownloadControllerProd {
       }
       zos.finish();
     }
-    log.info("Streamed ZIP download (slug={}, count={})", slug, images.size());
-  }
-
-  // ---------------------------------------------------------------------------
-  //  Helpers
-  // ---------------------------------------------------------------------------
-
-  /**
-   * Translate a CloudFront URL stored on the entity (e.g. {@code
-   * https://{cloudfront-domain}/Image/Web/2025/01/foo.webp}) back to the underlying S3 key. Returns
-   * {@code null} when the URL is empty or doesn't match the configured CloudFront domain.
-   */
-  private String extractS3Key(String cloudfrontUrl) {
-    if (cloudfrontUrl == null || cloudfrontUrl.isEmpty()) {
-      return null;
-    }
-    String prefix = "https://" + cloudfrontDomain + "/";
-    if (cloudfrontUrl.startsWith(prefix)) {
-      return cloudfrontUrl.substring(prefix.length());
-    }
-    log.warn("Cloudfront URL doesn't match configured domain: {}", cloudfrontUrl);
-    return null;
-  }
-
-  /**
-   * Sanitize a filename for use in {@code Content-Disposition} or as a ZIP entry. Strips path
-   * traversal and control characters, normalises the extension, falls back to a uuid if the input
-   * is unusable.
-   */
-  private String sanitizeFilename(String original, Object idForFallback, String extension) {
-    String base = original;
-    if (base != null) {
-      // Drop any path component to prevent traversal (`/`, `\`).
-      int slashIdx = Math.max(base.lastIndexOf('/'), base.lastIndexOf('\\'));
-      if (slashIdx >= 0) {
-        base = base.substring(slashIdx + 1);
-      }
-      base = base.replaceAll("[\\p{Cntrl}\"\\\\]", "");
-      // Strip any existing image extension, we'll reapply the canonical one.
-      base = base.replaceAll("(?i)\\.(jpg|jpeg|webp|png|tif|tiff)$", "");
-      base = base.trim();
-    }
-    if (base == null || base.isEmpty()) {
-      base =
-          (idForFallback != null ? idForFallback.toString() : "download")
-              + "-"
-              + UUID.randomUUID().toString().substring(0, 8);
-    }
-    return base + extension;
+    log.info("Streamed ZIP download (slug={}, format={}, count={})", slug, format, entries.size());
   }
 }

--- a/src/main/java/edens/zac/portfolio/backend/model/DownloadResolution.java
+++ b/src/main/java/edens/zac/portfolio/backend/model/DownloadResolution.java
@@ -1,0 +1,14 @@
+package edens.zac.portfolio.backend.model;
+
+/**
+ * Resolved download target for a single image. Carries everything the controller needs to stream
+ * the response after the service layer has decided which S3 object to serve and what
+ * Content-Type/filename to use.
+ *
+ * @param s3Key resolved S3 object key (already extracted from the CloudFront URL)
+ * @param extension canonical file extension including the dot (e.g. {@code .jpg}, {@code .webp})
+ * @param contentType MIME type to set on the HTTP response
+ * @param filename sanitized {@code Content-Disposition} filename
+ */
+public record DownloadResolution(
+    String s3Key, String extension, String contentType, String filename) {}

--- a/src/main/java/edens/zac/portfolio/backend/services/ContentService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/ContentService.java
@@ -23,6 +23,7 @@ import edens.zac.portfolio.backend.model.ContentImageUpdateResponse;
 import edens.zac.portfolio.backend.model.ContentModel;
 import edens.zac.portfolio.backend.model.ContentModels;
 import edens.zac.portfolio.backend.model.ContentRequests;
+import edens.zac.portfolio.backend.model.DownloadResolution;
 import edens.zac.portfolio.backend.model.ImageSearchRequest;
 import edens.zac.portfolio.backend.model.ImageSearchResponse;
 import edens.zac.portfolio.backend.model.Records;
@@ -36,10 +37,11 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -48,7 +50,6 @@ import org.springframework.web.multipart.MultipartFile;
 /** Service for managing content, tags, and people. */
 @Service
 @Slf4j
-@RequiredArgsConstructor
 public class ContentService {
 
   private final TagRepository tagRepository;
@@ -62,6 +63,37 @@ public class ContentService {
   private final ContentImageUpdateValidator contentImageUpdateValidator;
   private final ContentValidator contentValidator;
   private final MetadataService metadataService;
+  private final String cloudfrontDomain;
+
+  private static final String FORMAT_WEB = "web";
+  private static final String FORMAT_ORIGINAL = "original";
+
+  public ContentService(
+      TagRepository tagRepository,
+      ContentRepository contentRepository,
+      CollectionRepository collectionRepository,
+      PersonRepository personRepository,
+      LocationRepository locationRepository,
+      ContentMutationUtil contentMutationUtil,
+      ContentModelConverter contentModelConverter,
+      ImageProcessingService imageProcessingService,
+      ContentImageUpdateValidator contentImageUpdateValidator,
+      ContentValidator contentValidator,
+      MetadataService metadataService,
+      @Value("${cloudfront.domain}") String cloudfrontDomain) {
+    this.tagRepository = tagRepository;
+    this.contentRepository = contentRepository;
+    this.collectionRepository = collectionRepository;
+    this.personRepository = personRepository;
+    this.locationRepository = locationRepository;
+    this.contentMutationUtil = contentMutationUtil;
+    this.contentModelConverter = contentModelConverter;
+    this.imageProcessingService = imageProcessingService;
+    this.contentImageUpdateValidator = contentImageUpdateValidator;
+    this.contentValidator = contentValidator;
+    this.metadataService = metadataService;
+    this.cloudfrontDomain = cloudfrontDomain;
+  }
 
   public Map<String, Object> createTag(String tagName) {
     return metadataService.createTag(tagName);
@@ -532,6 +564,156 @@ public class ContentService {
       return Optional.empty();
     }
     return collectionRepository.findById(collectionId);
+  }
+
+  // ---------------------------------------------------------------------------
+  //  Download resolution
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Resolve which S3 object to serve for a single-image download. Throws {@link
+   * IllegalArgumentException} for unsupported formats and {@link ResourceNotFoundException} when
+   * {@code format=original} is requested but the image has no stored original.
+   *
+   * <p>The controller is responsible only for HTTP concerns (auth, streaming) -- all
+   * format-vs-field, extension, and MIME selection lives here.
+   */
+  @Transactional(readOnly = true)
+  public DownloadResolution resolveImageDownload(Long imageId, String format) {
+    requireSupportedFormat(format);
+    ContentImageEntity image = findImageById(imageId);
+    boolean isOriginal = FORMAT_ORIGINAL.equalsIgnoreCase(format);
+
+    String url;
+    String extension;
+    String contentType;
+    if (isOriginal) {
+      url = image.getImageUrlOriginal();
+      if (url == null) {
+        throw new ResourceNotFoundException("No original available for image " + imageId);
+      }
+      extension = ".jpg";
+      contentType = "image/jpeg";
+    } else {
+      url = image.getImageUrlWeb();
+      extension = ".webp";
+      contentType = "image/webp";
+    }
+
+    String s3Key = extractS3Key(url);
+    if (s3Key == null) {
+      throw new ResourceNotFoundException(
+          "Image " + imageId + " has no resolvable S3 key (url=" + url + ")");
+    }
+    String filename = sanitizeFilename(image.getOriginalFilename(), imageId, extension);
+    return new DownloadResolution(s3Key, extension, contentType, filename);
+  }
+
+  /**
+   * Resolve the per-image download targets for a collection ZIP. For {@code format=original},
+   * prefers {@code imageUrlOriginal} per image but transparently falls back to {@code imageUrlWeb}
+   * (and the {@code .webp} extension) when an original is not stored, so the ZIP is always
+   * complete. Images whose configured CloudFront URL cannot be parsed into an S3 key are skipped
+   * with a WARN log.
+   *
+   * <p>Throws {@link IllegalArgumentException} for unsupported formats.
+   */
+  @Transactional(readOnly = true)
+  public List<DownloadResolution> resolveCollectionDownloadEntries(
+      Long collectionId, String format) {
+    requireSupportedFormat(format);
+    boolean isOriginal = FORMAT_ORIGINAL.equalsIgnoreCase(format);
+    List<ContentImageEntity> images = findImagesForCollection(collectionId);
+    List<DownloadResolution> resolutions = new ArrayList<>(images.size());
+    for (ContentImageEntity image : images) {
+      String url = image.getImageUrlWeb();
+      String extension = ".webp";
+      String contentType = "image/webp";
+      if (isOriginal) {
+        String origUrl = image.getImageUrlOriginal();
+        if (origUrl != null) {
+          url = origUrl;
+          extension = ".jpg";
+          contentType = "image/jpeg";
+        } else {
+          log.warn(
+              "No original for image {} in ZIP (collectionId={}); using web version",
+              image.getId(),
+              collectionId);
+        }
+      }
+      String s3Key = extractS3Key(url);
+      if (s3Key == null) {
+        log.warn("Skipping image {} in ZIP (no resolvable S3 key, url={})", image.getId(), url);
+        continue;
+      }
+      String filename = sanitizeFilename(image.getOriginalFilename(), image.getId(), extension);
+      resolutions.add(new DownloadResolution(s3Key, extension, contentType, filename));
+    }
+    return resolutions;
+  }
+
+  private void requireSupportedFormat(String format) {
+    if (!FORMAT_WEB.equalsIgnoreCase(format) && !FORMAT_ORIGINAL.equalsIgnoreCase(format)) {
+      throw new IllegalArgumentException(
+          "Unsupported download format: " + format + " (supported: web, original)");
+    }
+  }
+
+  /**
+   * Build a sanitized {@code Content-Disposition} filename for a collection ZIP. Same sanitization
+   * rules as per-image entries -- strips path components, control characters, and quotes so the
+   * value is safe to embed in an HTTP header. The slug is already constrained at write time, but
+   * routing it through here keeps the ZIP filename consistent with the per-entry names and adds
+   * defense-in-depth against any legacy slug that slipped past validation.
+   */
+  public String collectionZipFilename(String slug, Long collectionId) {
+    String base = slug + "-" + collectionId;
+    return sanitizeFilename(base, collectionId, ".zip");
+  }
+
+  /**
+   * Translate a CloudFront URL stored on the entity (e.g. {@code
+   * https://{cloudfront-domain}/Image/Web/2025/01/foo.webp}) back to the underlying S3 key. Returns
+   * {@code null} when the URL is empty or doesn't match the configured CloudFront domain.
+   */
+  private String extractS3Key(String cloudfrontUrl) {
+    if (cloudfrontUrl == null || cloudfrontUrl.isEmpty()) {
+      return null;
+    }
+    String prefix = "https://" + cloudfrontDomain + "/";
+    if (cloudfrontUrl.startsWith(prefix)) {
+      return cloudfrontUrl.substring(prefix.length());
+    }
+    log.warn("Cloudfront URL doesn't match configured domain: {}", cloudfrontUrl);
+    return null;
+  }
+
+  /**
+   * Sanitize a filename for use in {@code Content-Disposition} or as a ZIP entry. Strips path
+   * traversal and control characters, normalises the extension, falls back to a uuid if the input
+   * is unusable.
+   */
+  private String sanitizeFilename(String original, Object idForFallback, String extension) {
+    String base = original;
+    if (base != null) {
+      // Drop any path component to prevent traversal (`/`, `\`).
+      int slashIdx = Math.max(base.lastIndexOf('/'), base.lastIndexOf('\\'));
+      if (slashIdx >= 0) {
+        base = base.substring(slashIdx + 1);
+      }
+      base = base.replaceAll("[\\p{Cntrl}\"\\\\]", "");
+      // Strip any existing image extension, we'll reapply the canonical one.
+      base = base.replaceAll("(?i)\\.(jpg|jpeg|webp|png|tif|tiff)$", "");
+      base = base.trim();
+    }
+    if (base == null || base.isEmpty()) {
+      base =
+          (idForFallback != null ? idForFallback.toString() : "download")
+              + "-"
+              + UUID.randomUUID().toString().substring(0, 8);
+    }
+    return base + extension;
   }
 
   // ---------------------------------------------------------------------------

--- a/src/test/java/edens/zac/portfolio/backend/controller/prod/ContentDownloadControllerProdTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/prod/ContentDownloadControllerProdTest.java
@@ -2,6 +2,7 @@ package edens.zac.portfolio.backend.controller.prod;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -10,8 +11,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import edens.zac.portfolio.backend.config.GlobalExceptionHandler;
+import edens.zac.portfolio.backend.config.ResourceNotFoundException;
 import edens.zac.portfolio.backend.entity.CollectionEntity;
-import edens.zac.portfolio.backend.entity.ContentImageEntity;
+import edens.zac.portfolio.backend.model.DownloadResolution;
 import edens.zac.portfolio.backend.services.ClientGalleryAuthService;
 import edens.zac.portfolio.backend.services.CollectionService;
 import edens.zac.portfolio.backend.services.ContentService;
@@ -42,10 +44,16 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 
+/**
+ * Controller-level tests. The controller is intentionally thin -- format-vs-field, MIME, and
+ * extension decisions all live in {@link ContentService}, so these tests stub the high-level
+ * service methods ({@code resolveImageDownload}, {@code resolveCollectionDownloadEntries}) and
+ * focus on auth gating, S3 streaming, and exception-to-HTTP-status mapping. Resolution logic is
+ * exercised separately in {@code ContentServiceDownloadTest}.
+ */
 @ExtendWith(MockitoExtension.class)
 class ContentDownloadControllerProdTest {
 
-  private static final String CLOUDFRONT_DOMAIN = "cdn.example.com";
   private static final String BUCKET = "test-bucket";
 
   private MockMvc mockMvc;
@@ -60,7 +68,6 @@ class ContentDownloadControllerProdTest {
   @BeforeEach
   void setUp() {
     ReflectionTestUtils.setField(controller, "bucketName", BUCKET);
-    ReflectionTestUtils.setField(controller, "cloudfrontDomain", CLOUDFRONT_DOMAIN);
     mockMvc =
         MockMvcBuilders.standaloneSetup(controller)
             .setControllerAdvice(new GlobalExceptionHandler())
@@ -77,12 +84,13 @@ class ContentDownloadControllerProdTest {
         meta, AbortableInputStream.create(new ByteArrayInputStream(bytes)));
   }
 
-  private static ContentImageEntity image(Long id, String filename, String suffix) {
-    return ContentImageEntity.builder()
-        .id(id)
-        .imageUrlWeb("https://" + CLOUDFRONT_DOMAIN + "/Image/Web/2025/01/" + suffix)
-        .originalFilename(filename)
-        .build();
+  private static DownloadResolution webResolution(String filename) {
+    return new DownloadResolution("Image/Web/2025/01/" + filename, ".webp", "image/webp", filename);
+  }
+
+  private static DownloadResolution jpegResolution(String filename) {
+    return new DownloadResolution(
+        "Image/Original/2025/01/" + filename, ".jpg", "image/jpeg", filename);
   }
 
   private static CollectionEntity protectedGallery() {
@@ -116,12 +124,12 @@ class ContentDownloadControllerProdTest {
 
     @Test
     void protectedCollection_validCookie_returns200WithBytes() throws Exception {
-      ContentImageEntity img = image(10L, "smith-001.jpg", "smith-001.webp");
       byte[] body = new byte[] {0x52, 0x49, 0x46, 0x46}; // RIFF magic, just a fake stub
-      when(contentService.findImageById(10L)).thenReturn(img);
       when(contentService.findCollectionForImage(10L)).thenReturn(Optional.of(protectedGallery()));
       when(clientGalleryAuthService.validateAccessToken("smith-wedding", "tok-123"))
           .thenReturn(true);
+      when(contentService.resolveImageDownload(10L, "web"))
+          .thenReturn(webResolution("smith-001.webp"));
       when(s3Client.getObject(any(GetObjectRequest.class))).thenReturn(fakeS3Stream(body));
 
       MvcResult result =
@@ -143,23 +151,22 @@ class ContentDownloadControllerProdTest {
 
     @Test
     void protectedCollection_noCookie_returns401() throws Exception {
-      ContentImageEntity img = image(10L, "smith-001.jpg", "smith-001.webp");
-      when(contentService.findImageById(10L)).thenReturn(img);
       when(contentService.findCollectionForImage(10L)).thenReturn(Optional.of(protectedGallery()));
 
       mockMvc
           .perform(get("/api/read/content/images/10/download"))
           .andExpect(status().isUnauthorized());
 
+      verify(contentService, never()).resolveImageDownload(any(), any());
       verify(s3Client, never()).getObject(any(GetObjectRequest.class));
     }
 
     @Test
     void unprotectedCollection_noCookie_returns200() throws Exception {
-      ContentImageEntity img = image(11L, "open-001.jpg", "open-001.webp");
       byte[] body = new byte[] {0x01, 0x02, 0x03, 0x04};
-      when(contentService.findImageById(11L)).thenReturn(img);
       when(contentService.findCollectionForImage(11L)).thenReturn(Optional.of(openCollection()));
+      when(contentService.resolveImageDownload(11L, "web"))
+          .thenReturn(webResolution("open-001.webp"));
       when(s3Client.getObject(any(GetObjectRequest.class))).thenReturn(fakeS3Stream(body));
 
       MvcResult result =
@@ -176,29 +183,64 @@ class ContentDownloadControllerProdTest {
 
     @Test
     void orphanImage_noCollection_returns200() throws Exception {
-      ContentImageEntity img = image(12L, "orphan.jpg", "orphan.webp");
       byte[] body = new byte[] {0x42};
-      when(contentService.findImageById(12L)).thenReturn(img);
       when(contentService.findCollectionForImage(12L)).thenReturn(Optional.empty());
+      when(contentService.resolveImageDownload(12L, "web"))
+          .thenReturn(webResolution("orphan.webp"));
       when(s3Client.getObject(any(GetObjectRequest.class))).thenReturn(fakeS3Stream(body));
 
       mockMvc.perform(get("/api/read/content/images/12/download")).andExpect(status().isOk());
     }
 
     @Test
-    void formatOriginal_returns400() throws Exception {
+    void formatOriginal_returns200WithJpeg() throws Exception {
+      byte[] body = new byte[] {(byte) 0xFF, (byte) 0xD8, (byte) 0xFF}; // JPEG magic bytes
+      when(contentService.findCollectionForImage(10L)).thenReturn(Optional.of(protectedGallery()));
+      when(clientGalleryAuthService.validateAccessToken("smith-wedding", "tok-123"))
+          .thenReturn(true);
+      when(contentService.resolveImageDownload(10L, "original"))
+          .thenReturn(jpegResolution("smith-001.jpg"));
+      when(s3Client.getObject(any(GetObjectRequest.class))).thenReturn(fakeS3Stream(body));
+
+      mockMvc
+          .perform(
+              get("/api/read/content/images/10/download")
+                  .param("format", "original")
+                  .cookie(new Cookie("gallery_access_smith-wedding", "tok-123")))
+          .andExpect(status().isOk())
+          .andExpect(header().string("Content-Type", "image/jpeg"))
+          .andExpect(
+              header().string("Content-Disposition", org.hamcrest.Matchers.containsString(".jpg")));
+    }
+
+    @Test
+    void formatOriginal_serviceThrowsNotFound_returns404() throws Exception {
+      when(contentService.findCollectionForImage(10L)).thenReturn(Optional.empty());
+      when(contentService.resolveImageDownload(10L, "original"))
+          .thenThrow(new ResourceNotFoundException("No original available for image 10"));
+
       mockMvc
           .perform(get("/api/read/content/images/10/download").param("format", "original"))
+          .andExpect(status().isNotFound());
+
+      verify(s3Client, never()).getObject(any(GetObjectRequest.class));
+    }
+
+    @Test
+    void formatUnsupported_serviceThrowsIllegalArgument_returns400() throws Exception {
+      when(contentService.findCollectionForImage(10L)).thenReturn(Optional.empty());
+      when(contentService.resolveImageDownload(10L, "raw"))
+          .thenThrow(new IllegalArgumentException("Unsupported download format: raw"));
+
+      mockMvc
+          .perform(get("/api/read/content/images/10/download").param("format", "raw"))
           .andExpect(status().isBadRequest());
 
-      verify(contentService, never()).findImageById(org.mockito.ArgumentMatchers.anyLong());
       verify(s3Client, never()).getObject(any(GetObjectRequest.class));
     }
 
     @Test
     void invalidCookie_returns401() throws Exception {
-      ContentImageEntity img = image(10L, "smith-001.jpg", "smith-001.webp");
-      when(contentService.findImageById(10L)).thenReturn(img);
       when(contentService.findCollectionForImage(10L)).thenReturn(Optional.of(protectedGallery()));
       when(clientGalleryAuthService.validateAccessToken("smith-wedding", "garbage"))
           .thenReturn(false);
@@ -209,6 +251,7 @@ class ContentDownloadControllerProdTest {
                   .cookie(new Cookie("gallery_access_smith-wedding", "garbage")))
           .andExpect(status().isUnauthorized());
 
+      verify(contentService, never()).resolveImageDownload(any(), any());
       verify(s3Client, never()).getObject(any(GetObjectRequest.class));
     }
   }
@@ -223,14 +266,11 @@ class ContentDownloadControllerProdTest {
     @Test
     void protectedCollection_validCookie_returnsZipWithEntries() throws Exception {
       CollectionEntity gallery = protectedGallery();
-      ContentImageEntity img1 = image(10L, "first.jpg", "first.webp");
-      ContentImageEntity img2 = image(11L, "second.jpg", "second.webp");
       when(collectionService.findEntityBySlug("smith-wedding")).thenReturn(gallery);
       when(clientGalleryAuthService.validateAccessToken("smith-wedding", "tok-123"))
           .thenReturn(true);
-      when(contentService.findImagesForCollection(1L)).thenReturn(List.of(img1, img2));
-
-      // Each S3 fetch returns a fresh stream (the controller reads them sequentially).
+      when(contentService.resolveCollectionDownloadEntries(1L, "web"))
+          .thenReturn(List.of(webResolution("first.webp"), webResolution("second.webp")));
       when(s3Client.getObject(any(GetObjectRequest.class)))
           .thenReturn(fakeS3Stream("aaaa".getBytes()))
           .thenReturn(fakeS3Stream("bbbb".getBytes()));
@@ -244,7 +284,6 @@ class ContentDownloadControllerProdTest {
               .andExpect(header().string("Content-Type", "application/zip"))
               .andReturn();
 
-      // Verify ZIP contents
       byte[] zipBytes = result.getResponse().getContentAsByteArray();
       try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipBytes))) {
         ZipEntry entry;
@@ -253,7 +292,6 @@ class ContentDownloadControllerProdTest {
         boolean sawSecond = false;
         while ((entry = zis.getNextEntry()) != null) {
           count++;
-          // Each entry name is "{seq}_{base}.webp"
           if (entry.getName().contains("first")) {
             sawFirst = true;
             assertThat(entry.getName()).endsWith(".webp");
@@ -283,15 +321,15 @@ class ContentDownloadControllerProdTest {
           .perform(get("/api/read/collections/smith-wedding/download"))
           .andExpect(status().isUnauthorized());
 
+      verify(contentService, never()).resolveCollectionDownloadEntries(any(), any());
       verify(s3Client, never()).getObject(any(GetObjectRequest.class));
     }
 
     @Test
     void unprotectedCollection_noCookie_returns200() throws Exception {
-      CollectionEntity open = openCollection();
-      ContentImageEntity img = image(10L, "open.jpg", "open.webp");
-      when(collectionService.findEntityBySlug("open-portfolio")).thenReturn(open);
-      when(contentService.findImagesForCollection(2L)).thenReturn(List.of(img));
+      when(collectionService.findEntityBySlug("open-portfolio")).thenReturn(openCollection());
+      when(contentService.resolveCollectionDownloadEntries(2L, "web"))
+          .thenReturn(List.of(webResolution("open.webp")));
       when(s3Client.getObject(any(GetObjectRequest.class)))
           .thenReturn(fakeS3Stream("zzzz".getBytes()));
 
@@ -302,26 +340,59 @@ class ContentDownloadControllerProdTest {
     }
 
     @Test
-    void formatOriginal_returns400() throws Exception {
+    void formatOriginal_returnsZipWithJpgEntries() throws Exception {
+      when(collectionService.findEntityBySlug("smith-wedding")).thenReturn(protectedGallery());
+      when(clientGalleryAuthService.validateAccessToken("smith-wedding", "tok-123"))
+          .thenReturn(true);
+      when(contentService.resolveCollectionDownloadEntries(1L, "original"))
+          .thenReturn(List.of(jpegResolution("first.jpg"), jpegResolution("second.jpg")));
+      when(s3Client.getObject(any(GetObjectRequest.class)))
+          .thenReturn(fakeS3Stream("JPEG1".getBytes()))
+          .thenReturn(fakeS3Stream("JPEG2".getBytes()));
+
+      MvcResult result =
+          mockMvc
+              .perform(
+                  get("/api/read/collections/smith-wedding/download")
+                      .param("format", "original")
+                      .cookie(new Cookie("gallery_access_smith-wedding", "tok-123")))
+              .andExpect(status().isOk())
+              .andReturn();
+
+      byte[] zipBytes = result.getResponse().getContentAsByteArray();
+      try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipBytes))) {
+        ZipEntry entry;
+        int count = 0;
+        while ((entry = zis.getNextEntry()) != null) {
+          count++;
+          assertThat(entry.getName()).endsWith(".jpg");
+        }
+        assertThat(count).isEqualTo(2);
+      }
+    }
+
+    @Test
+    void formatUnsupported_serviceThrowsIllegalArgument_returns400() throws Exception {
+      when(collectionService.findEntityBySlug("open-portfolio")).thenReturn(openCollection());
+      when(contentService.resolveCollectionDownloadEntries(eq(2L), eq("raw")))
+          .thenThrow(new IllegalArgumentException("Unsupported download format: raw"));
+
       mockMvc
-          .perform(get("/api/read/collections/smith-wedding/download").param("format", "original"))
+          .perform(get("/api/read/collections/open-portfolio/download").param("format", "raw"))
           .andExpect(status().isBadRequest());
 
-      verify(collectionService, never()).findEntityBySlug(org.mockito.ArgumentMatchers.anyString());
+      verify(s3Client, never()).getObject(any(GetObjectRequest.class));
     }
 
     @Test
     void zipsRemainingImagesWhenOneS3FetchFails() throws Exception {
-      // BE-H2: a per-image S3 failure must not corrupt the rest of the ZIP. The controller
-      // writes a placeholder error entry for the failed image and continues with the others.
-      CollectionEntity gallery = openCollection();
-      ContentImageEntity img1 = image(10L, "first.jpg", "first.webp");
-      ContentImageEntity img2 = image(11L, "second.jpg", "second.webp");
-      ContentImageEntity img3 = image(12L, "third.jpg", "third.webp");
-      when(collectionService.findEntityBySlug("open-portfolio")).thenReturn(gallery);
-      when(contentService.findImagesForCollection(2L)).thenReturn(List.of(img1, img2, img3));
-
-      // First image succeeds, second fails with SdkClientException, third succeeds.
+      when(collectionService.findEntityBySlug("open-portfolio")).thenReturn(openCollection());
+      when(contentService.resolveCollectionDownloadEntries(2L, "web"))
+          .thenReturn(
+              List.of(
+                  webResolution("first.webp"),
+                  webResolution("second.webp"),
+                  webResolution("third.webp")));
       when(s3Client.getObject(any(GetObjectRequest.class)))
           .thenReturn(fakeS3Stream("aaaa".getBytes()))
           .thenThrow(SdkClientException.builder().message("connection reset").build())
@@ -362,9 +433,8 @@ class ContentDownloadControllerProdTest {
 
     @Test
     void emptyCollection_returnsEmptyZip() throws Exception {
-      CollectionEntity gallery = openCollection();
-      when(collectionService.findEntityBySlug("open-portfolio")).thenReturn(gallery);
-      when(contentService.findImagesForCollection(2L)).thenReturn(List.of());
+      when(collectionService.findEntityBySlug("open-portfolio")).thenReturn(openCollection());
+      when(contentService.resolveCollectionDownloadEntries(2L, "web")).thenReturn(List.of());
 
       MvcResult result =
           mockMvc
@@ -372,7 +442,6 @@ class ContentDownloadControllerProdTest {
               .andExpect(status().isOk())
               .andReturn();
 
-      // ZIP is non-empty (header bytes) but contains no entries.
       byte[] zipBytes = result.getResponse().getContentAsByteArray();
       try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipBytes))) {
         assertThat(zis.getNextEntry()).isNull();

--- a/src/test/java/edens/zac/portfolio/backend/services/ContentServiceDownloadTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/ContentServiceDownloadTest.java
@@ -1,0 +1,263 @@
+package edens.zac.portfolio.backend.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import edens.zac.portfolio.backend.config.ResourceNotFoundException;
+import edens.zac.portfolio.backend.dao.CollectionRepository;
+import edens.zac.portfolio.backend.dao.ContentRepository;
+import edens.zac.portfolio.backend.dao.LocationRepository;
+import edens.zac.portfolio.backend.dao.PersonRepository;
+import edens.zac.portfolio.backend.dao.TagRepository;
+import edens.zac.portfolio.backend.entity.CollectionContentEntity;
+import edens.zac.portfolio.backend.entity.ContentImageEntity;
+import edens.zac.portfolio.backend.model.DownloadResolution;
+import edens.zac.portfolio.backend.services.validator.ContentImageUpdateValidator;
+import edens.zac.portfolio.backend.services.validator.ContentValidator;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Unit tests for download-resolution logic that lives on {@link ContentService}: format validation,
+ * imageUrlOriginal/imageUrlWeb selection, MIME/extension decisions, and the per-image fallback
+ * applied to the collection ZIP. Controller-level concerns (auth, S3 streaming, exception-to-status
+ * mapping) are tested separately in {@code ContentDownloadControllerProdTest}.
+ */
+@ExtendWith(MockitoExtension.class)
+class ContentServiceDownloadTest {
+
+  private static final String CLOUDFRONT_DOMAIN = "cdn.example.com";
+
+  @Mock private TagRepository tagRepository;
+  @Mock private ContentRepository contentRepository;
+  @Mock private CollectionRepository collectionRepository;
+  @Mock private PersonRepository personRepository;
+  @Mock private LocationRepository locationRepository;
+  @Mock private ContentMutationUtil contentMutationUtil;
+  @Mock private ContentModelConverter contentModelConverter;
+  @Mock private ImageProcessingService imageProcessingService;
+  @Mock private ContentImageUpdateValidator contentImageUpdateValidator;
+  @Mock private ContentValidator contentValidator;
+  @Mock private MetadataService metadataService;
+
+  @InjectMocks private ContentService service;
+
+  @BeforeEach
+  void setUp() {
+    ReflectionTestUtils.setField(service, "cloudfrontDomain", CLOUDFRONT_DOMAIN);
+  }
+
+  // ---------------------------------------------------------------------------
+  //  Helpers
+  // ---------------------------------------------------------------------------
+
+  private static ContentImageEntity image(Long id, String filename, String webSuffix) {
+    return ContentImageEntity.builder()
+        .id(id)
+        .imageUrlWeb("https://" + CLOUDFRONT_DOMAIN + "/Image/Web/2025/01/" + webSuffix)
+        .originalFilename(filename)
+        .build();
+  }
+
+  private static ContentImageEntity imageWithOriginal(
+      Long id, String filename, String webSuffix, String origSuffix) {
+    return ContentImageEntity.builder()
+        .id(id)
+        .imageUrlWeb("https://" + CLOUDFRONT_DOMAIN + "/Image/Web/2025/01/" + webSuffix)
+        .imageUrlOriginal("https://" + CLOUDFRONT_DOMAIN + "/Image/Original/2025/01/" + origSuffix)
+        .originalFilename(filename)
+        .build();
+  }
+
+  // ---------------------------------------------------------------------------
+  //  resolveImageDownload
+  // ---------------------------------------------------------------------------
+
+  @Nested
+  class ResolveImageDownload {
+
+    @Test
+    void web_returnsWebpResolution() {
+      ContentImageEntity img = image(10L, "smith-001.jpg", "smith-001.webp");
+      when(contentRepository.findImageById(10L)).thenReturn(Optional.of(img));
+
+      DownloadResolution res = service.resolveImageDownload(10L, "web");
+
+      assertThat(res.s3Key()).isEqualTo("Image/Web/2025/01/smith-001.webp");
+      assertThat(res.extension()).isEqualTo(".webp");
+      assertThat(res.contentType()).isEqualTo("image/webp");
+      assertThat(res.filename()).endsWith(".webp");
+    }
+
+    @Test
+    void original_withOriginalUrl_returnsJpegResolution() {
+      ContentImageEntity img =
+          imageWithOriginal(10L, "smith-001.jpg", "smith-001.webp", "smith-001.jpg");
+      when(contentRepository.findImageById(10L)).thenReturn(Optional.of(img));
+
+      DownloadResolution res = service.resolveImageDownload(10L, "original");
+
+      assertThat(res.s3Key()).isEqualTo("Image/Original/2025/01/smith-001.jpg");
+      assertThat(res.extension()).isEqualTo(".jpg");
+      assertThat(res.contentType()).isEqualTo("image/jpeg");
+      assertThat(res.filename()).endsWith(".jpg");
+    }
+
+    @Test
+    void original_caseInsensitive_acceptsORIGINAL() {
+      ContentImageEntity img =
+          imageWithOriginal(10L, "smith-001.jpg", "smith-001.webp", "smith-001.jpg");
+      when(contentRepository.findImageById(10L)).thenReturn(Optional.of(img));
+
+      DownloadResolution res = service.resolveImageDownload(10L, "ORIGINAL");
+
+      assertThat(res.contentType()).isEqualTo("image/jpeg");
+    }
+
+    @Test
+    void original_noOriginalUrl_throwsResourceNotFound() {
+      ContentImageEntity img = image(10L, "smith-001.jpg", "smith-001.webp");
+      when(contentRepository.findImageById(10L)).thenReturn(Optional.of(img));
+
+      assertThatThrownBy(() -> service.resolveImageDownload(10L, "original"))
+          .isInstanceOf(ResourceNotFoundException.class)
+          .hasMessageContaining("No original available");
+    }
+
+    @Test
+    void unsupportedFormat_throwsIllegalArgument() {
+      assertThatThrownBy(() -> service.resolveImageDownload(10L, "raw"))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Unsupported download format");
+    }
+
+    @Test
+    void web_nullImageUrlWeb_throwsNotFound() {
+      // Defensive: the entity's @NotNull on imageUrlWeb fires only on write, so a legacy
+      // row could have a null value. The service must not NPE; it should surface this as 404.
+      ContentImageEntity img =
+          ContentImageEntity.builder().id(10L).originalFilename("x.jpg").build();
+      when(contentRepository.findImageById(10L)).thenReturn(Optional.of(img));
+
+      assertThatThrownBy(() -> service.resolveImageDownload(10L, "web"))
+          .isInstanceOf(ResourceNotFoundException.class)
+          .hasMessageContaining("no resolvable S3 key");
+    }
+
+    @Test
+    void webUrlMatchesNonConfiguredDomain_throwsNotFound() {
+      // Image exists but its imageUrlWeb points at a different CloudFront domain — the
+      // extractor returns null and the service surfaces this as 404 rather than streaming
+      // a bogus S3 key.
+      ContentImageEntity img =
+          ContentImageEntity.builder()
+              .id(10L)
+              .imageUrlWeb("https://other-cdn.example.com/Image/Web/2025/01/x.webp")
+              .originalFilename("x.jpg")
+              .build();
+      when(contentRepository.findImageById(10L)).thenReturn(Optional.of(img));
+
+      assertThatThrownBy(() -> service.resolveImageDownload(10L, "web"))
+          .isInstanceOf(ResourceNotFoundException.class)
+          .hasMessageContaining("no resolvable S3 key");
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  //  resolveCollectionDownloadEntries
+  // ---------------------------------------------------------------------------
+
+  @Nested
+  class ResolveCollectionDownloadEntries {
+
+    private void stubCollectionImages(Long collectionId, List<ContentImageEntity> images) {
+      List<CollectionContentEntity> joinEntries =
+          images.stream()
+              .map(
+                  img ->
+                      CollectionContentEntity.builder()
+                          .collectionId(collectionId)
+                          .contentId(img.getId())
+                          .build())
+              .toList();
+      when(collectionRepository.findContentByCollectionIdOrderByOrderIndex(collectionId))
+          .thenReturn(joinEntries);
+      if (!images.isEmpty()) {
+        when(contentRepository.findImagesByIds(
+                images.stream().map(ContentImageEntity::getId).toList()))
+            .thenReturn(images);
+      }
+    }
+
+    @Test
+    void web_returnsAllWebpEntries() {
+      stubCollectionImages(
+          1L,
+          List.of(image(10L, "first.jpg", "first.webp"), image(11L, "second.jpg", "second.webp")));
+
+      List<DownloadResolution> entries = service.resolveCollectionDownloadEntries(1L, "web");
+
+      assertThat(entries).hasSize(2);
+      assertThat(entries).allMatch(e -> e.extension().equals(".webp"));
+      assertThat(entries).allMatch(e -> e.contentType().equals("image/webp"));
+    }
+
+    @Test
+    void original_allHaveOriginals_returnsAllJpgEntries() {
+      stubCollectionImages(
+          1L,
+          List.of(
+              imageWithOriginal(10L, "first.jpg", "first.webp", "first.jpg"),
+              imageWithOriginal(11L, "second.jpg", "second.webp", "second.jpg")));
+
+      List<DownloadResolution> entries = service.resolveCollectionDownloadEntries(1L, "original");
+
+      assertThat(entries).hasSize(2);
+      assertThat(entries).allMatch(e -> e.extension().equals(".jpg"));
+      assertThat(entries).allMatch(e -> e.contentType().equals("image/jpeg"));
+    }
+
+    @Test
+    void original_someMissingOriginal_fallsBackToWebPerImage() {
+      stubCollectionImages(
+          1L,
+          List.of(
+              imageWithOriginal(10L, "first.jpg", "first.webp", "first.jpg"),
+              image(11L, "second.jpg", "second.webp"))); // no imageUrlOriginal
+
+      List<DownloadResolution> entries = service.resolveCollectionDownloadEntries(1L, "original");
+
+      assertThat(entries).hasSize(2);
+      assertThat(entries.get(0).extension()).isEqualTo(".jpg");
+      assertThat(entries.get(0).contentType()).isEqualTo("image/jpeg");
+      assertThat(entries.get(1).extension()).isEqualTo(".webp");
+      assertThat(entries.get(1).contentType()).isEqualTo("image/webp");
+    }
+
+    @Test
+    void emptyCollection_returnsEmptyList() {
+      when(collectionRepository.findContentByCollectionIdOrderByOrderIndex(1L))
+          .thenReturn(List.of());
+
+      List<DownloadResolution> entries = service.resolveCollectionDownloadEntries(1L, "web");
+
+      assertThat(entries).isEmpty();
+    }
+
+    @Test
+    void unsupportedFormat_throwsIllegalArgument() {
+      assertThatThrownBy(() -> service.resolveCollectionDownloadEntries(1L, "raw"))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Unsupported download format");
+    }
+  }
+}


### PR DESCRIPTION
- Move download resolution (format, MIME, extension, S3 key, filename) out of ContentDownloadControllerProd and into ContentService via a new DownloadResolution record. Controller stays thin: auth + S3 streaming only.
- Single image format=original streams imageUrlOriginal as image/jpeg; 404 when no original is stored.
- Collection ZIP format=original prefers imageUrlOriginal per image but falls back to imageUrlWeb when an original is missing, so the ZIP is always complete (mixed .jpg / .webp entries).
- Switch ContentService to explicit constructor injection so cloudfrontDomain is final and the service is consistent with the rest of the service layer.
- Route the ZIP filename through sanitizeFilename for defense in depth (slug is already constrained, but consistency matters).
- 11 new ContentService tests for resolution logic; controller tests rewired to mock at the new boundary.