### PR TITLE
feat: PARENT password gating + listing cleanup + stable Page DTO

### DIFF
--- a/src/main/java/edens/zac/portfolio/backend/config/GalleryAccessCookies.java
+++ b/src/main/java/edens/zac/portfolio/backend/config/GalleryAccessCookies.java
@@ -18,6 +18,21 @@ public final class GalleryAccessCookies {
 
   public static final String COOKIE_PREFIX = "gallery_access_";
 
+  /**
+   * Cookie-name prefix for the password-fingerprint shared-unlock cookie. Issued alongside the
+   * per-slug cookie when a gallery is unlocked, so any other gallery whose password produces the
+   * same fingerprint also passes the gate without re-prompting (e.g. PARENT + propagated children).
+   */
+  public static final String PASSWORD_COOKIE_PREFIX = "gallery_access_pw_";
+
+  /**
+   * Sanitizer for the fingerprint segment of {@link #PASSWORD_COOKIE_PREFIX} cookies. The
+   * fingerprint is URL-safe base64 ({@code A-Za-z0-9_-}); any unexpected character is replaced with
+   * '_' as defense in depth against malformed input.
+   */
+  private static final java.util.regex.Pattern UNSAFE_FINGERPRINT_CHARS =
+      java.util.regex.Pattern.compile("[^A-Za-z0-9_-]");
+
   private GalleryAccessCookies() {}
 
   /**
@@ -44,6 +59,18 @@ public final class GalleryAccessCookies {
     return COOKIE_PREFIX + normalizeSlug(slug);
   }
 
+  /**
+   * Per-fingerprint cookie name for the shared-unlock path. The fingerprint comes from {@link
+   * ClientGalleryAuthService#passwordFingerprint(String)} and is already URL-safe base64; the
+   * sanitizer is a defense-in-depth no-op for valid input.
+   */
+  public static String passwordCookieName(String fingerprint) {
+    if (fingerprint == null || fingerprint.isEmpty()) {
+      return PASSWORD_COOKIE_PREFIX;
+    }
+    return PASSWORD_COOKIE_PREFIX + UNSAFE_FINGERPRINT_CHARS.matcher(fingerprint).replaceAll("_");
+  }
+
   /** Read a single cookie value by name; {@code null} if absent. */
   public static String readCookie(HttpServletRequest request, String name) {
     Cookie[] cookies = request.getCookies();
@@ -65,5 +92,33 @@ public final class GalleryAccessCookies {
   public static boolean hasValidAccess(
       HttpServletRequest request, String slug, ClientGalleryAuthService auth) {
     return auth.validateAccessToken(slug, readCookie(request, cookieName(slug)));
+  }
+
+  /**
+   * True iff the request carries either (a) a valid per-slug access cookie or (b) a valid
+   * password-fingerprint cookie matching the gallery's current password. The fingerprint variant is
+   * what makes a PARENT password unlock its propagated CLIENT_GALLERY children (and vice versa)
+   * without re-prompting — they share the password, so they share the cookie.
+   *
+   * @param request Servlet request
+   * @param slug Collection slug for the per-slug cookie lookup
+   * @param password Current plaintext password on the gallery being read; null/blank treats the
+   *     gallery as unprotected and short-circuits to {@code true}
+   * @param auth Auth service for HMAC validation
+   */
+  public static boolean hasValidAccess(
+      HttpServletRequest request, String slug, String password, ClientGalleryAuthService auth) {
+    if (password == null || password.isEmpty()) {
+      return true;
+    }
+    if (auth.validateAccessToken(slug, readCookie(request, cookieName(slug)))) {
+      return true;
+    }
+    String fingerprint = auth.passwordFingerprint(password);
+    if (fingerprint == null) {
+      return false;
+    }
+    return auth.validatePasswordAccessToken(
+        password, readCookie(request, passwordCookieName(fingerprint)));
   }
 }

--- a/src/main/java/edens/zac/portfolio/backend/controller/dev/AdminController.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/dev/AdminController.java
@@ -12,6 +12,7 @@ import edens.zac.portfolio.backend.model.GeneralMetadataDTO;
 import edens.zac.portfolio.backend.model.ImageSearchRequest;
 import edens.zac.portfolio.backend.model.ImageSearchResponse;
 import edens.zac.portfolio.backend.model.ImageUploadResult;
+import edens.zac.portfolio.backend.model.PagedResponse;
 import edens.zac.portfolio.backend.model.Records;
 import edens.zac.portfolio.backend.services.AdminHomeService;
 import edens.zac.portfolio.backend.services.CollectionService;
@@ -127,12 +128,12 @@ class AdminController {
 
   /** All collections paginated, ordered by collection date DESC. Visibility is not filtered. */
   @GetMapping("/collections/all")
-  public ResponseEntity<Page<CollectionModel>> getAllCollectionsOrderedByDate(
+  public ResponseEntity<PagedResponse<CollectionModel>> getAllCollectionsOrderedByDate(
       @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "50") int size) {
     Pageable pageable = PaginationUtil.normalizeCollectionPageable(page, size);
     Page<CollectionModel> collections = collectionService.getAllCollections(pageable);
     log.debug("Retrieved {} collections ordered by date", collections.getNumberOfElements());
-    return ResponseEntity.ok(collections);
+    return ResponseEntity.ok(PagedResponse.from(collections));
   }
 
   /** Manage-page payload: collection plus all metadata (tags, people, cameras, films, etc.). */
@@ -269,7 +270,7 @@ class AdminController {
    * visibility filtering.
    */
   @GetMapping("/content/images")
-  public ResponseEntity<Page<ContentModels.Image>> getAllImages(
+  public ResponseEntity<PagedResponse<ContentModels.Image>> getAllImages(
       @RequestParam(required = false) List<Long> personIds,
       @RequestParam(required = false) List<Long> tagIds,
       @RequestParam(required = false) Long cameraId,
@@ -303,7 +304,7 @@ class AdminController {
     Pageable pageable = PageRequest.of(page, safeSize);
     Page<ContentModels.Image> wrapped =
         new PageImpl<>(response.content(), pageable, response.totalElements());
-    return ResponseEntity.ok(wrapped);
+    return ResponseEntity.ok(PagedResponse.from(wrapped));
   }
 
   /** Delete one or more images. */

--- a/src/main/java/edens/zac/portfolio/backend/controller/prod/CollectionControllerProd.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/prod/CollectionControllerProd.java
@@ -1,12 +1,10 @@
 package edens.zac.portfolio.backend.controller.prod;
 
-import static edens.zac.portfolio.backend.config.GalleryAccessCookies.cookieName;
-
 import edens.zac.portfolio.backend.config.ClientGalleryAccessLimiter;
 import edens.zac.portfolio.backend.config.DefaultValues;
-import edens.zac.portfolio.backend.config.GalleryAccessCookies;
 import edens.zac.portfolio.backend.model.CollectionModel;
 import edens.zac.portfolio.backend.model.LocationPageResponse;
+import edens.zac.portfolio.backend.model.PagedResponse;
 import edens.zac.portfolio.backend.model.PasswordRequest;
 import edens.zac.portfolio.backend.services.ClientGalleryAuthService;
 import edens.zac.portfolio.backend.services.CollectionService;
@@ -23,7 +21,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -66,11 +63,11 @@ public class CollectionControllerProd {
    * @return ResponseEntity with paginated collections
    */
   @GetMapping
-  public ResponseEntity<Page<CollectionModel>> getAllCollections(
+  public ResponseEntity<PagedResponse<CollectionModel>> getAllCollections(
       @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "50") int size) {
     Pageable pageable = PaginationUtil.normalizeCollectionPageable(page, size);
     Page<CollectionModel> collections = collectionService.getVisibleCollections(pageable);
-    return ResponseEntity.ok(collections);
+    return ResponseEntity.ok(PagedResponse.from(collections));
   }
 
   /**
@@ -98,9 +95,8 @@ public class CollectionControllerProd {
     CollectionModel collection =
         collectionService.getCollectionWithPagination(slug, normalizedPage, normalizedSize);
 
-    // For password-protected galleries, omit content unless a valid cookie is supplied.
     if (Boolean.TRUE.equals(collection.getIsPasswordProtected())
-        && !GalleryAccessCookies.hasValidAccess(request, slug, clientGalleryAuthService)) {
+        && !collectionService.isGalleryAccessAuthorized(slug, request)) {
       collection.setContent(null);
       collection.setContentCount(null);
     }
@@ -189,16 +185,10 @@ public class CollectionControllerProd {
       return ResponseEntity.ok(Map.of("hasAccess", false));
     }
 
-    String token = clientGalleryAuthService.generateAccessToken(slug);
-    ResponseCookie cookie =
-        ResponseCookie.from(cookieName(slug), token)
-            .httpOnly(true)
-            .secure(galleryCookieSecure)
-            .sameSite("Strict")
-            .path("/")
-            .maxAge(GALLERY_COOKIE_MAX_AGE)
-            .build();
-    response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    clientGalleryAuthService
+        .buildAccessCookies(
+            slug, passwordRequest.password(), galleryCookieSecure, GALLERY_COOKIE_MAX_AGE)
+        .forEach(c -> response.addHeader(HttpHeaders.SET_COOKIE, c.toString()));
 
     return ResponseEntity.ok(Map.of("hasAccess", true));
   }

--- a/src/main/java/edens/zac/portfolio/backend/dao/CollectionRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/CollectionRepository.java
@@ -169,11 +169,10 @@ public class CollectionRepository extends BaseDao {
   }
 
   /**
-   * Same join chain as {@link #findReferencedCollectionsByParentId} but returns ALL referenced
-   * children regardless of {@code c.visibility}. Per-membership {@code cc.visible = true} is still
-   * enforced so soft-removed memberships are excluded. Used by admin-context flows like PARENT
-   * password propagation, where the admin must reach UNLISTED/HIDDEN children (CLIENT_GALLERY
-   * default visibility is UNLISTED per V20 migration).
+   * Same join chain as {@link #findReferencedCollectionsByParentId} but returns every referenced
+   * child regardless of either {@code c.visibility} or per-membership {@code cc.visible}. Used by
+   * admin-context flows (e.g. PARENT password propagation) where the admin must reach every linked
+   * child — UI/membership visibility does not gate admin operations.
    */
   @Transactional(readOnly = true)
   public List<CollectionEntity> findAllReferencedCollectionsByParentId(Long parentId) {
@@ -186,7 +185,6 @@ public class CollectionRepository extends BaseDao {
         JOIN content_collection cct ON cct.referenced_collection_id = c.id
         JOIN collection_content cc ON cc.content_id = cct.id
         WHERE cc.collection_id = :parentId
-          AND cc.visible = true
         ORDER BY cc.order_index ASC
         """;
     MapSqlParameterSource params = createParameterSource().addValue("parentId", parentId);
@@ -305,6 +303,76 @@ public class CollectionRepository extends BaseDao {
     }
     sql.append(" ORDER BY rating DESC NULLS LAST, collection_date DESC NULLS LAST");
     return query(sql.toString(), COLLECTION_ROW_MAPPER, params);
+  }
+
+  /**
+   * Same as {@link #findOrderedByVisibilityIn} but additionally drops collections that have zero
+   * non-soft-removed entries in {@code collection_content}. Used by synthetic-list endpoints (e.g.
+   * {@code /all-collections}, {@code /all-blogs}) so the listing never renders empty tiles.
+   * Admin-only flows that need empty collections (e.g. cover-image picking) should keep using
+   * {@link #findOrderedByVisibilityIn}.
+   */
+  @Transactional(readOnly = true)
+  public List<CollectionEntity> findNonEmptyOrderedByVisibilityIn(
+      List<CollectionVisibility> allowed, CollectionType typeFilter) {
+    StringBuilder sql =
+        new StringBuilder(SELECT_COLLECTION).append(" WHERE visibility IN (:visibilities) ");
+    MapSqlParameterSource params =
+        createParameterSource()
+            .addValue("visibilities", allowed.stream().map(CollectionVisibility::name).toList());
+    if (typeFilter != null) {
+      sql.append(" AND type = :type ");
+      params.addValue("type", typeFilter.name());
+    }
+    sql.append(
+        """
+         AND EXISTS (
+           SELECT 1 FROM collection_content cc
+           WHERE cc.collection_id = collection.id
+             AND cc.visible = true
+         )
+         ORDER BY rating DESC NULLS LAST, collection_date DESC NULLS LAST
+        """);
+    return query(sql.toString(), COLLECTION_ROW_MAPPER, params);
+  }
+
+  /**
+   * Find every CLIENT_GALLERY plus every PARENT that has at least one CLIENT_GALLERY child, all
+   * within the supplied visibility set, ordered by rating then collection_date. The PARENT branch
+   * walks the same join chain as {@link #findReferencedCollectionsByParentId} (parent ->
+   * collection_content -> content_collection -> child) and applies the same visibility scope to the
+   * child rows so PARENTs whose only matching child is HIDDEN do not appear. Used by the
+   * "all-client-galleries" synthetic listing where PARENT-of-galleries (e.g. wedding wrappers)
+   * should appear alongside standalone CLIENT_GALLERYs.
+   */
+  @Transactional(readOnly = true)
+  public List<CollectionEntity> findClientGalleriesAndQualifyingParents(
+      List<CollectionVisibility> allowed) {
+    String sql =
+        SELECT_COLLECTION
+            + """
+             WHERE visibility IN (:visibilities)
+               AND (
+                 type = 'CLIENT_GALLERY'
+                 OR (
+                   type = 'PARENT'
+                   AND id IN (
+                     SELECT cc.collection_id
+                     FROM collection_content cc
+                     JOIN content_collection cct ON cct.id = cc.content_id
+                     JOIN collection child ON child.id = cct.referenced_collection_id
+                     WHERE child.type = 'CLIENT_GALLERY'
+                       AND child.visibility IN (:visibilities)
+                       AND cc.visible = true
+                   )
+                 )
+               )
+             ORDER BY rating DESC NULLS LAST, collection_date DESC NULLS LAST
+             """;
+    MapSqlParameterSource params =
+        createParameterSource()
+            .addValue("visibilities", allowed.stream().map(CollectionVisibility::name).toList());
+    return query(sql, COLLECTION_ROW_MAPPER, params);
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/edens/zac/portfolio/backend/model/PagedResponse.java
+++ b/src/main/java/edens/zac/portfolio/backend/model/PagedResponse.java
@@ -1,0 +1,24 @@
+package edens.zac.portfolio.backend.model;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+/**
+ * Stable JSON envelope for paginated endpoints. Returning {@link Page} directly triggers Spring's
+ * "Serializing PageImpl instances as-is is not supported" warning because the wire shape is not
+ * guaranteed across versions. This DTO pins the keys our frontend reads ({@code content}, {@code
+ * totalElements}, {@code totalPages}, {@code number}, {@code last}) and drops the Spring-internal
+ * fields (pageable, sort, numberOfElements, empty, first, size) that no client relies on.
+ */
+public record PagedResponse<T>(
+    List<T> content, long totalElements, int totalPages, int number, boolean last) {
+
+  public static <T> PagedResponse<T> from(Page<T> page) {
+    return new PagedResponse<>(
+        page.getContent(),
+        page.getTotalElements(),
+        page.getTotalPages(),
+        page.getNumber(),
+        page.isLast());
+  }
+}

--- a/src/main/java/edens/zac/portfolio/backend/services/AdminHomeService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/AdminHomeService.java
@@ -74,8 +74,11 @@ public class AdminHomeService {
           randomCoverUrlFromCollections(
               collectionService.findVisibleByTypeOrderByDate(CollectionType.BLOG));
       case "client-galleries" ->
+          // Client galleries are typically UNLISTED (their listing is private by design), so the
+          // LISTED-only lookup would yield no candidates and the tile would render with no cover.
+          // Admin-context lookup includes UNLISTED.
           randomCoverUrlFromCollections(
-              collectionService.findVisibleByTypeOrderByDate(CollectionType.CLIENT_GALLERY));
+              collectionService.findByTypeForAdminCovers(CollectionType.CLIENT_GALLERY));
       // metadata, comments, create, manage, about: no cover (rendered as plain entries elsewhere)
       default -> null;
     };

--- a/src/main/java/edens/zac/portfolio/backend/services/ClientGalleryAuthService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/ClientGalleryAuthService.java
@@ -1,5 +1,6 @@
 package edens.zac.portfolio.backend.services;
 
+import edens.zac.portfolio.backend.config.GalleryAccessCookies;
 import edens.zac.portfolio.backend.config.ResourceNotFoundException;
 import edens.zac.portfolio.backend.dao.CollectionRepository;
 import edens.zac.portfolio.backend.entity.CollectionEntity;
@@ -7,12 +8,15 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Base64;
+import java.util.List;
 import java.util.Optional;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -115,6 +119,110 @@ public class ClientGalleryAuthService {
     } catch (NumberFormatException e) {
       return false;
     }
+  }
+
+  /**
+   * Stable, opaque fingerprint of a gallery password. Two galleries with the same password produce
+   * the same fingerprint, enabling shared-unlock cookies across a "password group" without storing
+   * any group identifier. Computed via HMAC keyed by {@code accessTokenSecret} so the fingerprint
+   * is not derivable without the server secret.
+   *
+   * @param password The plaintext gallery password
+   * @return URL-safe base64 fingerprint, or {@code null} when {@code password} is null/blank
+   */
+  public String passwordFingerprint(String password) {
+    if (password == null || password.isEmpty()) {
+      return null;
+    }
+    return computeHmac("pwfp:" + password, accessTokenSecret);
+  }
+
+  /**
+   * Generate a time-limited HMAC access token bound to a password fingerprint. Issued alongside the
+   * per-slug token at unlock so any gallery sharing the same password also unlocks.
+   *
+   * @param password The plaintext gallery password (must be non-null/non-empty)
+   * @return HMAC token with embedded expiry
+   */
+  public String generatePasswordAccessToken(String password) {
+    String fingerprint = passwordFingerprint(password);
+    long expiry = Instant.now().plus(Duration.ofHours(24)).getEpochSecond();
+    String payload = "pw:" + fingerprint + "|" + expiry;
+    String hmac = computeHmac(payload, accessTokenSecret);
+    return hmac + "|" + expiry;
+  }
+
+  /**
+   * Validate a password-fingerprint access token against the gallery's current password. Returns
+   * false (gate) when the password is null/blank — fingerprint cookies are only meaningful for
+   * protected galleries.
+   *
+   * @param password The current plaintext password of the gallery being read
+   * @param accessToken The token from the {@code gallery_access_pw_<fingerprint>} cookie
+   * @return true if valid, fingerprint matches, and not expired
+   */
+  public boolean validatePasswordAccessToken(String password, String accessToken) {
+    if (password == null || password.isEmpty()) {
+      return false;
+    }
+    if (accessToken == null || !accessToken.contains("|")) {
+      return false;
+    }
+    String[] parts = accessToken.split("\\|");
+    if (parts.length != 2) {
+      return false;
+    }
+    try {
+      long expiry = Long.parseLong(parts[1]);
+      if (Instant.now().getEpochSecond() > expiry) {
+        return false;
+      }
+      String fingerprint = passwordFingerprint(password);
+      String expectedHmac = computeHmac("pw:" + fingerprint + "|" + expiry, accessTokenSecret);
+      return MessageDigest.isEqual(
+          expectedHmac.getBytes(StandardCharsets.UTF_8), parts[0].getBytes(StandardCharsets.UTF_8));
+    } catch (NumberFormatException e) {
+      return false;
+    }
+  }
+
+  /**
+   * Build the {@code Set-Cookie} cookies issued on a successful gallery unlock. Always includes the
+   * per-slug access cookie. When {@code password} is non-blank, additionally includes the shared
+   * password-fingerprint cookie so any other gallery whose password produces the same fingerprint
+   * also passes the gate without re-prompting.
+   *
+   * <p>Centralizing cookie construction here keeps controllers focused on HTTP wiring and prevents
+   * drift between the cookie name/value/attributes used at unlock and the names looked up in {@link
+   * GalleryAccessCookies#hasValidAccess(jakarta.servlet.http.HttpServletRequest, String, String,
+   * ClientGalleryAuthService)}.
+   */
+  public List<ResponseCookie> buildAccessCookies(
+      String slug, String password, boolean secure, Duration maxAge) {
+    List<ResponseCookie> cookies = new ArrayList<>(2);
+    cookies.add(
+        ResponseCookie.from(GalleryAccessCookies.cookieName(slug), generateAccessToken(slug))
+            .httpOnly(true)
+            .secure(secure)
+            .sameSite("Strict")
+            .path("/")
+            .maxAge(maxAge)
+            .build());
+
+    String fingerprint = passwordFingerprint(password);
+    if (fingerprint != null) {
+      cookies.add(
+          ResponseCookie.from(
+                  GalleryAccessCookies.passwordCookieName(fingerprint),
+                  generatePasswordAccessToken(password))
+              .httpOnly(true)
+              .secure(secure)
+              .sameSite("Strict")
+              .path("/")
+              .maxAge(maxAge)
+              .build());
+    }
+    return cookies;
   }
 
   private String computeHmac(String data, String secret) {

--- a/src/main/java/edens/zac/portfolio/backend/services/CollectionService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/CollectionService.java
@@ -68,6 +68,7 @@ public class CollectionService {
   private final MetadataService metadataService;
   private final EmailService emailService;
   private final SyntheticCollectionResolver syntheticResolver;
+  private final ClientGalleryAuthService clientGalleryAuthService;
   private final Environment springEnv;
 
   private static final int DEFAULT_PAGE_SIZE = default_content_per_page;
@@ -156,6 +157,21 @@ public class CollectionService {
   public List<CollectionModel> findVisibleByTypeOrderByDate(CollectionType type) {
     log.debug("Finding visible collections by type ordered by date: {}", type);
     List<CollectionEntity> collections = collectionRepository.findByTypeAndListedOrdered(type);
+    return collectionProcessingUtil.batchConvertToBasicModels(collections);
+  }
+
+  /**
+   * Find non-HIDDEN collections of a given type (LISTED + UNLISTED) for admin-only contexts where
+   * UNLISTED is acceptable to surface. Used by {@link AdminHomeService} to pick cover images for
+   * tiles like {@code client-galleries}, where the typical visibility is UNLISTED — the regular
+   * "visible" lookup would return no candidates and the tile would render with no cover.
+   */
+  @Transactional(readOnly = true)
+  public List<CollectionModel> findByTypeForAdminCovers(CollectionType type) {
+    log.debug("Finding admin-cover candidates by type: {}", type);
+    List<CollectionEntity> collections =
+        collectionRepository.findOrderedByVisibilityIn(
+            List.of(CollectionVisibility.LISTED, CollectionVisibility.UNLISTED), type);
     return collectionProcessingUtil.batchConvertToBasicModels(collections);
   }
 
@@ -416,6 +432,25 @@ public class CollectionService {
         .findBySlug(slug)
         .orElseThrow(
             () -> new ResourceNotFoundException("Collection not found with slug: " + slug));
+  }
+
+  /**
+   * Decide whether an incoming request is authorized to read the gated content of a gallery.
+   * Encapsulates both the per-slug cookie check and the shared password-fingerprint cookie check
+   * (the latter is what makes a PARENT password also unlock its propagated CLIENT_GALLERY children,
+   * and vice versa, without re-prompting). Returns {@code true} for unprotected or missing
+   * collections — the GET handler still returns 200 with the stripped/empty model.
+   */
+  @Transactional(readOnly = true)
+  public boolean isGalleryAccessAuthorized(
+      String slug, jakarta.servlet.http.HttpServletRequest request) {
+    return collectionRepository
+        .findBySlug(slug)
+        .map(
+            entity ->
+                edens.zac.portfolio.backend.config.GalleryAccessCookies.hasValidAccess(
+                    request, slug, entity.getGalleryPassword(), clientGalleryAuthService))
+        .orElse(true);
   }
 
   @Transactional
@@ -803,7 +838,7 @@ public class CollectionService {
                   .collectionId(parentCollection.getId())
                   .contentId(existingContentCollection.getId())
                   .orderIndex(orderIndex)
-                  .visible(childCollection.visible() != null ? childCollection.visible() : false)
+                  .visible(childCollection.visible() != null ? childCollection.visible() : true)
                   .createdAt(LocalDateTime.now())
                   .updatedAt(LocalDateTime.now())
                   .build();
@@ -1075,9 +1110,13 @@ public class CollectionService {
   }
 
   /**
-   * Remove child collection content items that reference non-LISTED collections. This prevents
-   * UNLISTED and HIDDEN collections from leaking through parent collection responses on public
-   * endpoints.
+   * Remove child collection content items that reference children the viewer should not see in this
+   * context. Default scope (e.g. PARENT-of-portfolios) drops UNLISTED + HIDDEN children so
+   * directories don't leak unlisted work. Client-gallery context — viewing a CLIENT_GALLERY
+   * directly, or a PARENT that contains at least one CLIENT_GALLERY child — drops only HIDDEN, so
+   * UNLISTED client galleries (the typical visibility for password-protected work) remain visible
+   * to viewers who have already navigated into the parent. Authentication is enforced upstream;
+   * this method runs only for already-authorized responses.
    */
   private void filterNonListedChildCollections(CollectionModel model) {
     if (model == null || model.getContent() == null || model.getContent().isEmpty()) {
@@ -1098,31 +1137,45 @@ public class CollectionService {
       return;
     }
 
-    // Batch-load referenced collections and find non-LISTED ones (UNLISTED + HIDDEN)
-    Set<Long> nonListedIds =
-        collectionRepository.findByIds(referencedIds).stream()
-            .filter(c -> !c.getVisibility().appearsInLists())
+    // Batch-load referenced children once — used for both context detection and visibility filter
+    List<CollectionEntity> children = collectionRepository.findByIds(referencedIds);
+
+    boolean isClientGalleryContext =
+        model.getType() == CollectionType.CLIENT_GALLERY
+            || (model.getType() == CollectionType.PARENT
+                && children.stream().anyMatch(c -> c.getType() == CollectionType.CLIENT_GALLERY));
+
+    Set<Long> excludedIds =
+        children.stream()
+            .filter(
+                c ->
+                    isClientGalleryContext
+                        ? c.getVisibility() == CollectionVisibility.HIDDEN
+                        : !c.getVisibility().appearsInLists())
             .map(CollectionEntity::getId)
             .collect(Collectors.toSet());
 
-    if (nonListedIds.isEmpty()) {
+    if (excludedIds.isEmpty()) {
       return;
     }
 
-    // Filter out content items that reference non-LISTED collections
     List<ContentModel> filtered =
         model.getContent().stream()
             .filter(
                 content -> {
                   if (content instanceof ContentModels.Collection col) {
-                    return !nonListedIds.contains(col.referencedCollectionId());
+                    return !excludedIds.contains(col.referencedCollectionId());
                   }
                   return true;
                 })
             .collect(Collectors.toList());
 
     model.setContent(filtered);
-    log.debug("Filtered {} non-LISTED child collections from response", nonListedIds.size());
+    log.debug(
+        "Filtered {} child collections from response (parent={}, clientGalleryContext={})",
+        excludedIds.size(),
+        model.getSlug(),
+        isClientGalleryContext);
   }
 
   /**
@@ -1204,10 +1257,23 @@ public class CollectionService {
       CollectionEntity parent, GalleryAccessRequest request) {
     if (!Boolean.TRUE.equals(request.propagateToChildren())
         || parent.getType() != CollectionType.PARENT) {
+      log.debug(
+          "Skipping password propagation (parentId={}, propagate={}, type={})",
+          parent.getId(),
+          request.propagateToChildren(),
+          parent.getType());
       return;
     }
     List<CollectionEntity> children =
         collectionRepository.findAllReferencedCollectionsByParentId(parent.getId());
+    long clientGalleryCount =
+        children.stream().filter(c -> c.getType() == CollectionType.CLIENT_GALLERY).count();
+    log.info(
+        "Propagating password from parent (id={}, slug={}): {} children found, {} are CLIENT_GALLERY",
+        parent.getId(),
+        parent.getSlug(),
+        children.size(),
+        clientGalleryCount);
     for (CollectionEntity child : children) {
       if (child.getType() == CollectionType.CLIENT_GALLERY) {
         collectionRepository.updateGalleryPassword(child.getId(), request.password());

--- a/src/main/java/edens/zac/portfolio/backend/services/SyntheticCollectionResolver.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/SyntheticCollectionResolver.java
@@ -28,14 +28,22 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class SyntheticCollectionResolver {
 
+  static final String ALL_CLIENT_GALLERIES = "all-client-galleries";
+
   private static final Map<String, Synthetic> CATALOG =
       Map.of(
-          "all-collections", new Synthetic("All Collections", null),
-          "all-blogs", new Synthetic("Blogs", CollectionType.BLOG),
-          "all-portfolios", new Synthetic("Portfolios", CollectionType.PORTFOLIO),
-          "all-client-galleries", new Synthetic("Client Galleries", CollectionType.CLIENT_GALLERY),
-          "all-art-galleries", new Synthetic("Art Galleries", CollectionType.ART_GALLERY),
-          "all-misc", new Synthetic("Misc", CollectionType.MISC));
+          "all-collections",
+          new Synthetic("All Collections", null),
+          "all-blogs",
+          new Synthetic("Blogs", CollectionType.BLOG),
+          "all-portfolios",
+          new Synthetic("Portfolios", CollectionType.PORTFOLIO),
+          ALL_CLIENT_GALLERIES,
+          new Synthetic("Client Galleries", CollectionType.CLIENT_GALLERY),
+          "all-art-galleries",
+          new Synthetic("Art Galleries", CollectionType.ART_GALLERY),
+          "all-misc",
+          new Synthetic("Misc", CollectionType.MISC));
 
   private final CollectionRepository collectionRepository;
   private final CollectionProcessingUtil collectionProcessingUtil;
@@ -63,8 +71,15 @@ public class SyntheticCollectionResolver {
                 CollectionVisibility.UNLISTED,
                 CollectionVisibility.HIDDEN)
             : List.of(CollectionVisibility.LISTED);
+
+    // "all-client-galleries" includes PARENT collections that have ≥1 CLIENT_GALLERY child
+    // (e.g. wedding wrappers with ceremony/reception sub-galleries) so they appear alongside
+    // standalone CLIENT_GALLERYs. Other synthetic slugs use the simple type filter, and exclude
+    // collections that have zero content rows so the listing never shows empty tiles.
     List<CollectionEntity> rows =
-        collectionRepository.findOrderedByVisibilityIn(allowed, spec.typeFilter());
+        ALL_CLIENT_GALLERIES.equals(slug)
+            ? collectionRepository.findClientGalleriesAndQualifyingParents(allowed)
+            : collectionRepository.findNonEmptyOrderedByVisibilityIn(allowed, spec.typeFilter());
     List<CollectionModel> children = collectionProcessingUtil.batchConvertToBasicModels(rows);
 
     List<ContentModel> content =

--- a/src/test/java/edens/zac/portfolio/backend/config/GalleryAccessCookiesTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/config/GalleryAccessCookiesTest.java
@@ -97,4 +97,84 @@ class GalleryAccessCookiesTest {
 
     assertFalse(GalleryAccessCookies.hasValidAccess(request, "my-gallery", auth));
   }
+
+  @Test
+  void passwordCookieName_appliesPrefix() {
+    assertThat(GalleryAccessCookies.passwordCookieName("abc123_-"))
+        .isEqualTo("gallery_access_pw_abc123_-");
+  }
+
+  @Test
+  void passwordCookieName_sanitizesUnsafeChars() {
+    assertThat(GalleryAccessCookies.passwordCookieName("abc/=+xyz"))
+        .isEqualTo("gallery_access_pw_abc___xyz");
+  }
+
+  @Test
+  void passwordCookieName_handlesNullAndBlank() {
+    assertThat(GalleryAccessCookies.passwordCookieName(null)).isEqualTo("gallery_access_pw_");
+    assertThat(GalleryAccessCookies.passwordCookieName("")).isEqualTo("gallery_access_pw_");
+  }
+
+  @Test
+  void passwordAwareHasValidAccess_returnsTrue_forUnprotectedGallery() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getCookies()).thenReturn(null);
+    ClientGalleryAuthService auth = mock(ClientGalleryAuthService.class);
+
+    assertTrue(GalleryAccessCookies.hasValidAccess(request, "any-slug", null, auth));
+    assertTrue(GalleryAccessCookies.hasValidAccess(request, "any-slug", "", auth));
+  }
+
+  @Test
+  void passwordAwareHasValidAccess_acceptsSlugCookie() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    Cookie slugCookie = new Cookie("gallery_access_my-gallery", "slug-token");
+    when(request.getCookies()).thenReturn(new Cookie[] {slugCookie});
+    ClientGalleryAuthService auth = mock(ClientGalleryAuthService.class);
+    when(auth.validateAccessToken("my-gallery", "slug-token")).thenReturn(true);
+
+    assertTrue(GalleryAccessCookies.hasValidAccess(request, "my-gallery", "secret", auth));
+  }
+
+  @Test
+  void passwordAwareHasValidAccess_acceptsFingerprintCookie() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    Cookie fpCookie = new Cookie("gallery_access_pw_FINGER", "group-token");
+    when(request.getCookies()).thenReturn(new Cookie[] {fpCookie});
+    ClientGalleryAuthService auth = mock(ClientGalleryAuthService.class);
+    when(auth.validateAccessToken("sibling-gallery", null)).thenReturn(false);
+    when(auth.passwordFingerprint("shared-pw")).thenReturn("FINGER");
+    when(auth.validatePasswordAccessToken("shared-pw", "group-token")).thenReturn(true);
+
+    assertTrue(GalleryAccessCookies.hasValidAccess(request, "sibling-gallery", "shared-pw", auth));
+  }
+
+  @Test
+  void passwordAwareHasValidAccess_rejectsWhenBothCookiesInvalid() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    Cookie fpCookie = new Cookie("gallery_access_pw_FINGER", "stale-token");
+    when(request.getCookies()).thenReturn(new Cookie[] {fpCookie});
+    ClientGalleryAuthService auth = mock(ClientGalleryAuthService.class);
+    when(auth.validateAccessToken("sibling-gallery", null)).thenReturn(false);
+    when(auth.passwordFingerprint("shared-pw")).thenReturn("FINGER");
+    when(auth.validatePasswordAccessToken("shared-pw", "stale-token")).thenReturn(false);
+
+    assertFalse(GalleryAccessCookies.hasValidAccess(request, "sibling-gallery", "shared-pw", auth));
+  }
+
+  @Test
+  void passwordAwareHasValidAccess_rejectsWhenFingerprintMismatch() {
+    // The user has a valid group cookie for password-A, but the gallery they're requesting
+    // has password-B. The fingerprint cookie name doesn't match → effectively no group cookie.
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    Cookie fpCookie = new Cookie("gallery_access_pw_FINGER_A", "good-token-for-A");
+    when(request.getCookies()).thenReturn(new Cookie[] {fpCookie});
+    ClientGalleryAuthService auth = mock(ClientGalleryAuthService.class);
+    when(auth.validateAccessToken("solo-gallery", null)).thenReturn(false);
+    when(auth.passwordFingerprint("password-B")).thenReturn("FINGER_B");
+    when(auth.validatePasswordAccessToken("password-B", null)).thenReturn(false);
+
+    assertFalse(GalleryAccessCookies.hasValidAccess(request, "solo-gallery", "password-B", auth));
+  }
 }

--- a/src/test/java/edens/zac/portfolio/backend/controller/prod/CollectionControllerProdTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/prod/CollectionControllerProdTest.java
@@ -27,6 +27,7 @@ import edens.zac.portfolio.backend.services.CollectionService;
 import edens.zac.portfolio.backend.types.CollectionType;
 import edens.zac.portfolio.backend.types.CollectionVisibility;
 import jakarta.servlet.http.Cookie;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,6 +42,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseCookie;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -186,7 +188,14 @@ class CollectionControllerProdTest {
         .andExpect(jsonPath("$.content[2].title", is("Test Client Gallery")))
         .andExpect(jsonPath("$.totalElements", is(3)))
         .andExpect(jsonPath("$.totalPages", is(1)))
-        .andExpect(jsonPath("$.number", is(0)));
+        .andExpect(jsonPath("$.number", is(0)))
+        .andExpect(jsonPath("$.last", is(true)))
+        // Pin the wire shape: response uses our PagedResponse DTO, NOT Spring's PageImpl, which
+        // would also leak pageable/sort/numberOfElements/empty and which Spring's
+        // PageModule$WarningLoggingModifier warns about as unstable across versions.
+        .andExpect(jsonPath("$.pageable").doesNotExist())
+        .andExpect(jsonPath("$.sort").doesNotExist())
+        .andExpect(jsonPath("$.numberOfElements").doesNotExist());
   }
 
   @Test
@@ -280,8 +289,17 @@ class CollectionControllerProdTest {
     when(clientGalleryAuthService.validateClientGalleryAccess(
             eq("test-client-gallery"), eq("correct-password")))
         .thenReturn(true);
-    when(clientGalleryAuthService.generateAccessToken(eq("test-client-gallery")))
-        .thenReturn("hmac-token|1234567890");
+    when(clientGalleryAuthService.buildAccessCookies(
+            eq("test-client-gallery"), eq("correct-password"), eq(true), any(Duration.class)))
+        .thenReturn(
+            List.of(
+                ResponseCookie.from("gallery_access_test-client-gallery", "hmac-token|1234567890")
+                    .httpOnly(true)
+                    .secure(true)
+                    .sameSite("Strict")
+                    .path("/")
+                    .maxAge(Duration.ofHours(24))
+                    .build()));
 
     // Act & Assert
     mockMvc
@@ -306,6 +324,50 @@ class CollectionControllerProdTest {
 
   @Test
   @DisplayName(
+      "POST /collections/{slug}/access also sets the shared password-fingerprint cookie for group unlock")
+  void validateClientGalleryAccess_alsoSetsFingerprintCookie() throws Exception {
+    PasswordRequest passwordRequest = new PasswordRequest("shared-pw");
+    when(accessLimiter.allow(anyString(), eq("test-client-gallery"))).thenReturn(true);
+    when(clientGalleryAuthService.validateClientGalleryAccess(
+            eq("test-client-gallery"), eq("shared-pw")))
+        .thenReturn(true);
+    when(clientGalleryAuthService.buildAccessCookies(
+            eq("test-client-gallery"), eq("shared-pw"), eq(true), any(Duration.class)))
+        .thenReturn(
+            List.of(
+                ResponseCookie.from("gallery_access_test-client-gallery", "slug-token")
+                    .httpOnly(true)
+                    .secure(true)
+                    .sameSite("Strict")
+                    .path("/")
+                    .maxAge(Duration.ofHours(24))
+                    .build(),
+                ResponseCookie.from("gallery_access_pw_FINGERPRINT", "group-token")
+                    .httpOnly(true)
+                    .secure(true)
+                    .sameSite("Strict")
+                    .path("/")
+                    .maxAge(Duration.ofHours(24))
+                    .build()));
+
+    mockMvc
+        .perform(
+            post("/api/read/collections/test-client-gallery/access")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(passwordRequest)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.hasAccess", is(true)))
+        .andExpect(cookie().exists("gallery_access_test-client-gallery"))
+        .andExpect(cookie().exists("gallery_access_pw_FINGERPRINT"))
+        .andExpect(cookie().value("gallery_access_pw_FINGERPRINT", "group-token"))
+        .andExpect(cookie().httpOnly("gallery_access_pw_FINGERPRINT", true))
+        .andExpect(cookie().secure("gallery_access_pw_FINGERPRINT", true))
+        .andExpect(cookie().path("gallery_access_pw_FINGERPRINT", "/"))
+        .andExpect(cookie().maxAge("gallery_access_pw_FINGERPRINT", 24 * 60 * 60));
+  }
+
+  @Test
+  @DisplayName(
       "POST /collections/{slug}/access in dev profile (cookie-secure=false) should omit Secure attr")
   void validateClientGalleryAccess_devProfile_shouldOmitSecureCookieAttribute() throws Exception {
     // Localhost runs over plain http; browsers silently reject Secure cookies on
@@ -319,8 +381,17 @@ class CollectionControllerProdTest {
     when(clientGalleryAuthService.validateClientGalleryAccess(
             eq("test-client-gallery"), eq("correct-password")))
         .thenReturn(true);
-    when(clientGalleryAuthService.generateAccessToken(eq("test-client-gallery")))
-        .thenReturn("hmac-token|1234567890");
+    when(clientGalleryAuthService.buildAccessCookies(
+            eq("test-client-gallery"), eq("correct-password"), eq(false), any(Duration.class)))
+        .thenReturn(
+            List.of(
+                ResponseCookie.from("gallery_access_test-client-gallery", "hmac-token|1234567890")
+                    .httpOnly(true)
+                    .secure(false)
+                    .sameSite("Strict")
+                    .path("/")
+                    .maxAge(Duration.ofHours(24))
+                    .build()));
 
     mockMvc
         .perform(
@@ -504,6 +575,8 @@ class CollectionControllerProdTest {
 
     when(collectionService.getCollectionWithPagination(eq("client-gallery"), anyInt(), anyInt()))
         .thenReturn(protectedCollection);
+    when(collectionService.isGalleryAccessAuthorized(eq("client-gallery"), any()))
+        .thenReturn(false);
 
     // Act & Assert
     mockMvc
@@ -527,7 +600,7 @@ class CollectionControllerProdTest {
 
     when(collectionService.getCollectionWithPagination(eq("client-gallery"), anyInt(), anyInt()))
         .thenReturn(protectedCollection);
-    when(clientGalleryAuthService.validateAccessToken(eq("client-gallery"), eq("wrong-token")))
+    when(collectionService.isGalleryAccessAuthorized(eq("client-gallery"), any()))
         .thenReturn(false);
 
     // Act & Assert
@@ -587,8 +660,7 @@ class CollectionControllerProdTest {
 
     when(collectionService.getCollectionWithPagination(eq("client-gallery"), anyInt(), anyInt()))
         .thenReturn(protectedCollection);
-    when(clientGalleryAuthService.validateAccessToken(eq("client-gallery"), eq("cookie-token")))
-        .thenReturn(true);
+    when(collectionService.isGalleryAccessAuthorized(eq("client-gallery"), any())).thenReturn(true);
 
     // Act & Assert
     mockMvc
@@ -606,6 +678,30 @@ class CollectionControllerProdTest {
   }
 
   @Test
+  @DisplayName(
+      "GET /collections/{slug} password-protected, group cookie via shared password, includes content")
+  void getCollectionBySlug_passwordProtected_groupCookie_shouldIncludeContent() throws Exception {
+    // Sibling gallery scenario: viewer unlocked the parent (or another sibling) and now visits
+    // this gallery directly. Per the gated-yard model, isGalleryAccessAuthorized returns true
+    // because the fingerprint cookie matches this gallery's password.
+    CollectionModel protectedCollection = createPasswordProtectedCollection();
+    when(collectionService.getCollectionWithPagination(eq("client-gallery"), anyInt(), anyInt()))
+        .thenReturn(protectedCollection);
+    when(collectionService.isGalleryAccessAuthorized(eq("client-gallery"), any())).thenReturn(true);
+
+    mockMvc
+        .perform(
+            get("/api/read/collections/client-gallery")
+                .param("page", "0")
+                .param("size", "30")
+                .cookie(new Cookie("gallery_access_pw_FINGERPRINT", "group-token"))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content", hasSize(1)))
+        .andExpect(jsonPath("$.contentCount", is(5)));
+  }
+
+  @Test
   @DisplayName("GET /collections/{slug} password protected with no cookie strips content")
   void getCollectionBySlug_passwordProtected_noCookie_stripsContent() throws Exception {
     // Arrange
@@ -613,6 +709,8 @@ class CollectionControllerProdTest {
 
     when(collectionService.getCollectionWithPagination(eq("client-gallery"), anyInt(), anyInt()))
         .thenReturn(protectedCollection);
+    when(collectionService.isGalleryAccessAuthorized(eq("client-gallery"), any()))
+        .thenReturn(false);
 
     // Act & Assert — no cookie attached
     mockMvc
@@ -660,7 +758,7 @@ class CollectionControllerProdTest {
   void getCollectionBySlug_protectedInvalidCookie_retainsCoverImage() throws Exception {
     when(collectionService.getCollectionWithPagination(eq("client-gallery"), anyInt(), anyInt()))
         .thenReturn(createPasswordProtectedCollectionWithCover());
-    when(clientGalleryAuthService.validateAccessToken(eq("client-gallery"), eq("bad")))
+    when(collectionService.isGalleryAccessAuthorized(eq("client-gallery"), any()))
         .thenReturn(false);
 
     mockMvc
@@ -680,8 +778,7 @@ class CollectionControllerProdTest {
   void getCollectionBySlug_protectedValidCookie_retainsCoverImage() throws Exception {
     when(collectionService.getCollectionWithPagination(eq("client-gallery"), anyInt(), anyInt()))
         .thenReturn(createPasswordProtectedCollectionWithCover());
-    when(clientGalleryAuthService.validateAccessToken(eq("client-gallery"), eq("good")))
-        .thenReturn(true);
+    when(collectionService.isGalleryAccessAuthorized(eq("client-gallery"), any())).thenReturn(true);
 
     mockMvc
         .perform(
@@ -710,8 +807,17 @@ class CollectionControllerProdTest {
     when(clientGalleryAuthService.validateClientGalleryAccess(
             eq("test-client-gallery"), eq("correct-password")))
         .thenReturn(true);
-    when(clientGalleryAuthService.generateAccessToken(eq("test-client-gallery")))
-        .thenReturn("some-token");
+    when(clientGalleryAuthService.buildAccessCookies(
+            eq("test-client-gallery"), eq("correct-password"), eq(true), any(Duration.class)))
+        .thenReturn(
+            List.of(
+                ResponseCookie.from("gallery_access_test-client-gallery", "some-token")
+                    .httpOnly(true)
+                    .secure(true)
+                    .sameSite("Strict")
+                    .path("/")
+                    .maxAge(Duration.ofHours(24))
+                    .build()));
 
     // Act: send with only X-Forwarded-For, no X-Real-IP
     // The controller must fall through to getRemoteAddr() ("127.0.0.1" in MockMvc)

--- a/src/test/java/edens/zac/portfolio/backend/dao/CollectionRepositoryTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/dao/CollectionRepositoryTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import edens.zac.portfolio.backend.types.CollectionType;
+import edens.zac.portfolio.backend.types.CollectionVisibility;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -164,6 +165,58 @@ class CollectionRepositoryTest {
       String sql = sqlCaptor.getValue();
       assertThat(sql).containsIgnoringCase("ORDER BY rating DESC NULLS LAST, collection_date DESC");
       assertThat(sql).containsIgnoringCase("WHERE type = :type AND visibility = 'LISTED'");
+    }
+  }
+
+  @Nested
+  class FindNonEmptyOrderedByVisibilityIn {
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void sqlGatesOnExistsCollectionContentRowsAndPassesVisibilities() {
+      // Pin the SQL: caller relies on the EXISTS gate to drop empty collections from
+      // synthetic listings (/all-collections, /all-blogs, etc.). Soft-removed memberships
+      // (cc.visible=false) must NOT count as content — must mirror the gate used by
+      // findReferencedCollectionsByParentId.
+      when(namedParameterJdbcTemplate.query(
+              anyString(), any(MapSqlParameterSource.class), any(RowMapper.class)))
+          .thenReturn(List.of());
+
+      collectionRepository.findNonEmptyOrderedByVisibilityIn(
+          List.of(CollectionVisibility.LISTED, CollectionVisibility.UNLISTED),
+          CollectionType.PORTFOLIO);
+
+      verify(namedParameterJdbcTemplate)
+          .query(sqlCaptor.capture(), paramsCaptor.capture(), any(RowMapper.class));
+      String sql = sqlCaptor.getValue();
+      assertThat(sql).containsIgnoringCase("EXISTS");
+      assertThat(sql).containsIgnoringCase("collection_content cc");
+      assertThat(sql).containsIgnoringCase("cc.collection_id = collection.id");
+      assertThat(sql).containsIgnoringCase("cc.visible = true");
+      assertThat(sql).containsIgnoringCase("WHERE visibility IN (:visibilities)");
+      assertThat(sql).containsIgnoringCase("AND type = :type");
+      assertThat(sql).containsIgnoringCase("ORDER BY rating DESC NULLS LAST, collection_date DESC");
+      MapSqlParameterSource params = paramsCaptor.getValue();
+      assertThat((List<String>) params.getValue("visibilities"))
+          .containsExactly("LISTED", "UNLISTED");
+      assertThat(params.getValue("type")).isEqualTo("PORTFOLIO");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void sqlOmitsTypePredicateWhenTypeFilterIsNull() {
+      when(namedParameterJdbcTemplate.query(
+              anyString(), any(MapSqlParameterSource.class), any(RowMapper.class)))
+          .thenReturn(List.of());
+
+      collectionRepository.findNonEmptyOrderedByVisibilityIn(
+          List.of(CollectionVisibility.LISTED), null);
+
+      verify(namedParameterJdbcTemplate)
+          .query(sqlCaptor.capture(), any(MapSqlParameterSource.class), any(RowMapper.class));
+      String sql = sqlCaptor.getValue();
+      assertThat(sql).containsIgnoringCase("EXISTS");
+      assertThat(sql).doesNotContainIgnoringCase("type = :type");
     }
   }
 

--- a/src/test/java/edens/zac/portfolio/backend/services/AdminHomeServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/AdminHomeServiceTest.java
@@ -109,7 +109,7 @@ class AdminHomeServiceTest {
           .thenReturn(List.of(blog));
 
       var gallery = collectionWithCoverUrl(41L, "smith", "https://cdn/example/gallery.webp");
-      when(collectionService.findVisibleByTypeOrderByDate(CollectionType.CLIENT_GALLERY))
+      when(collectionService.findByTypeForAdminCovers(CollectionType.CLIENT_GALLERY))
           .thenReturn(List.of(gallery));
 
       List<Records.AdminHomeTileResponse> tiles = service.getTiles();

--- a/src/test/java/edens/zac/portfolio/backend/services/ClientGalleryAuthServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/ClientGalleryAuthServiceTest.java
@@ -168,4 +168,100 @@ class ClientGalleryAuthServiceTest {
       assertThat(result).isFalse();
     }
   }
+
+  @Nested
+  class PasswordFingerprint {
+
+    @Test
+    void passwordFingerprint_nullPassword_returnsNull() {
+      assertThat(clientGalleryAuthService.passwordFingerprint(null)).isNull();
+    }
+
+    @Test
+    void passwordFingerprint_emptyPassword_returnsNull() {
+      assertThat(clientGalleryAuthService.passwordFingerprint("")).isNull();
+    }
+
+    @Test
+    void passwordFingerprint_samePassword_isStable() {
+      String first = clientGalleryAuthService.passwordFingerprint("secret123");
+      String second = clientGalleryAuthService.passwordFingerprint("secret123");
+
+      assertThat(first).isNotNull();
+      assertThat(first).isEqualTo(second);
+    }
+
+    @Test
+    void passwordFingerprint_differentPasswords_diverge() {
+      String a = clientGalleryAuthService.passwordFingerprint("password-a");
+      String b = clientGalleryAuthService.passwordFingerprint("password-b");
+
+      assertThat(a).isNotEqualTo(b);
+    }
+
+    @Test
+    void passwordFingerprint_isUrlSafeBase64() {
+      String fp = clientGalleryAuthService.passwordFingerprint("any-password");
+
+      assertThat(fp).matches("[A-Za-z0-9_-]+");
+    }
+  }
+
+  @Nested
+  class ValidatePasswordAccessToken {
+
+    @Test
+    void roundTrip_returnsTrue() {
+      String token = clientGalleryAuthService.generatePasswordAccessToken("shared-pw");
+
+      boolean result = clientGalleryAuthService.validatePasswordAccessToken("shared-pw", token);
+
+      assertThat(result).isTrue();
+    }
+
+    @Test
+    void mismatchedPassword_returnsFalse() {
+      String token = clientGalleryAuthService.generatePasswordAccessToken("shared-pw");
+
+      boolean result = clientGalleryAuthService.validatePasswordAccessToken("other-pw", token);
+
+      assertThat(result).isFalse();
+    }
+
+    @Test
+    void nullPassword_returnsFalse() {
+      String token = clientGalleryAuthService.generatePasswordAccessToken("shared-pw");
+
+      boolean result = clientGalleryAuthService.validatePasswordAccessToken(null, token);
+
+      assertThat(result).isFalse();
+    }
+
+    @Test
+    void nullToken_returnsFalse() {
+      boolean result = clientGalleryAuthService.validatePasswordAccessToken("shared-pw", null);
+
+      assertThat(result).isFalse();
+    }
+
+    @Test
+    void tokenWithoutPipe_returnsFalse() {
+      boolean result =
+          clientGalleryAuthService.validatePasswordAccessToken("shared-pw", "garbage-no-pipe");
+
+      assertThat(result).isFalse();
+    }
+
+    @Test
+    void expiredToken_returnsFalse() {
+      String fingerprint = clientGalleryAuthService.passwordFingerprint("shared-pw");
+      // craft an expired token by computing the HMAC directly with expiry=0
+      // (validation only accepts hmac+expiry pairs that haven't expired yet)
+      boolean result =
+          clientGalleryAuthService.validatePasswordAccessToken("shared-pw", "fakehmac|0");
+
+      assertThat(result).isFalse();
+      assertThat(fingerprint).isNotNull(); // sanity: fingerprint computable for non-null pw
+    }
+  }
 }

--- a/src/test/java/edens/zac/portfolio/backend/services/CollectionServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/CollectionServiceTest.java
@@ -55,6 +55,7 @@ class CollectionServiceTest {
   @Mock private ContentModelConverter contentModelConverter;
   @Mock private MetadataService metadataService;
   @Mock private SyntheticCollectionResolver syntheticResolver;
+  @Mock private ClientGalleryAuthService clientGalleryAuthService;
   @Mock private org.springframework.core.env.Environment springEnv;
 
   @InjectMocks private CollectionService service;
@@ -870,6 +871,180 @@ class CollectionServiceTest {
       assertThat(result.childCollectionImages()).isNull();
       verify(collectionProcessingUtil, never()).loadImagesFromChildCollections(any());
     }
+
+    @Test
+    void parentOfClientGalleries_keepsUnlistedChildren_dropsHidden() {
+      // PARENT containing CLIENT_GALLERY children: viewer is already inside the password-gated
+      // parent context, so UNLISTED galleries (the typical visibility for client work) must
+      // remain visible. HIDDEN is still excluded.
+      String slug = "smith-wedding";
+      CollectionEntity parent =
+          CollectionEntity.builder()
+              .id(50L)
+              .slug(slug)
+              .type(CollectionType.PARENT)
+              .visibility(CollectionVisibility.LISTED)
+              .build();
+
+      ContentModels.Collection unlistedGallery =
+          childCollectionContent(101L, CollectionType.CLIENT_GALLERY);
+      ContentModels.Collection hiddenGallery =
+          childCollectionContent(102L, CollectionType.CLIENT_GALLERY);
+      ContentModels.Collection listedGallery =
+          childCollectionContent(103L, CollectionType.CLIENT_GALLERY);
+
+      CollectionModel model =
+          CollectionModel.builder()
+              .id(50L)
+              .slug(slug)
+              .type(CollectionType.PARENT)
+              .content(
+                  new java.util.ArrayList<>(List.of(unlistedGallery, hiddenGallery, listedGallery)))
+              .build();
+
+      when(collectionRepository.findBySlug(slug)).thenReturn(Optional.of(parent));
+      when(collectionRepository.findContentByCollectionIdAndContentType(50L, "COLLECTION"))
+          .thenReturn(List.of());
+      when(collectionProcessingUtil.convertToModel(
+              eq(parent), any(), anyInt(), anyInt(), anyLong()))
+          .thenReturn(model);
+      when(collectionRepository.findByIds(List.of(101L, 102L, 103L)))
+          .thenReturn(
+              List.of(
+                  childEntity(101L, CollectionType.CLIENT_GALLERY, CollectionVisibility.UNLISTED),
+                  childEntity(102L, CollectionType.CLIENT_GALLERY, CollectionVisibility.HIDDEN),
+                  childEntity(103L, CollectionType.CLIENT_GALLERY, CollectionVisibility.LISTED)));
+
+      CollectionModel result = service.getCollectionWithPagination(slug, 0, 10);
+
+      assertThat(result.getContent())
+          .extracting(c -> ((ContentModels.Collection) c).referencedCollectionId())
+          .containsExactly(101L, 103L); // UNLISTED kept, HIDDEN dropped
+    }
+
+    @Test
+    void parentOfPortfolios_keepsListedOnly_dropsUnlistedAndHidden() {
+      // PARENT containing non-CLIENT_GALLERY children (e.g. portfolio rollup): public listing
+      // semantics apply — only LISTED children appear, UNLISTED is excluded.
+      String slug = "photography";
+      CollectionEntity parent =
+          CollectionEntity.builder()
+              .id(60L)
+              .slug(slug)
+              .type(CollectionType.PARENT)
+              .visibility(CollectionVisibility.LISTED)
+              .build();
+
+      ContentModels.Collection listed = childCollectionContent(201L, CollectionType.PORTFOLIO);
+      ContentModels.Collection unlisted = childCollectionContent(202L, CollectionType.PORTFOLIO);
+
+      CollectionModel model =
+          CollectionModel.builder()
+              .id(60L)
+              .slug(slug)
+              .type(CollectionType.PARENT)
+              .content(new java.util.ArrayList<>(List.of(listed, unlisted)))
+              .build();
+
+      when(collectionRepository.findBySlug(slug)).thenReturn(Optional.of(parent));
+      when(collectionRepository.findContentByCollectionIdAndContentType(60L, "COLLECTION"))
+          .thenReturn(List.of());
+      when(collectionProcessingUtil.convertToModel(
+              eq(parent), any(), anyInt(), anyInt(), anyLong()))
+          .thenReturn(model);
+      when(collectionRepository.findByIds(List.of(201L, 202L)))
+          .thenReturn(
+              List.of(
+                  childEntity(201L, CollectionType.PORTFOLIO, CollectionVisibility.LISTED),
+                  childEntity(202L, CollectionType.PORTFOLIO, CollectionVisibility.UNLISTED)));
+
+      CollectionModel result = service.getCollectionWithPagination(slug, 0, 10);
+
+      assertThat(result.getContent())
+          .extracting(c -> ((ContentModels.Collection) c).referencedCollectionId())
+          .containsExactly(201L); // LISTED kept, UNLISTED dropped (current behavior preserved)
+    }
+
+    @Test
+    void parentOfMixedClientGalleryAndPortfolio_appliesClientGalleryContextToAllChildren() {
+      // Pinning current behavior: a PARENT with at least one CLIENT_GALLERY child flips the entire
+      // response into "client gallery context" — only HIDDEN children are dropped, regardless of
+      // the sibling child's type. So an UNLISTED PORTFOLIO sibling stays visible because the viewer
+      // is already inside the password-gated parent. The alternative (per-child context) is much
+      // more complex; this test pins the simpler whole-PARENT rule so a future refactor has to
+      // consciously change it.
+      String slug = "smith-wedding";
+      CollectionEntity parent =
+          CollectionEntity.builder()
+              .id(70L)
+              .slug(slug)
+              .type(CollectionType.PARENT)
+              .visibility(CollectionVisibility.LISTED)
+              .build();
+
+      ContentModels.Collection unlistedGallery =
+          childCollectionContent(301L, CollectionType.CLIENT_GALLERY);
+      ContentModels.Collection unlistedPortfolio =
+          childCollectionContent(302L, CollectionType.PORTFOLIO);
+      ContentModels.Collection listedPortfolio =
+          childCollectionContent(303L, CollectionType.PORTFOLIO);
+      ContentModels.Collection hiddenPortfolio =
+          childCollectionContent(304L, CollectionType.PORTFOLIO);
+
+      CollectionModel model =
+          CollectionModel.builder()
+              .id(70L)
+              .slug(slug)
+              .type(CollectionType.PARENT)
+              .content(
+                  new java.util.ArrayList<>(
+                      List.of(
+                          unlistedGallery, unlistedPortfolio, listedPortfolio, hiddenPortfolio)))
+              .build();
+
+      when(collectionRepository.findBySlug(slug)).thenReturn(Optional.of(parent));
+      when(collectionRepository.findContentByCollectionIdAndContentType(70L, "COLLECTION"))
+          .thenReturn(List.of());
+      when(collectionProcessingUtil.convertToModel(
+              eq(parent), any(), anyInt(), anyInt(), anyLong()))
+          .thenReturn(model);
+      when(collectionRepository.findByIds(List.of(301L, 302L, 303L, 304L)))
+          .thenReturn(
+              List.of(
+                  childEntity(301L, CollectionType.CLIENT_GALLERY, CollectionVisibility.UNLISTED),
+                  childEntity(302L, CollectionType.PORTFOLIO, CollectionVisibility.UNLISTED),
+                  childEntity(303L, CollectionType.PORTFOLIO, CollectionVisibility.LISTED),
+                  childEntity(304L, CollectionType.PORTFOLIO, CollectionVisibility.HIDDEN)));
+
+      CollectionModel result = service.getCollectionWithPagination(slug, 0, 10);
+
+      assertThat(result.getContent())
+          .extracting(c -> ((ContentModels.Collection) c).referencedCollectionId())
+          .containsExactly(
+              301L, 302L, 303L); // gallery + both non-hidden portfolios kept; HIDDEN dropped
+    }
+
+    private ContentModels.Collection childCollectionContent(Long childId, CollectionType type) {
+      return new ContentModels.Collection(
+          childId,
+          edens.zac.portfolio.backend.types.ContentType.COLLECTION,
+          "Child " + childId,
+          null,
+          null,
+          0,
+          true,
+          null,
+          null,
+          childId,
+          "child-" + childId,
+          type,
+          null);
+    }
+
+    private CollectionEntity childEntity(
+        Long id, CollectionType type, CollectionVisibility visibility) {
+      return CollectionEntity.builder().id(id).type(type).visibility(visibility).build();
+    }
   }
 
   @Nested
@@ -1136,6 +1311,103 @@ class CollectionServiceTest {
       service.updateGalleryAccess(100L, request);
 
       verify(collectionRepository).updateGalleryPassword(101L, "secretpw");
+    }
+  }
+
+  @Nested
+  class IsGalleryAccessAuthorized {
+
+    @Test
+    void unprotectedCollection_returnsTrue() {
+      CollectionEntity entity =
+          CollectionEntity.builder().id(1L).slug("public-gallery").galleryPassword(null).build();
+      when(collectionRepository.findBySlug("public-gallery")).thenReturn(Optional.of(entity));
+      // Null password short-circuits in hasValidAccess before any cookie is read,
+      // so we don't need to stub request.getCookies().
+      jakarta.servlet.http.HttpServletRequest request =
+          org.mockito.Mockito.mock(jakarta.servlet.http.HttpServletRequest.class);
+
+      assertThat(service.isGalleryAccessAuthorized("public-gallery", request)).isTrue();
+    }
+
+    @Test
+    void missingCollection_returnsTrue() {
+      when(collectionRepository.findBySlug("missing")).thenReturn(Optional.empty());
+      jakarta.servlet.http.HttpServletRequest request =
+          org.mockito.Mockito.mock(jakarta.servlet.http.HttpServletRequest.class);
+
+      assertThat(service.isGalleryAccessAuthorized("missing", request)).isTrue();
+    }
+
+    @Test
+    void protectedCollection_validSlugCookie_returnsTrue() {
+      CollectionEntity entity =
+          CollectionEntity.builder()
+              .id(1L)
+              .slug("protected-gallery")
+              .galleryPassword("secret123")
+              .build();
+      when(collectionRepository.findBySlug("protected-gallery")).thenReturn(Optional.of(entity));
+      jakarta.servlet.http.HttpServletRequest request =
+          org.mockito.Mockito.mock(jakarta.servlet.http.HttpServletRequest.class);
+      when(request.getCookies())
+          .thenReturn(
+              new jakarta.servlet.http.Cookie[] {
+                new jakarta.servlet.http.Cookie("gallery_access_protected-gallery", "valid-token")
+              });
+      when(clientGalleryAuthService.validateAccessToken("protected-gallery", "valid-token"))
+          .thenReturn(true);
+
+      assertThat(service.isGalleryAccessAuthorized("protected-gallery", request)).isTrue();
+    }
+
+    @Test
+    void protectedCollection_validFingerprintCookie_returnsTrue() {
+      CollectionEntity entity =
+          CollectionEntity.builder()
+              .id(1L)
+              .slug("sibling-gallery")
+              .galleryPassword("shared-pw")
+              .build();
+      when(collectionRepository.findBySlug("sibling-gallery")).thenReturn(Optional.of(entity));
+      jakarta.servlet.http.HttpServletRequest request =
+          org.mockito.Mockito.mock(jakarta.servlet.http.HttpServletRequest.class);
+      when(request.getCookies())
+          .thenReturn(
+              new jakarta.servlet.http.Cookie[] {
+                new jakarta.servlet.http.Cookie("gallery_access_pw_FP", "group-token")
+              });
+      when(clientGalleryAuthService.validateAccessToken(
+              eq("sibling-gallery"), org.mockito.Mockito.any()))
+          .thenReturn(false);
+      when(clientGalleryAuthService.passwordFingerprint("shared-pw")).thenReturn("FP");
+      when(clientGalleryAuthService.validatePasswordAccessToken("shared-pw", "group-token"))
+          .thenReturn(true);
+
+      assertThat(service.isGalleryAccessAuthorized("sibling-gallery", request)).isTrue();
+    }
+
+    @Test
+    void protectedCollection_noCookies_returnsFalse() {
+      CollectionEntity entity =
+          CollectionEntity.builder()
+              .id(1L)
+              .slug("protected-gallery")
+              .galleryPassword("secret123")
+              .build();
+      when(collectionRepository.findBySlug("protected-gallery")).thenReturn(Optional.of(entity));
+      jakarta.servlet.http.HttpServletRequest request =
+          org.mockito.Mockito.mock(jakarta.servlet.http.HttpServletRequest.class);
+      when(request.getCookies()).thenReturn(null);
+      when(clientGalleryAuthService.validateAccessToken(
+              eq("protected-gallery"), org.mockito.Mockito.any()))
+          .thenReturn(false);
+      when(clientGalleryAuthService.passwordFingerprint("secret123")).thenReturn("FP");
+      when(clientGalleryAuthService.validatePasswordAccessToken(
+              eq("secret123"), org.mockito.Mockito.any()))
+          .thenReturn(false);
+
+      assertThat(service.isGalleryAccessAuthorized("protected-gallery", request)).isFalse();
     }
   }
 }

--- a/src/test/java/edens/zac/portfolio/backend/services/SyntheticCollectionResolverTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/SyntheticCollectionResolverTest.java
@@ -48,7 +48,7 @@ class SyntheticCollectionResolverTest {
 
   @Test
   void resolveAllCollectionsInDevAllowsAllVisibilitiesAndReturnsChildrenAsContent() {
-    when(collectionRepository.findOrderedByVisibilityIn(
+    when(collectionRepository.findNonEmptyOrderedByVisibilityIn(
             eq(
                 List.of(
                     CollectionVisibility.LISTED,
@@ -79,7 +79,7 @@ class SyntheticCollectionResolverTest {
 
   @Test
   void resolveAllBlogsInProdFiltersToBlogTypeAndListedOnly() {
-    when(collectionRepository.findOrderedByVisibilityIn(
+    when(collectionRepository.findNonEmptyOrderedByVisibilityIn(
             eq(List.of(CollectionVisibility.LISTED)), eq(CollectionType.BLOG)))
         .thenReturn(List.of(new CollectionEntity()));
     when(collectionProcessingUtil.batchConvertToBasicModels(any()))
@@ -93,6 +93,62 @@ class SyntheticCollectionResolverTest {
     assertThat(out.getTitle()).isEqualTo("Blogs");
     assertThat(out.getType()).isEqualTo(CollectionType.PARENT);
     assertThat(out.getContent()).hasSize(1);
+  }
+
+  @Test
+  void resolveAllClientGalleriesUsesParentInclusiveQueryAndMixesParentAndGalleryTiles() {
+    // Standalone gallery + a wedding PARENT that has CLIENT_GALLERY children — the inclusive
+    // repo query returns both rows and the resolver must pass each through unchanged so PARENT
+    // tiles render alongside CLIENT_GALLERY tiles on the listing.
+    when(collectionRepository.findClientGalleriesAndQualifyingParents(
+            eq(List.of(CollectionVisibility.LISTED))))
+        .thenReturn(List.of(new CollectionEntity(), new CollectionEntity()));
+    when(collectionProcessingUtil.batchConvertToBasicModels(any()))
+        .thenReturn(
+            List.of(
+                CollectionModel.builder()
+                    .id(50L)
+                    .slug("smith-wedding")
+                    .title("Smith Wedding")
+                    .type(CollectionType.PARENT)
+                    .build(),
+                CollectionModel.builder()
+                    .id(51L)
+                    .slug("jones-engagement")
+                    .title("Jones Engagement")
+                    .type(CollectionType.CLIENT_GALLERY)
+                    .build()));
+
+    CollectionModel out = resolver.resolve("all-client-galleries", false);
+
+    assertThat(out.getSlug()).isEqualTo("all-client-galleries");
+    assertThat(out.getTitle()).isEqualTo("Client Galleries");
+    assertThat(out.getType()).isEqualTo(CollectionType.PARENT);
+    assertThat(out.getContent()).hasSize(2);
+
+    ContentModels.Collection parentTile = (ContentModels.Collection) out.getContent().get(0);
+    assertThat(parentTile.slug()).isEqualTo("smith-wedding");
+    assertThat(parentTile.collectionType()).isEqualTo(CollectionType.PARENT);
+
+    ContentModels.Collection galleryTile = (ContentModels.Collection) out.getContent().get(1);
+    assertThat(galleryTile.slug()).isEqualTo("jones-engagement");
+    assertThat(galleryTile.collectionType()).isEqualTo(CollectionType.CLIENT_GALLERY);
+  }
+
+  @Test
+  void resolveAllClientGalleriesInDevPassesAllVisibilitiesToInclusiveQuery() {
+    when(collectionRepository.findClientGalleriesAndQualifyingParents(
+            eq(
+                List.of(
+                    CollectionVisibility.LISTED,
+                    CollectionVisibility.UNLISTED,
+                    CollectionVisibility.HIDDEN))))
+        .thenReturn(List.of());
+    when(collectionProcessingUtil.batchConvertToBasicModels(any())).thenReturn(List.of());
+
+    CollectionModel out = resolver.resolve("all-client-galleries", true);
+
+    assertThat(out.getContent()).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
PARENT password gating
- Shared password-fingerprint cookie path: PARENT and propagated CLIENT_GALLERY children unlock each other without re-prompting since they share a password (GalleryAccessCookies.hasValidAccess, ClientGalleryAuthService.passwordFingerprint / validatePasswordAccessToken)
- CollectionService.isGalleryAccessAuthorized centralizes the read-side auth check and routes PARENT through the same gate as CLIENT_GALLERY

Listing cleanup
- /all-collections, /all-blogs, /all-portfolios, /all-art-galleries, /all-misc no longer surface empty collections — new findNonEmptyOrderedByVisibilityIn with EXISTS on collection_content (cc.visible = true, mirroring findReferencedCollectionsByParentId). findByTypeForAdminCovers keeps the original method since covers legitimately need empty-but-cover-set collections
- /all-client-galleries subquery now also gates cc.visible = true so PARENTs whose only matching CLIENT_GALLERY membership has been soft-removed no longer qualify
- Pin mixed-PARENT visibility rule: PARENT with >=1 CLIENT_GALLERY child applies "client gallery context" to all children — UNLISTED siblings of any type kept, only HIDDEN dropped (parentOfMixedClientGalleryAndPortfolio in CollectionServiceTest$ParentTypeCollections)

Stable Page DTO
- 3 endpoints (getAllImages, getAllCollectionsOrderedByDate, getAllCollections) return PagedResponse<T> instead of Page<>. Silences PageModule WarningLoggingModifier ("no guarantee about the stability of the resulting JSON structure"). Wire shape unchanged — keys content/totalElements/totalPages/number/last match what frontend already reads. CollectionControllerProdTest pins via \$.pageable.doesNotExist()

AdminHomeService cover picker now uses findByTypeForAdminCovers for UNLISTED-acceptable cover candidates.