### PR TITLE
feat(content-gif): mirror image rating + collections + admin CRUD on …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,10 @@ AWS_ACCESS_KEY_ID=your_aws_access_key_here
 AWS_SECRET_ACCESS_KEY=your_aws_secret_key_here
 AWS_PORTFOLIO_S3_BUCKET=your_s3_bucket_name
 AWS_CLOUDFRONT_DOMAIN=your_cloudfront_domain.cloudfront.net
+# CloudFront distribution id (e.g. E1ABCDEFGHIJKL). Required for cache invalidation
+# on image delete. If unset, deletes still succeed but stale-cached images may persist
+# until CloudFront's TTL expires.
+AWS_CLOUDFRONT_DISTRIBUTION_ID=
 
 # Shared secret between the Next.js BFF proxy and the Spring backend.
 # For production, generate with: openssl rand -hex 32

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,10 @@ RUN mvn clean package -DskipTests
 # Use an official Java runtime as a parent image
 FROM --platform=linux/amd64 eclipse-temurin:23-jre-alpine
 
+# ffmpeg is required at runtime by ImageProcessingService.processGifContent
+# for first-frame thumbnail extraction on MP4/MOV uploads.
+RUN apk add --no-cache ffmpeg
+
 # Set the working directory in the container
 WORKDIR /app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       AWS_REGION: us-west-2
       AWS_PORTFOLIO_S3_BUCKET: ${AWS_PORTFOLIO_S3_BUCKET}
       AWS_CLOUDFRONT_DOMAIN: ${AWS_CLOUDFRONT_DOMAIN}
+      AWS_CLOUDFRONT_DISTRIBUTION_ID: ${AWS_CLOUDFRONT_DISTRIBUTION_ID:-}
 
       # Shared secret for BFF proxy authentication
       INTERNAL_API_SECRET: ${INTERNAL_API_SECRET:-dev-internal-secret}

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,11 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
+            <artifactId>cloudfront</artifactId>
+            <version>2.29.52</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
             <artifactId>sesv2</artifactId>
             <version>2.29.52</version>
         </dependency>

--- a/src/main/java/edens/zac/portfolio/backend/config/S3Config.java
+++ b/src/main/java/edens/zac/portfolio/backend/config/S3Config.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.cloudfront.CloudFrontClient;
 import software.amazon.awssdk.services.s3.S3Client;
 
 @Slf4j
@@ -45,5 +46,15 @@ public class S3Config {
       log.error("Failed to create S3Client", e);
       throw e;
     }
+  }
+
+  @Bean(destroyMethod = "close")
+  public CloudFrontClient cloudFrontClient() {
+    log.info("Creating CloudFrontClient");
+    AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKeyId, secretAccessKey);
+    return CloudFrontClient.builder()
+        .credentialsProvider(StaticCredentialsProvider.create(credentials))
+        .region(Region.AWS_GLOBAL)
+        .build();
   }
 }

--- a/src/main/java/edens/zac/portfolio/backend/controller/dev/AdminController.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/dev/AdminController.java
@@ -345,6 +345,31 @@ class AdminController {
     return ResponseEntity.status(HttpStatus.CREATED).body(gif);
   }
 
+  /**
+   * Patch an existing GIF/MP4 content block. Only the fields present on the request are applied.
+   */
+  @PatchMapping("/content/gifs/{id}")
+  public ResponseEntity<ContentModels.Gif> updateGif(
+      @PathVariable Long id, @RequestBody @Valid ContentRequests.UpdateGif request) {
+    ContentModels.Gif gif = contentService.updateGif(id, request);
+    log.info("Updated GIF {}", id);
+    return ResponseEntity.ok(gif);
+  }
+
+  /**
+   * Delete a GIF/MP4 content block. Cleans up the S3 objects (full media + thumbnail) and the
+   * content_gif row + base content row + tag join entries.
+   */
+  @DeleteMapping("/content/gifs/{id}")
+  public ResponseEntity<Map<String, Object>> deleteGif(@PathVariable Long id) {
+    Long deletedId = contentService.deleteGif(id);
+    if (deletedId == null) {
+      throw new IllegalArgumentException("GIF not found: " + id);
+    }
+    log.info("Deleted GIF {}", deletedId);
+    return ResponseEntity.ok(Map.of("deletedId", deletedId));
+  }
+
   /** Create a new collection and upload images to it in one request. */
   @PostMapping(
       value = "/content/images/create-collection",

--- a/src/main/java/edens/zac/portfolio/backend/dao/ContentRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/ContentRepository.java
@@ -127,6 +127,7 @@ public class ContentRepository extends BaseDao {
               .height(getInteger(rs, "height"))
               .author(getString(rs, "author"))
               .createDate(getString(rs, "create_date"))
+              .rating(getInteger(rs, "rating"))
               .createdAt(getLocalDateTime(rs, "created_at"))
               .updatedAt(getLocalDateTime(rs, "updated_at"))
               .tags(new HashSet<>())
@@ -179,7 +180,7 @@ public class ContentRepository extends BaseDao {
       """
       SELECT c.id, c.content_type, c.created_at, c.updated_at,
              cg.title, cg.gif_url, cg.thumbnail_url, cg.width, cg.height,
-             cg.author, cg.create_date
+             cg.author, cg.create_date, cg.rating
       FROM content c
       JOIN content_gif cg ON c.id = cg.id
       """;
@@ -849,8 +850,8 @@ public class ContentRepository extends BaseDao {
 
       String gifSql =
           """
-          INSERT INTO content_gif (id, title, gif_url, thumbnail_url, width, height, author, create_date)
-          VALUES (:id, :title, :gifUrl, :thumbnailUrl, :width, :height, :author, :createDate)
+          INSERT INTO content_gif (id, title, gif_url, thumbnail_url, width, height, author, create_date, rating)
+          VALUES (:id, :title, :gifUrl, :thumbnailUrl, :width, :height, :author, :createDate, :rating)
           """;
 
       MapSqlParameterSource gifParams =
@@ -862,7 +863,8 @@ public class ContentRepository extends BaseDao {
               .addValue("width", entity.getWidth())
               .addValue("height", entity.getHeight())
               .addValue("author", entity.getAuthor())
-              .addValue("createDate", entity.getCreateDate());
+              .addValue("createDate", entity.getCreateDate())
+              .addValue("rating", entity.getRating());
 
       update(gifSql, gifParams);
 
@@ -890,7 +892,8 @@ public class ContentRepository extends BaseDao {
           """
           UPDATE content_gif
           SET title = :title, gif_url = :gifUrl, thumbnail_url = :thumbnailUrl,
-              width = :width, height = :height, author = :author, create_date = :createDate
+              width = :width, height = :height, author = :author, create_date = :createDate,
+              rating = :rating
           WHERE id = :id
           """;
 
@@ -903,7 +906,8 @@ public class ContentRepository extends BaseDao {
               .addValue("width", entity.getWidth())
               .addValue("height", entity.getHeight())
               .addValue("author", entity.getAuthor())
-              .addValue("createDate", entity.getCreateDate());
+              .addValue("createDate", entity.getCreateDate())
+              .addValue("rating", entity.getRating());
 
       update(gifSql, gifParams);
 

--- a/src/main/java/edens/zac/portfolio/backend/entity/ContentGifEntity.java
+++ b/src/main/java/edens/zac/portfolio/backend/entity/ContentGifEntity.java
@@ -47,6 +47,15 @@ public class ContentGifEntity extends ContentEntity {
   /** Column: create_date (VARCHAR) */
   private String createDate;
 
+  /**
+   * Column: rating (INT, 0-5 or NULL).
+   *
+   * <p>Drives the layout slot-width algorithm: a horizontal GIF with rating &gt;= 4 takes the full
+   * row, rating 3 takes half a row, lower ratings take a single slot. New uploads default to 4 so
+   * animated content reads as feature media; admins can downgrade later.
+   */
+  private Integer rating;
+
   /** Relationship: Many-to-many with TagEntity (via content_tags table) */
   @Builder.Default private Set<TagEntity> tags = new HashSet<>();
 

--- a/src/main/java/edens/zac/portfolio/backend/model/ContentModels.java
+++ b/src/main/java/edens/zac/portfolio/backend/model/ContentModels.java
@@ -117,8 +117,34 @@ public final class ContentModels {
       Integer height,
       String author,
       String createDate,
-      List<Records.Tag> tags)
-      implements ContentModel {}
+      Integer rating,
+      List<Records.Tag> tags,
+      List<Records.ChildCollection> collections)
+      implements ContentModel {
+
+    /** Returns a new Gif with the collections field replaced (records are immutable). */
+    public Gif withCollections(List<Records.ChildCollection> collections) {
+      return new Gif(
+          id,
+          contentType,
+          title,
+          description,
+          imageUrl,
+          orderIndex,
+          visible,
+          createdAt,
+          updatedAt,
+          gifUrl,
+          thumbnailUrl,
+          width,
+          height,
+          author,
+          createDate,
+          rating,
+          tags,
+          collections);
+    }
+  }
 
   /**
    * Collection reference content block. The {@code id} field is the content-table ID used for

--- a/src/main/java/edens/zac/portfolio/backend/model/ContentRequests.java
+++ b/src/main/java/edens/zac/portfolio/backend/model/ContentRequests.java
@@ -2,6 +2,8 @@ package edens.zac.portfolio.backend.model;
 
 import edens.zac.portfolio.backend.types.FilmFormat;
 import edens.zac.portfolio.backend.types.TextFormType;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
@@ -44,4 +46,18 @@ public final class ContentRequests {
       String description,
       @NotBlank(message = "Text content is required") String textContent,
       TextFormType formType) {}
+
+  /**
+   * Request for updating an existing GIF/MP4 content block. All fields optional — only non-null
+   * fields are applied. Mirrors the slice of {@code ContentImageUpdateRequest} that makes sense for
+   * animated content (no EXIF/equipment fields).
+   *
+   * <p>{@code tags} and {@code collections} use the prev/newValue/remove pattern from {@link
+   * CollectionRequests} so a single request can add, remove, and re-order memberships in one shot.
+   */
+  public record UpdateGif(
+      @Size(max = 200, message = "Title must be 200 characters or less") String title,
+      @Min(value = 0, message = "Rating must be between 0 and 5") @Max(value = 5, message = "Rating must be between 0 and 5") Integer rating,
+      CollectionRequests.TagUpdate tags,
+      CollectionRequests.CollectionUpdate collections) {}
 }

--- a/src/main/java/edens/zac/portfolio/backend/services/CollectionProcessingUtil.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/CollectionProcessingUtil.java
@@ -374,24 +374,32 @@ public class CollectionProcessingUtil {
                     Collectors.toMap(
                         ContentImageEntity::getId, ContentImageEntity::getImageUrlWeb));
 
-    // Populate collections on image content (records are immutable -- use withCollections)
+    // Populate collections on image AND GIF content (records are immutable — use withCollections).
+    // GIFs participate in many-to-many collection membership the same way images do.
     List<ContentModel> contents =
         model.getContent().stream()
             .map(
                 content -> {
+                  Long contentId = content.id();
+                  List<CollectionContentEntity> contentCollections =
+                      collectionsByContentId.getOrDefault(contentId, Collections.emptyList());
+                  if (contentCollections.isEmpty()) {
+                    return content;
+                  }
+                  List<Records.ChildCollection> childCollections =
+                      contentCollections.stream()
+                          .map(
+                              joinEntry ->
+                                  convertToChildCollection(
+                                      joinEntry, collectionsById, coverImageUrlsById))
+                          .filter(Objects::nonNull)
+                          .collect(Collectors.toList());
+
                   if (content instanceof ContentModels.Image imageModel) {
-                    Long contentId = content.id();
-                    List<CollectionContentEntity> contentCollections =
-                        collectionsByContentId.getOrDefault(contentId, Collections.emptyList());
-                    List<Records.ChildCollection> childCollections =
-                        contentCollections.stream()
-                            .map(
-                                joinEntry ->
-                                    convertToChildCollection(
-                                        joinEntry, collectionsById, coverImageUrlsById))
-                            .filter(Objects::nonNull)
-                            .collect(Collectors.toList());
                     return (ContentModel) imageModel.withCollections(childCollections);
+                  }
+                  if (content instanceof ContentModels.Gif gifModel) {
+                    return (ContentModel) gifModel.withCollections(childCollections);
                   }
                   return content;
                 })

--- a/src/main/java/edens/zac/portfolio/backend/services/ContentModelConverter.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/ContentModelConverter.java
@@ -437,7 +437,9 @@ class ContentModelConverter {
         entity.getHeight(),
         entity.getAuthor(),
         entity.getCreateDate(),
-        convertTagsToModels(tags));
+        entity.getRating(),
+        convertTagsToModels(tags),
+        new ArrayList<>());
   }
 
   /**

--- a/src/main/java/edens/zac/portfolio/backend/services/ContentMutationUtil.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/ContentMutationUtil.java
@@ -47,14 +47,15 @@ public class ContentMutationUtil {
   // =============================================================================
 
   /**
-   * Handle collection visibility and orderIndex updates for an image. Updates the 'visible' flag
-   * and 'orderIndex' for the content entry in the current collection.
+   * Handle collection visibility and orderIndex updates for a content block. Updates the 'visible'
+   * flag and 'orderIndex' for the content entry in each referenced collection. Works for any
+   * content type (image, gif, text, ...) — only the polymorphic content id is needed.
    *
-   * @param image The image entity being updated
+   * @param contentId The content id being updated
    * @param collectionUpdates List of collection updates containing visibility and orderIndex
    */
   public void handleContentChildCollectionUpdates(
-      ContentImageEntity image, List<Records.ChildCollection> collectionUpdates) {
+      Long contentId, List<Records.ChildCollection> collectionUpdates) {
     if (collectionUpdates == null || collectionUpdates.isEmpty()) {
       return;
     }
@@ -66,12 +67,12 @@ public class ContentMutationUtil {
         Boolean visible = collectionUpdate.visible();
 
         Optional<CollectionContentEntity> joinEntryOpt =
-            collectionRepository.findContentByCollectionIdAndContentId(collectionId, image.getId());
+            collectionRepository.findContentByCollectionIdAndContentId(collectionId, contentId);
 
         if (joinEntryOpt.isEmpty()) {
           log.warn(
               "No join table entry found for content {} in collection {}. Skipping update.",
-              image.getId(),
+              contentId,
               collectionId);
           continue;
         }
@@ -82,8 +83,8 @@ public class ContentMutationUtil {
         if (orderIndex != null) {
           collectionRepository.updateContentOrderIndex(joinEntry.getId(), orderIndex);
           log.info(
-              "Updated orderIndex for image {} in collection {} to {}",
-              image.getId(),
+              "Updated orderIndex for content {} in collection {} to {}",
+              contentId,
               collectionId,
               orderIndex);
           updated = true;
@@ -92,8 +93,8 @@ public class ContentMutationUtil {
         if (visible != null) {
           collectionRepository.updateContentVisible(joinEntry.getId(), visible);
           log.info(
-              "Updated visibility for image {} in collection {} to {}",
-              image.getId(),
+              "Updated visibility for content {} in collection {} to {}",
+              contentId,
               collectionId,
               visible);
           updated = true;
@@ -101,8 +102,8 @@ public class ContentMutationUtil {
 
         if (updated) {
           log.debug(
-              "Updated collection membership for image {} in collection {}",
-              image.getId(),
+              "Updated collection membership for content {} in collection {}",
+              contentId,
               collectionId);
         }
       }
@@ -110,11 +111,19 @@ public class ContentMutationUtil {
   }
 
   /**
-   * Add content (image) to new collections with specified visibility and orderIndex. Creates join
-   * table entries for the content in the specified collections.
+   * Convenience overload for callers holding a {@link ContentImageEntity}. Kept for back-compat —
+   * dispatches to the contentId-based variant.
    */
-  public void handleAddToCollections(
-      ContentImageEntity image, List<Records.ChildCollection> collections) {
+  public void handleContentChildCollectionUpdates(
+      ContentImageEntity image, List<Records.ChildCollection> collectionUpdates) {
+    handleContentChildCollectionUpdates(image.getId(), collectionUpdates);
+  }
+
+  /**
+   * Add a content block to new collections with specified visibility and orderIndex. Creates join
+   * table entries for the content in the specified collections. Works for any content type.
+   */
+  public void handleAddToCollections(Long contentId, List<Records.ChildCollection> collections) {
     for (Records.ChildCollection childCollection : collections) {
       if (childCollection.collectionId() == null) {
         log.warn("Skipping collection addition: collectionId is null");
@@ -131,17 +140,17 @@ public class ContentMutationUtil {
 
       if (collection.getType().isParentType()) {
         throw new IllegalArgumentException(
-            "Cannot add images to parent-type collection: " + collection.getTitle());
+            "Cannot add content to parent-type collection: " + collection.getTitle());
       }
 
       Optional<CollectionContentEntity> existingOpt =
           collectionRepository.findContentByCollectionIdAndContentId(
-              childCollection.collectionId(), image.getId());
+              childCollection.collectionId(), contentId);
 
       if (existingOpt.isPresent()) {
         log.warn(
-            "Image {} is already in collection {}. Skipping duplicate add.",
-            image.getId(),
+            "Content {} is already in collection {}. Skipping duplicate add.",
+            contentId,
             childCollection.collectionId());
         continue;
       }
@@ -156,18 +165,26 @@ public class ContentMutationUtil {
       CollectionContentEntity joinEntry =
           CollectionContentEntity.builder()
               .collectionId(childCollection.collectionId())
-              .contentId(image.getId())
+              .contentId(contentId)
               .orderIndex(orderIndex)
               .visible(visible)
               .build();
       collectionRepository.saveContent(joinEntry);
       log.info(
-          "Added image {} to collection {} at orderIndex {} with visible={}",
-          image.getId(),
+          "Added content {} to collection {} at orderIndex {} with visible={}",
+          contentId,
           childCollection.collectionId(),
           orderIndex,
           visible);
     }
+  }
+
+  /**
+   * Convenience overload for callers holding a {@link ContentImageEntity}. Kept for back-compat.
+   */
+  public void handleAddToCollections(
+      ContentImageEntity image, List<Records.ChildCollection> collections) {
+    handleAddToCollections(image.getId(), collections);
   }
 
   /** Returns the next available orderIndex for a collection (max + 1, or 0 if empty). */

--- a/src/main/java/edens/zac/portfolio/backend/services/ContentService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/ContentService.java
@@ -501,6 +501,97 @@ public class ContentService {
     return castContentModel(contentModel, ContentModels.Gif.class);
   }
 
+  /**
+   * Delete a GIF/MP4 content block — removes the join-table linkage, the S3 objects (full media +
+   * thumbnail), and the entity rows. Mirrors {@link #deleteImages} for the single-id case.
+   *
+   * @return id of the deleted gif, or null if no entity was found
+   */
+  @Transactional
+  public Long deleteGif(Long id) {
+    ContentGifEntity gif = contentRepository.findGifById(id).orElse(null);
+    if (gif == null) {
+      log.warn("Attempted to delete missing GIF: {}", id);
+      return null;
+    }
+    imageProcessingService.deleteGifFromS3(gif);
+    contentRepository.deleteGifById(id);
+    log.info("Deleted GIF {}", id);
+    return id;
+  }
+
+  /**
+   * Patch a GIF/MP4 content block. Only non-null fields on the request are applied. Today's
+   * surface: title, rating, tags, and collection memberships (prev/newValue/remove pattern). The
+   * latter two reuse the same mutation utilities and join-table semantics that drive image updates
+   * — see {@link ContentMutationUtil#handleAddToCollections(Long, java.util.List)} and {@link
+   * ContentMutationUtil#handleContentChildCollectionUpdates(Long, java.util.List)}.
+   *
+   * <p>EXIF/equipment fields (camera, lens, ISO, etc.) intentionally have no analog for GIF — the
+   * frontend modal greys them out for animated content.
+   */
+  @Transactional
+  public ContentModels.Gif updateGif(Long id, ContentRequests.UpdateGif request) {
+    ContentGifEntity gif =
+        contentRepository
+            .findGifById(id)
+            .orElseThrow(() -> new ResourceNotFoundException("GIF not found: " + id));
+
+    if (request.title() != null) {
+      gif.setTitle(request.title());
+    }
+    if (request.rating() != null) {
+      gif.setRating(request.rating());
+    }
+
+    // Tags: reuse the optimized image-tag helper — it only needs the content id + current tag
+    // list + the prev/newValue/remove update payload. ContentGifEntity also exposes setTags.
+    if (request.tags() != null) {
+      List<TagEntity> currentTagEntities = tagRepository.findContentTags(gif.getId());
+      Set<TagEntity> currentTags = new HashSet<>(currentTagEntities);
+      Set<TagEntity> newlyCreatedTags = new HashSet<>();
+      Set<TagEntity> updatedTags =
+          contentMutationUtil.updateTags(currentTags, request.tags(), newlyCreatedTags);
+      gif.setTags(updatedTags);
+      List<Long> updatedTagIds =
+          updatedTags.stream()
+              .map(TagEntity::getId)
+              .filter(Objects::nonNull)
+              .distinct()
+              .collect(Collectors.toList());
+      tagRepository.saveContentTags(gif.getId(), updatedTagIds);
+    }
+
+    ContentGifEntity saved = contentRepository.saveGif(gif);
+    log.info("Updated GIF {} (title={}, rating={})", id, saved.getTitle(), saved.getRating());
+
+    // Collections: prev/newValue/remove pattern, same as images.
+    if (request.collections() != null) {
+      CollectionRequests.CollectionUpdate cu = request.collections();
+      if (cu.remove() != null && !cu.remove().isEmpty()) {
+        for (Long collectionIdToRemove : cu.remove()) {
+          collectionRepository.removeContentFromCollection(collectionIdToRemove, List.of(id));
+          log.info("Removed GIF {} from collection {}", id, collectionIdToRemove);
+        }
+      }
+      if (cu.prev() != null && !cu.prev().isEmpty()) {
+        contentMutationUtil.handleContentChildCollectionUpdates(id, cu.prev());
+      }
+      if (cu.newValue() != null && !cu.newValue().isEmpty()) {
+        contentMutationUtil.handleAddToCollections(id, cu.newValue());
+      }
+    }
+
+    ContentModel model =
+        contentModelConverter.convertEntityToModel(
+            CollectionContentEntity.builder()
+                .contentId(saved.getId())
+                .orderIndex(null)
+                .visible(null)
+                .build());
+    return castContentModel(model, ContentModels.Gif.class);
+  }
+
   // ---------------------------------------------------------------------------
   //  Read helpers for download endpoints
   // ---------------------------------------------------------------------------

--- a/src/main/java/edens/zac/portfolio/backend/services/ImageProcessingService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/ImageProcessingService.java
@@ -21,6 +21,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +38,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.cloudfront.CloudFrontClient;
+import software.amazon.awssdk.services.cloudfront.model.CreateInvalidationResponse;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
@@ -49,6 +52,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 public class ImageProcessingService {
 
   private final S3Client s3Client;
+  private final CloudFrontClient cloudFrontClient;
   private final ContentRepository contentRepository;
   private final EquipmentRepository equipmentRepository;
   private final LocationRepository locationRepository;
@@ -56,17 +60,21 @@ public class ImageProcessingService {
   private final ContentValidator contentValidator;
   private final String bucketName;
   private final String cloudfrontDomain;
+  private final String cloudFrontDistributionId;
 
   ImageProcessingService(
       S3Client s3Client,
+      CloudFrontClient cloudFrontClient,
       ContentRepository contentRepository,
       EquipmentRepository equipmentRepository,
       LocationRepository locationRepository,
       ImageMetadataExtractor imageMetadataExtractor,
       ContentValidator contentValidator,
       @Value("${aws.portfolio.s3.bucket}") String bucketName,
-      @Value("${cloudfront.domain}") String cloudfrontDomain) {
+      @Value("${cloudfront.domain}") String cloudfrontDomain,
+      @Value("${cloudfront.distribution-id:}") String cloudFrontDistributionId) {
     this.s3Client = s3Client;
+    this.cloudFrontClient = cloudFrontClient;
     this.contentRepository = contentRepository;
     this.equipmentRepository = equipmentRepository;
     this.locationRepository = locationRepository;
@@ -74,6 +82,7 @@ public class ImageProcessingService {
     this.contentValidator = contentValidator;
     this.bucketName = bucketName;
     this.cloudfrontDomain = cloudfrontDomain;
+    this.cloudFrontDistributionId = cloudFrontDistributionId;
   }
 
   // S3 path constants for content type hierarchy:
@@ -527,7 +536,9 @@ public class ImageProcessingService {
         log.warn("Could not extract first frame from: {}", originalFilename);
       }
 
-      // Build and save entity
+      // Build and save entity. Default rating to 4 so a new GIF/MP4 reads as
+      // feature media in the row grid — horizontal gets a full row, vertical
+      // gets half. Admins can downgrade later.
       ContentGifEntity entity =
           ContentGifEntity.builder()
               .contentType(ContentType.GIF)
@@ -538,6 +549,7 @@ public class ImageProcessingService {
               .height(height)
               .author(ImageMetadataExtractor.DEFAULT.AUTHOR)
               .createDate(now.toString())
+              .rating(4)
               .build();
 
       return contentRepository.saveGif(entity);
@@ -616,29 +628,91 @@ public class ImageProcessingService {
   }
 
   /**
-   * Delete an image and its variants from S3.
+   * Delete an image and its variants from S3, then invalidate the CloudFront cache for the same
+   * paths so re-uploads at identical S3 keys (which is the norm — keys are deterministic from
+   * filename/year/month) are served fresh instead of from CDN cache.
    *
    * @param image The ContentImageEntity containing S3 URLs to delete
    */
   public void deleteImageFromS3(ContentImageEntity image) {
-    deleteS3ObjectByUrl(image.getImageUrlWeb());
-    deleteS3ObjectByUrl(image.getImageUrlOriginal());
-    deleteS3ObjectByUrl(image.getImageUrlRaw());
+    List<String> deletedKeys = new ArrayList<>();
+    String webKey = deleteS3ObjectByUrl(image.getImageUrlWeb());
+    if (webKey != null) deletedKeys.add(webKey);
+    String originalKey = deleteS3ObjectByUrl(image.getImageUrlOriginal());
+    if (originalKey != null) deletedKeys.add(originalKey);
+    String rawKey = deleteS3ObjectByUrl(image.getImageUrlRaw());
+    if (rawKey != null) deletedKeys.add(rawKey);
+    invalidateCloudFrontPaths(deletedKeys);
   }
 
-  /** Delete a single S3 object by its CloudFront URL. Logs but does not throw on failure. */
-  private void deleteS3ObjectByUrl(String url) {
+  /**
+   * Delete S3 objects backing a GIF/MP4 entity: the full-resolution media plus the WebP first-frame
+   * thumbnail. Mirrors {@link #deleteImageFromS3} — failures are logged, not thrown, and we still
+   * issue a single CloudFront invalidation for the keys we attempted.
+   *
+   * @param gif The ContentGifEntity containing S3 URLs to delete
+   */
+  public void deleteGifFromS3(ContentGifEntity gif) {
+    List<String> deletedKeys = new ArrayList<>();
+    String gifKey = deleteS3ObjectByUrl(gif.getGifUrl());
+    if (gifKey != null) deletedKeys.add(gifKey);
+    String thumbKey = deleteS3ObjectByUrl(gif.getThumbnailUrl());
+    if (thumbKey != null) deletedKeys.add(thumbKey);
+    invalidateCloudFrontPaths(deletedKeys);
+  }
+
+  /**
+   * Delete a single S3 object by its CloudFront URL. Logs but does not throw on failure.
+   *
+   * @return the S3 key that was targeted (whether or not the delete succeeded), or null if no
+   *     attempt was made (url was null or did not match the configured CloudFront domain).
+   */
+  private String deleteS3ObjectByUrl(String url) {
     if (url == null) {
+      return null;
+    }
+    String s3Key = extractS3KeyFromUrl(url);
+    if (s3Key == null) {
+      return null;
+    }
+    try {
+      log.trace("Deleting from S3: {}", s3Key);
+      s3Client.deleteObject(builder -> builder.bucket(bucketName).key(s3Key));
+    } catch (Exception e) {
+      log.error("Failed to delete S3 object {}: {}", url, e.getMessage());
+    }
+    return s3Key;
+  }
+
+  /**
+   * Issue a single CloudFront invalidation covering the given S3 keys. Skipped silently when no
+   * keys are provided or when {@code cloudfront.distribution-id} is unset (deletes still work, the
+   * CDN just keeps serving stale-cached bytes until its own TTL expires).
+   */
+  private void invalidateCloudFrontPaths(List<String> s3Keys) {
+    if (s3Keys.isEmpty()) {
+      return;
+    }
+    if (cloudFrontDistributionId == null || cloudFrontDistributionId.isBlank()) {
+      log.debug("Skipping CloudFront invalidation: cloudfront.distribution-id is not configured");
       return;
     }
     try {
-      String s3Key = extractS3KeyFromUrl(url);
-      if (s3Key != null) {
-        log.trace("Deleting from S3: {}", s3Key);
-        s3Client.deleteObject(builder -> builder.bucket(bucketName).key(s3Key));
-      }
+      List<String> paths = s3Keys.stream().map(k -> "/" + k).toList();
+      CreateInvalidationResponse res =
+          cloudFrontClient.createInvalidation(
+              req ->
+                  req.distributionId(cloudFrontDistributionId)
+                      .invalidationBatch(
+                          b ->
+                              b.paths(p -> p.quantity(paths.size()).items(paths))
+                                  .callerReference(UUID.randomUUID().toString())));
+      log.info(
+          "Created CloudFront invalidation {} for {} path(s)",
+          res.invalidation().id(),
+          paths.size());
     } catch (Exception e) {
-      log.error("Failed to delete S3 object {}: {}", url, e.getMessage());
+      log.error("Failed to invalidate CloudFront paths {}: {}", s3Keys, e.getMessage());
     }
   }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -42,6 +42,7 @@ aws.secret.access.key=${AWS_SECRET_ACCESS_KEY}
 aws.s3.region=us-west-2
 aws.portfolio.s3.bucket=${AWS_PORTFOLIO_S3_BUCKET}
 cloudfront.domain=${AWS_CLOUDFRONT_DOMAIN}
+cloudfront.distribution-id=${AWS_CLOUDFRONT_DISTRIBUTION_ID:}
 
 #----------------------------------------#
 # Internal API Secret (shared with Next.js proxy)

--- a/src/main/resources/db/migration/V24__add_rating_to_content_gif.sql
+++ b/src/main/resources/db/migration/V24__add_rating_to_content_gif.sql
@@ -1,0 +1,18 @@
+-- V24: Add rating column to content_gif (mirrors content_image.rating).
+-- Range 0-5 (NULL means unrated). Used by the layout algorithm to size GIF/MP4
+-- content blocks in the row grid — without a rating, GIFs fall back to a
+-- 1-slot wrapper, which leaves empty row space around them.
+--
+-- Backfill existing rows to 4 so prior uploads render as feature content
+-- (full row for horizontal, half row for vertical) by default.
+
+ALTER TABLE content_gif
+    ADD COLUMN rating INT;
+
+UPDATE content_gif SET rating = 4 WHERE rating IS NULL;
+
+ALTER TABLE content_gif
+    ADD CONSTRAINT content_gif_rating_chk
+    CHECK (rating IS NULL OR (rating >= 0 AND rating <= 5));
+
+CREATE INDEX idx_content_gif_rating ON content_gif(rating);

--- a/src/test/java/edens/zac/portfolio/backend/services/ImageProcessingServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/ImageProcessingServiceTest.java
@@ -22,12 +22,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.cloudfront.CloudFrontClient;
 import software.amazon.awssdk.services.s3.S3Client;
 
 @ExtendWith(MockitoExtension.class)
 class ImageProcessingServiceTest {
 
   @Mock private S3Client s3Client;
+  @Mock private CloudFrontClient cloudFrontClient;
   @Mock private ContentRepository contentRepository;
   @Mock private EquipmentRepository equipmentRepository;
   @Mock private LocationRepository locationRepository;
@@ -38,19 +40,22 @@ class ImageProcessingServiceTest {
 
   private static final String BUCKET_NAME = "test-bucket";
   private static final String CLOUDFRONT_DOMAIN = "test.cloudfront.net";
+  private static final String CLOUDFRONT_DISTRIBUTION_ID = "";
 
   @BeforeEach
   void setUp() {
     imageProcessingService =
         new ImageProcessingService(
             s3Client,
+            cloudFrontClient,
             contentRepository,
             equipmentRepository,
             locationRepository,
             imageMetadataExtractor,
             contentValidator,
             BUCKET_NAME,
-            CLOUDFRONT_DOMAIN);
+            CLOUDFRONT_DOMAIN,
+            CLOUDFRONT_DISTRIBUTION_ID);
   }
 
   // ============================================================================


### PR DESCRIPTION
…GIFs

- V24 migration: content_gif.rating INT (0-5), backfill existing rows to 4
- Dockerfile: ffmpeg installed in alpine runtime for animated content
- ContentModels.Gif: +rating, +collections list, withCollections builder
- ContentRequests.UpdateGif: title, rating, tags (TagUpdate), collections (CollectionUpdate) — matches the image update contract
- ContentService.updateGif/deleteGif: full CRUD with S3 cleanup via deleteGifFromS3
- ContentMutationUtil.handleAddToCollections / handleContentChildCollectionUpdates generalized from ContentImageEntity to Long contentId; image overloads kept for back-compat
- CollectionProcessingUtil populates collections on both Image AND Gif via instanceof check post-conversion
- ContentModelConverter: Gif conversion produces empty collections list which CollectionProcessingUtil later fills
- AdminController: POST / PATCH / DELETE /api/admin/content/gifs/{id}
- ImageProcessingService.processGifContent defaults rating=4 so new uploads read as feature media unless admin lowers them
- S3Config + ContentRepository + ContentGifEntity wired for the rating column and the saveGif path
- ImageProcessingServiceTest updated for new GIF default rating