### PR TITLE
feat: sibling collections — collection_sibling join + API (backend)

### DIFF
--- a/src/main/java/edens/zac/portfolio/backend/dao/CollectionSiblingRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/CollectionSiblingRepository.java
@@ -1,0 +1,73 @@
+package edens.zac.portfolio.backend.dao;
+
+import edens.zac.portfolio.backend.model.Records;
+import edens.zac.portfolio.backend.types.CollectionType;
+import java.util.List;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Mutual ("sibling") association between collections (mirror of collection_people). Rows are stored
+ * reciprocally — a link between A and B is two rows (A,B) and (B,A) — so "siblings of X" is a
+ * single-direction lookup on collection_id. No dedicated entity POJO: the join is manipulated
+ * directly via SQL, matching collection_people / collection_locations.
+ */
+@Component
+public class CollectionSiblingRepository extends BaseDao {
+
+  private static final RowMapper<Records.CollectionList> SIBLING_ROW_MAPPER =
+      (rs, rowNum) ->
+          new Records.CollectionList(
+              rs.getLong("id"),
+              rs.getString("name"),
+              rs.getString("slug"),
+              CollectionType.valueOf(rs.getString("type")));
+
+  public CollectionSiblingRepository(JdbcTemplate jdbcTemplate) {
+    super(jdbcTemplate);
+  }
+
+  /**
+   * Reciprocal insert of the pair (a,b) and (b,a). Idempotent via {@code ON CONFLICT DO NOTHING}
+   * against the composite PK, so re-adding an existing link is a no-op.
+   */
+  @Transactional
+  public void addSibling(Long a, Long b) {
+    String sql =
+        "INSERT INTO collection_sibling (collection_id, sibling_collection_id) "
+            + "VALUES (:a, :b), (:b, :a) "
+            + "ON CONFLICT DO NOTHING";
+    update(sql, createParameterSource().addValue("a", a).addValue("b", b));
+  }
+
+  /** Bidirectional delete: removes both (a,b) and (b,a). */
+  @Transactional
+  public void removeSibling(Long a, Long b) {
+    String sql =
+        "DELETE FROM collection_sibling "
+            + "WHERE (collection_id = :a AND sibling_collection_id = :b) "
+            + "OR (collection_id = :b AND sibling_collection_id = :a)";
+    update(sql, createParameterSource().addValue("a", a).addValue("b", b));
+  }
+
+  /**
+   * Siblings of one collection as {@link Records.CollectionList} rows, ordered by title. When
+   * {@code listedOnly} is true, only LISTED siblings are returned (public read path); when false,
+   * every sibling regardless of visibility is returned (admin manage payload).
+   */
+  @Transactional(readOnly = true)
+  public List<Records.CollectionList> findSiblings(Long collectionId, boolean listedOnly) {
+    String sql =
+        "SELECT c.id, c.title AS name, c.slug, c.type "
+            + "FROM collection_sibling cs "
+            + "JOIN collection c ON c.id = cs.sibling_collection_id "
+            + "WHERE cs.collection_id = :id "
+            + (listedOnly ? "AND c.visibility = 'LISTED' " : "")
+            + "ORDER BY c.title ASC";
+    MapSqlParameterSource params = createParameterSource().addValue("id", collectionId);
+    return query(sql, SIBLING_ROW_MAPPER, params);
+  }
+}

--- a/src/main/java/edens/zac/portfolio/backend/model/CollectionModel.java
+++ b/src/main/java/edens/zac/portfolio/backend/model/CollectionModel.java
@@ -74,6 +74,12 @@ public class CollectionModel {
 
   private List<String> tags;
 
+  /**
+   * Sibling collections (mutual association via collection_sibling). LISTED-only on the public read
+   * path; all siblings on the admin manage payload. Null/empty when none.
+   */
+  private List<Records.CollectionList> siblings;
+
   @Valid private List<ContentModel> content;
 
   // === Access Control ===

--- a/src/main/java/edens/zac/portfolio/backend/model/CollectionRequests.java
+++ b/src/main/java/edens/zac/portfolio/backend/model/CollectionRequests.java
@@ -80,7 +80,14 @@ public final class CollectionRequests {
        * Collection updates using prev/new/remove pattern. Used to manage child collections within
        * this collection (add, remove, update visibility/order of nested collections).
        */
-      CollectionUpdate collections) {}
+      CollectionUpdate collections,
+      /**
+       * Sibling (mutual) collection updates. Reuses {@link CollectionUpdate}; only {@code newValue}
+       * (add) and {@code remove} (delete) are honored, and only each entry's {@code collectionId}
+       * is read ({@code orderIndex}/{@code visible}/{@code prev} are ignored — siblings carry no
+       * ordering or per-link visibility).
+       */
+      CollectionUpdate siblings) {}
 
   /**
    * Request for reordering content within a collection. Allows multiple content items to be

--- a/src/main/java/edens/zac/portfolio/backend/services/CollectionProcessingUtil.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/CollectionProcessingUtil.java
@@ -3,6 +3,7 @@ package edens.zac.portfolio.backend.services;
 import edens.zac.portfolio.backend.config.DefaultValues;
 import edens.zac.portfolio.backend.dao.CollectionPeopleRepository;
 import edens.zac.portfolio.backend.dao.CollectionRepository;
+import edens.zac.portfolio.backend.dao.CollectionSiblingRepository;
 import edens.zac.portfolio.backend.dao.ContentRepository;
 import edens.zac.portfolio.backend.dao.LocationRepository;
 import edens.zac.portfolio.backend.dao.PersonRepository;
@@ -44,6 +45,7 @@ public class CollectionProcessingUtil {
 
   private final CollectionRepository collectionRepository;
   private final CollectionPeopleRepository collectionPeopleRepository;
+  private final CollectionSiblingRepository collectionSiblingRepository;
   private final ContentRepository contentRepository;
   private final ContentModelConverter contentModelConverter;
   private final ContentMutationUtil contentMutationUtil;
@@ -306,11 +308,13 @@ public class CollectionProcessingUtil {
     if (joinEntries.isEmpty()) {
       CollectionModel model = convertToBasicModel(entity);
       model.setContent(Collections.emptyList());
+      populateSiblings(model, false);
       return model;
     }
 
     CollectionModel model = convertToModel(entity, joinEntries, 0, 0, joinEntries.size());
     populateCollectionsOnContent(model);
+    populateSiblings(model, false);
     return model;
   }
 
@@ -406,6 +410,18 @@ public class CollectionProcessingUtil {
             .collect(Collectors.toList());
 
     model.setContent(contents);
+  }
+
+  /**
+   * Populate {@code model.siblings} from the collection_sibling join. {@code listedOnly=true} on
+   * the public read path (LISTED siblings only — no dead links leak); {@code listedOnly=false} on
+   * the admin manage payload. No-op when the model or its id is null.
+   */
+  public void populateSiblings(CollectionModel model, boolean listedOnly) {
+    if (model == null || model.getId() == null) {
+      return;
+    }
+    model.setSiblings(collectionSiblingRepository.findSiblings(model.getId(), listedOnly));
   }
 
   /**

--- a/src/main/java/edens/zac/portfolio/backend/services/CollectionService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/CollectionService.java
@@ -125,6 +125,9 @@ public class CollectionService {
     // Populate collections on content items
     collectionProcessingUtil.populateCollectionsOnContent(model);
 
+    // Populate siblings — public read path shows LISTED siblings only (no dead links leak)
+    collectionProcessingUtil.populateSiblings(model, true);
+
     // Filter out child collection content that references non-LISTED collections
     filterNonListedChildCollections(model);
 

--- a/src/main/java/edens/zac/portfolio/backend/services/CollectionService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/CollectionService.java
@@ -5,6 +5,7 @@ import static edens.zac.portfolio.backend.config.DefaultValues.default_content_p
 import edens.zac.portfolio.backend.config.ResourceNotFoundException;
 import edens.zac.portfolio.backend.dao.CollectionPeopleRepository;
 import edens.zac.portfolio.backend.dao.CollectionRepository;
+import edens.zac.portfolio.backend.dao.CollectionSiblingRepository;
 import edens.zac.portfolio.backend.dao.ContentRepository;
 import edens.zac.portfolio.backend.dao.LocationRepository;
 import edens.zac.portfolio.backend.dao.TagRepository;
@@ -59,6 +60,7 @@ public class CollectionService {
 
   private final CollectionRepository collectionRepository;
   private final CollectionPeopleRepository collectionPeopleRepository;
+  private final CollectionSiblingRepository collectionSiblingRepository;
   private final ContentRepository contentRepository;
   private final LocationRepository locationRepository;
   private final TagRepository tagRepository;
@@ -487,6 +489,9 @@ public class CollectionService {
       handleCollectionToCollectionUpdates(entity, updateDTO.collections());
     }
 
+    // Handle sibling (mutual) collection updates
+    handleSiblingUpdates(entity.getId(), updateDTO.siblings());
+
     // Update total blocks count from join table before saving
     long totalBlocks = collectionRepository.countContentByCollectionId(entity.getId());
     entity.setTotalContent((int) totalBlocks);
@@ -900,6 +905,35 @@ public class CollectionService {
         }
       }
     }
+  }
+
+  /**
+   * Apply mutual sibling updates. Each {@code newValue} entry's collectionId is added via a
+   * reciprocal INSERT; each {@code remove} id is deleted bidirectionally. Self-links are skipped
+   * defensively (the DB CHECK also blocks them). No-op when {@code siblings} is null.
+   */
+  private void handleSiblingUpdates(Long parentId, CollectionRequests.CollectionUpdate siblings) {
+    if (siblings == null) {
+      return;
+    }
+    if (siblings.remove() != null) {
+      for (Long siblingId : siblings.remove()) {
+        if (siblingId == null || siblingId.equals(parentId)) {
+          continue;
+        }
+        collectionSiblingRepository.removeSibling(parentId, siblingId);
+      }
+    }
+    if (siblings.newValue() != null) {
+      for (Records.ChildCollection entry : siblings.newValue()) {
+        Long siblingId = entry.collectionId();
+        if (siblingId == null || siblingId.equals(parentId)) {
+          continue;
+        }
+        collectionSiblingRepository.addSibling(parentId, siblingId);
+      }
+    }
+    log.info("Applied sibling updates for collection {}", parentId);
   }
 
   /**

--- a/src/main/resources/db/migration/V26__collection_sibling.sql
+++ b/src/main/resources/db/migration/V26__collection_sibling.sql
@@ -1,0 +1,19 @@
+-- V26__collection_sibling
+-- Description: Mutual ("sibling") association between collections. Rows are stored
+-- reciprocally: a sibling link between A and B is two rows (A,B) and (B,A), so
+-- "siblings of X" is a single-direction lookup on collection_id. ON DELETE CASCADE
+-- cleans up both directions when either collection is deleted.
+
+BEGIN;
+
+CREATE TABLE collection_sibling (
+    collection_id         BIGINT NOT NULL REFERENCES collection(id) ON DELETE CASCADE,
+    sibling_collection_id BIGINT NOT NULL REFERENCES collection(id) ON DELETE CASCADE,
+    PRIMARY KEY (collection_id, sibling_collection_id),
+    CONSTRAINT chk_collection_sibling_not_self CHECK (collection_id <> sibling_collection_id)
+);
+
+CREATE INDEX idx_collection_sibling_collection ON collection_sibling(collection_id);
+CREATE INDEX idx_collection_sibling_sibling    ON collection_sibling(sibling_collection_id);
+
+COMMIT;

--- a/src/main/resources/db/migration/V26__collection_sibling.sql
+++ b/src/main/resources/db/migration/V26__collection_sibling.sql
@@ -13,7 +13,9 @@ CREATE TABLE collection_sibling (
     CONSTRAINT chk_collection_sibling_not_self CHECK (collection_id <> sibling_collection_id)
 );
 
-CREATE INDEX idx_collection_sibling_collection ON collection_sibling(collection_id);
-CREATE INDEX idx_collection_sibling_sibling    ON collection_sibling(sibling_collection_id);
+-- collection_id is already the leading column of the composite PK, so a separate index
+-- on it would be redundant. Only sibling_collection_id needs its own index — it backs the
+-- ON DELETE CASCADE lookup on the reverse FK (the forward direction is served by the PK).
+CREATE INDEX idx_collection_sibling_sibling ON collection_sibling(sibling_collection_id);
 
 COMMIT;

--- a/src/test/java/edens/zac/portfolio/backend/controller/dev/CollectionControllerDevTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/dev/CollectionControllerDevTest.java
@@ -492,6 +492,33 @@ class CollectionControllerDevTest {
   }
 
   @Test
+  @DisplayName("PUT /collections/{id} should accept a siblings block in the body")
+  void updateCollection_acceptsSiblings() throws Exception {
+    // Arrange
+    when(collectionService.updateContentWithMetadata(eq(1L), any(CollectionRequests.Update.class)))
+        .thenReturn(testCollectionUpdateResponse);
+
+    String body = "{\"id\":1,\"siblings\":{\"newValue\":[{\"collectionId\":20}],\"remove\":[30]}}";
+
+    // Act
+    mockMvc
+        .perform(
+            put("/api/admin/collections/1").contentType(MediaType.APPLICATION_JSON).content(body))
+        .andExpect(status().isOk());
+
+    // Assert: Jackson bound the raw siblings block onto Update and the controller forwarded it.
+    org.mockito.ArgumentCaptor<CollectionRequests.Update> captor =
+        org.mockito.ArgumentCaptor.forClass(CollectionRequests.Update.class);
+    verify(collectionService).updateContentWithMetadata(eq(1L), captor.capture());
+    CollectionRequests.Update sent = captor.getValue();
+    org.assertj.core.api.Assertions.assertThat(sent.siblings()).isNotNull();
+    org.assertj.core.api.Assertions.assertThat(sent.siblings().newValue()).hasSize(1);
+    org.assertj.core.api.Assertions.assertThat(sent.siblings().newValue().get(0).collectionId())
+        .isEqualTo(20L);
+    org.assertj.core.api.Assertions.assertThat(sent.siblings().remove()).containsExactly(30L);
+  }
+
+  @Test
   @DisplayName("GET /collections/all should return all collections ordered by date")
   void getAllCollectionsOrderedByDate_shouldReturnAllCollections() throws Exception {
     // Arrange

--- a/src/test/java/edens/zac/portfolio/backend/controller/dev/CollectionControllerDevTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/dev/CollectionControllerDevTest.java
@@ -108,6 +108,7 @@ class CollectionControllerDevTest {
             null,
             null,
             null,
+            null,
             null);
   }
 
@@ -181,6 +182,7 @@ class CollectionControllerDevTest {
             999L,
             null,
             "Updated Test Blog",
+            null,
             null,
             null,
             null,
@@ -374,6 +376,7 @@ class CollectionControllerDevTest {
             null,
             tagUpdate,
             null,
+            null,
             null);
 
     when(collectionService.updateContentWithMetadata(eq(1L), any(CollectionRequests.Update.class)))
@@ -420,6 +423,7 @@ class CollectionControllerDevTest {
             null,
             null,
             personUpdate,
+            null,
             null);
 
     when(collectionService.updateContentWithMetadata(eq(1L), any(CollectionRequests.Update.class)))
@@ -467,6 +471,7 @@ class CollectionControllerDevTest {
             null,
             tagUpdate,
             personUpdate,
+            null,
             null);
 
     when(collectionService.updateContentWithMetadata(eq(1L), any(CollectionRequests.Update.class)))

--- a/src/test/java/edens/zac/portfolio/backend/controller/dev/CollectionControllerDevTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/dev/CollectionControllerDevTest.java
@@ -498,7 +498,9 @@ class CollectionControllerDevTest {
     when(collectionService.updateContentWithMetadata(eq(1L), any(CollectionRequests.Update.class)))
         .thenReturn(testCollectionUpdateResponse);
 
-    String body = "{\"id\":1,\"siblings\":{\"newValue\":[{\"collectionId\":20}],\"remove\":[30]}}";
+    // Mirror the real frontend payload: newValue entries carry { collectionId, name }.
+    String body =
+        "{\"id\":1,\"siblings\":{\"newValue\":[{\"collectionId\":20,\"name\":\"Sibling B\"}],\"remove\":[30]}}";
 
     // Act
     mockMvc
@@ -515,6 +517,9 @@ class CollectionControllerDevTest {
     org.assertj.core.api.Assertions.assertThat(sent.siblings().newValue()).hasSize(1);
     org.assertj.core.api.Assertions.assertThat(sent.siblings().newValue().get(0).collectionId())
         .isEqualTo(20L);
+    // The extra `name` field from the frontend binds cleanly (it is a real ChildCollection field).
+    org.assertj.core.api.Assertions.assertThat(sent.siblings().newValue().get(0).name())
+        .isEqualTo("Sibling B");
     org.assertj.core.api.Assertions.assertThat(sent.siblings().remove()).containsExactly(30L);
   }
 

--- a/src/test/java/edens/zac/portfolio/backend/controller/prod/CollectionControllerProdTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/prod/CollectionControllerProdTest.java
@@ -242,6 +242,34 @@ class CollectionControllerProdTest {
   }
 
   @Test
+  @DisplayName("GET /{slug} should serialize siblings in the response")
+  void getCollectionBySlug_returnsSiblings() throws Exception {
+    // Arrange
+    CollectionModel model =
+        CollectionModel.builder()
+            .id(1L)
+            .type(CollectionType.PORTFOLIO)
+            .title("Dolomites")
+            .slug("dolomites")
+            .visibility(CollectionVisibility.LISTED)
+            .siblings(
+                List.of(
+                    new Records.CollectionList(
+                        2L, "Dolomites Film", "dolomites-film", CollectionType.PORTFOLIO)))
+            .build();
+    when(collectionService.getCollectionWithPagination(eq("dolomites"), anyInt(), anyInt()))
+        .thenReturn(model);
+
+    // Act & Assert
+    mockMvc
+        .perform(get("/api/read/collections/dolomites"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.siblings", hasSize(1)))
+        .andExpect(jsonPath("$.siblings[0].slug", is("dolomites-film")))
+        .andExpect(jsonPath("$.siblings[0].name", is("Dolomites Film")));
+  }
+
+  @Test
   @DisplayName("GET /collections/{slug} with non-existent slug should return not found")
   void getCollectionBySlug_withNonExistentSlug_shouldReturnNotFound() throws Exception {
     // Arrange

--- a/src/test/java/edens/zac/portfolio/backend/dao/CollectionSiblingRepositoryTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/dao/CollectionSiblingRepositoryTest.java
@@ -1,0 +1,126 @@
+package edens.zac.portfolio.backend.dao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import edens.zac.portfolio.backend.model.Records;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class CollectionSiblingRepositoryTest {
+
+  @Mock private JdbcTemplate jdbcTemplate;
+  @Mock private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+  @Captor private ArgumentCaptor<String> sqlCaptor;
+  @Captor private ArgumentCaptor<MapSqlParameterSource> paramsCaptor;
+
+  private CollectionSiblingRepository repository;
+
+  @BeforeEach
+  void setUp() {
+    repository = new CollectionSiblingRepository(jdbcTemplate);
+    setNamedParameterJdbcTemplate(repository, namedParameterJdbcTemplate);
+  }
+
+  private void setNamedParameterJdbcTemplate(
+      CollectionSiblingRepository repo, NamedParameterJdbcTemplate template) {
+    try {
+      java.lang.reflect.Field field = BaseDao.class.getDeclaredField("namedParameterJdbcTemplate");
+      field.setAccessible(true);
+      field.set(repo, template);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to set mock NamedParameterJdbcTemplate", e);
+    }
+  }
+
+  @Nested
+  class AddSibling {
+    @Test
+    void addSibling_issuesReciprocalInsertWithOnConflictDoNothing() {
+      when(namedParameterJdbcTemplate.update(anyString(), any(MapSqlParameterSource.class)))
+          .thenReturn(2);
+      repository.addSibling(1L, 2L);
+      verify(namedParameterJdbcTemplate).update(sqlCaptor.capture(), paramsCaptor.capture());
+      String sql = sqlCaptor.getValue();
+      assertThat(sql)
+          .containsIgnoringCase(
+              "INSERT INTO collection_sibling (collection_id, sibling_collection_id)");
+      assertThat(sql).containsIgnoringCase("VALUES (:a, :b), (:b, :a)");
+      assertThat(sql).containsIgnoringCase("ON CONFLICT DO NOTHING");
+      MapSqlParameterSource params = paramsCaptor.getValue();
+      assertThat(params.getValue("a")).isEqualTo(1L);
+      assertThat(params.getValue("b")).isEqualTo(2L);
+    }
+  }
+
+  @Nested
+  class RemoveSibling {
+    @Test
+    void removeSibling_issuesBidirectionalDelete() {
+      when(namedParameterJdbcTemplate.update(anyString(), any(MapSqlParameterSource.class)))
+          .thenReturn(2);
+      repository.removeSibling(3L, 4L);
+      verify(namedParameterJdbcTemplate).update(sqlCaptor.capture(), paramsCaptor.capture());
+      String sql = sqlCaptor.getValue();
+      assertThat(sql).containsIgnoringCase("DELETE FROM collection_sibling");
+      assertThat(sql).containsIgnoringCase("(collection_id = :a AND sibling_collection_id = :b)");
+      assertThat(sql).containsIgnoringCase("(collection_id = :b AND sibling_collection_id = :a)");
+      MapSqlParameterSource params = paramsCaptor.getValue();
+      assertThat(params.getValue("a")).isEqualTo(3L);
+      assertThat(params.getValue("b")).isEqualTo(4L);
+    }
+  }
+
+  @Nested
+  class FindSiblings {
+    @SuppressWarnings("unchecked")
+    @Test
+    void findSiblings_listedOnlyTrue_appendsVisibilityClause() {
+      when(namedParameterJdbcTemplate.query(
+              anyString(), any(MapSqlParameterSource.class), any(RowMapper.class)))
+          .thenReturn(List.of());
+      List<Records.CollectionList> result = repository.findSiblings(7L, true);
+      assertThat(result).isEmpty();
+      verify(namedParameterJdbcTemplate)
+          .query(sqlCaptor.capture(), paramsCaptor.capture(), any(RowMapper.class));
+      String sql = sqlCaptor.getValue();
+      assertThat(sql).containsIgnoringCase("SELECT c.id, c.title AS name, c.slug, c.type");
+      assertThat(sql).containsIgnoringCase("FROM collection_sibling cs");
+      assertThat(sql).containsIgnoringCase("JOIN collection c ON c.id = cs.sibling_collection_id");
+      assertThat(sql).containsIgnoringCase("WHERE cs.collection_id = :id");
+      assertThat(sql).containsIgnoringCase("AND c.visibility = 'LISTED'");
+      assertThat(sql).containsIgnoringCase("ORDER BY c.title ASC");
+      assertThat(paramsCaptor.getValue().getValue("id")).isEqualTo(7L);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void findSiblings_listedOnlyFalse_omitsVisibilityClause() {
+      when(namedParameterJdbcTemplate.query(
+              anyString(), any(MapSqlParameterSource.class), any(RowMapper.class)))
+          .thenReturn(List.of());
+      repository.findSiblings(8L, false);
+      verify(namedParameterJdbcTemplate)
+          .query(sqlCaptor.capture(), any(MapSqlParameterSource.class), any(RowMapper.class));
+      String sql = sqlCaptor.getValue();
+      assertThat(sql).containsIgnoringCase("WHERE cs.collection_id = :id");
+      assertThat(sql).doesNotContainIgnoringCase("visibility = 'LISTED'");
+      assertThat(sql).containsIgnoringCase("ORDER BY c.title ASC");
+    }
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/model/CollectionUpdateRequestTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/model/CollectionUpdateRequestTest.java
@@ -64,7 +64,8 @@ class CollectionUpdateRequestTest {
         coverImageId,
         tags,
         people,
-        collections);
+        collections,
+        null);
   }
 
   @BeforeEach

--- a/src/test/java/edens/zac/portfolio/backend/services/CollectionProcessingUtilTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/CollectionProcessingUtilTest.java
@@ -1,10 +1,12 @@
 package edens.zac.portfolio.backend.services;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import edens.zac.portfolio.backend.dao.CollectionPeopleRepository;
 import edens.zac.portfolio.backend.dao.CollectionRepository;
+import edens.zac.portfolio.backend.dao.CollectionSiblingRepository;
 import edens.zac.portfolio.backend.dao.ContentRepository;
 import edens.zac.portfolio.backend.dao.LocationRepository;
 import edens.zac.portfolio.backend.dao.PersonRepository;
@@ -13,6 +15,7 @@ import edens.zac.portfolio.backend.entity.CollectionEntity;
 import edens.zac.portfolio.backend.entity.ContentEntity;
 import edens.zac.portfolio.backend.entity.ContentTextEntity;
 import edens.zac.portfolio.backend.model.CollectionModel;
+import edens.zac.portfolio.backend.model.Records;
 import edens.zac.portfolio.backend.types.CollectionType;
 import edens.zac.portfolio.backend.types.CollectionVisibility;
 import edens.zac.portfolio.backend.types.ContentType;
@@ -43,6 +46,8 @@ class CollectionProcessingUtilTest {
   @Mock private TagRepository tagRepository;
 
   @Mock private PersonRepository personRepository;
+
+  @Mock private CollectionSiblingRepository collectionSiblingRepository;
 
   @InjectMocks private CollectionProcessingUtil util;
 
@@ -149,5 +154,32 @@ class CollectionProcessingUtilTest {
     assertEquals(30, result.getContentPerPage());
     // Client galleries are private by default -> UNLISTED (direct slug access only).
     assertEquals(CollectionVisibility.UNLISTED, result.getVisibility());
+  }
+
+  @Test
+  void populateSiblings_listedOnlyTrue_setsResultFromRepository() {
+    CollectionModel model = CollectionModel.builder().id(5L).build();
+    List<Records.CollectionList> siblings =
+        List.of(
+            new Records.CollectionList(
+                9L, "Dolomites Film", "dolomites-film", CollectionType.PORTFOLIO));
+    when(collectionSiblingRepository.findSiblings(5L, true)).thenReturn(siblings);
+
+    util.populateSiblings(model, true);
+
+    assertThat(model.getSiblings()).isEqualTo(siblings);
+    verify(collectionSiblingRepository).findSiblings(5L, true);
+  }
+
+  @Test
+  void populateSiblings_nullModel_isNoOp() {
+    util.populateSiblings(null, true);
+    verifyNoInteractions(collectionSiblingRepository);
+  }
+
+  @Test
+  void populateSiblings_nullId_isNoOp() {
+    util.populateSiblings(CollectionModel.builder().build(), false);
+    verifyNoInteractions(collectionSiblingRepository);
   }
 }

--- a/src/test/java/edens/zac/portfolio/backend/services/CollectionServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/CollectionServiceTest.java
@@ -340,6 +340,7 @@ class CollectionServiceTest {
 
       assertThat(result).isNotNull();
       assertThat(result.getTitle()).isEqualTo("Test Collection");
+      verify(collectionProcessingUtil).populateSiblings(model, true);
     }
 
     @Test

--- a/src/test/java/edens/zac/portfolio/backend/services/CollectionServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/CollectionServiceTest.java
@@ -56,6 +56,10 @@ class CollectionServiceTest {
   @Mock private MetadataService metadataService;
   @Mock private SyntheticCollectionResolver syntheticResolver;
   @Mock private ClientGalleryAuthService clientGalleryAuthService;
+
+  @Mock
+  private edens.zac.portfolio.backend.dao.CollectionSiblingRepository collectionSiblingRepository;
+
   @Mock private org.springframework.core.env.Environment springEnv;
 
   @InjectMocks private CollectionService service;
@@ -215,6 +219,7 @@ class CollectionServiceTest {
               null,
               null,
               null,
+              null,
               null);
 
       CollectionModel updatedModel =
@@ -260,6 +265,7 @@ class CollectionServiceTest {
               null,
               null,
               null,
+              null,
               null);
 
       when(collectionRepository.findById(collectionId)).thenReturn(Optional.empty());
@@ -279,6 +285,7 @@ class CollectionServiceTest {
               "New Title",
               "new-slug",
               "New desc",
+              null,
               null,
               null,
               null,
@@ -1408,6 +1415,64 @@ class CollectionServiceTest {
           .thenReturn(false);
 
       assertThat(service.isGalleryAccessAuthorized("protected-gallery", request)).isFalse();
+    }
+  }
+
+  @Nested
+  class HandleSiblingUpdates {
+
+    private CollectionRequests.Update updateWithSiblings(
+        Long id, CollectionRequests.CollectionUpdate siblings) {
+      // 18 positional args: id first, siblings last, everything else null
+      return new CollectionRequests.Update(
+          id, null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+          null, /* collections */ null, /* siblings */ siblings);
+    }
+
+    @Test
+    void addsEachNewValueAndRemovesEachRemoveId() {
+      Long parentId = 1L;
+      CollectionRequests.CollectionUpdate siblings =
+          new CollectionRequests.CollectionUpdate(
+              null,
+              List.of(
+                  new Records.ChildCollection(20L, null, null, null, null, null),
+                  new Records.ChildCollection(21L, null, null, null, null, null)),
+              List.of(30L, 31L));
+      when(collectionRepository.findById(parentId)).thenReturn(Optional.of(testCollection));
+
+      service.updateContent(parentId, updateWithSiblings(parentId, siblings));
+
+      verify(collectionSiblingRepository).addSibling(parentId, 20L);
+      verify(collectionSiblingRepository).addSibling(parentId, 21L);
+      verify(collectionSiblingRepository).removeSibling(parentId, 30L);
+      verify(collectionSiblingRepository).removeSibling(parentId, 31L);
+    }
+
+    @Test
+    void skipsSelfReferenceInNewValue() {
+      Long parentId = 1L;
+      CollectionRequests.CollectionUpdate siblings =
+          new CollectionRequests.CollectionUpdate(
+              null,
+              List.of(new Records.ChildCollection(parentId, null, null, null, null, null)),
+              null);
+      when(collectionRepository.findById(parentId)).thenReturn(Optional.of(testCollection));
+
+      service.updateContent(parentId, updateWithSiblings(parentId, siblings));
+
+      verify(collectionSiblingRepository, never()).addSibling(eq(parentId), eq(parentId));
+    }
+
+    @Test
+    void nullSiblings_isNoOp() {
+      Long parentId = 1L;
+      when(collectionRepository.findById(parentId)).thenReturn(Optional.of(testCollection));
+
+      service.updateContent(parentId, updateWithSiblings(parentId, null));
+
+      verify(collectionSiblingRepository, never()).addSibling(anyLong(), anyLong());
+      verify(collectionSiblingRepository, never()).removeSibling(anyLong(), anyLong());
     }
   }
 }


### PR DESCRIPTION
## Sibling Collections — Backend

Backend half of the **mutual "sibling"** collection feature. Pairs with the frontend PR (`0144-sibling-collections` in `edens.zac`).

### Changes
- **`V26__collection_sibling.sql`** — reciprocal join table (composite PK, `ON DELETE CASCADE`, self-reference CHECK).
- **`CollectionSiblingRepository`** — reciprocal `addSibling`/`removeSibling`, `findSiblings(id, listedOnly)`.
- **DTO:** `siblings` on `CollectionModel` + `CollectionRequests.Update`.
- **Service:** `handleSiblingUpdates` (mutual add/remove, skip-self) wired into `updateContent`; `populateSiblings` on read paths — public = LISTED-only (no dead links), admin = all.
- No new endpoints — rides existing `PUT /api/admin/collections/{id}` + `GET /api/read/collections/{slug}`.

### ⚠️ Migration
`V26` must be applied — runs on next app boot via Flyway. Verify: `psql "$DEV_DATABASE_URL" -c '\d collection_sibling'`.

### Verification
- `./mvnw verify`: **646 tests, 0 failures**; Checkstyle + Spotless clean. (SpotBugs is disabled repo-wide — pre-existing.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
