### PR TITLE
feat(download): optional imageIds subset filter for collection ZIP

### DIFF
--- a/src/main/java/edens/zac/portfolio/backend/controller/prod/ContentDownloadControllerProd.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/prod/ContentDownloadControllerProd.java
@@ -49,6 +49,9 @@ import software.amazon.awssdk.services.s3.model.GetObjectResponse;
  *   <li>{@code GET /api/read/collections/{slug}/download?format=web} -- ZIP of every WebP
  *   <li>{@code GET /api/read/collections/{slug}/download?format=original} -- ZIP of full-res JPEGs
  *       (per-image fallback to WebP when no original is stored)
+ *   <li>{@code GET /api/read/collections/{slug}/download?format=web&imageIds=1,2,3} -- ZIP of just
+ *       the selected images (optional {@code imageIds} subset; ids not in the collection are
+ *       dropped, and the ZIP filename gains a {@code -selection-N} suffix)
  * </ul>
  */
 @Slf4j
@@ -111,6 +114,7 @@ public class ContentDownloadControllerProd {
   public void downloadCollection(
       @PathVariable String slug,
       @RequestParam(defaultValue = "web") String format,
+      @RequestParam(required = false) List<Long> imageIds,
       HttpServletRequest request,
       HttpServletResponse response)
       throws IOException {
@@ -125,9 +129,15 @@ public class ContentDownloadControllerProd {
     }
 
     List<DownloadResolution> entries =
-        contentService.resolveCollectionDownloadEntries(collection.getId(), format);
+        contentService.resolveCollectionDownloadEntries(collection.getId(), format, imageIds);
 
+    boolean isSubset = imageIds != null && !imageIds.isEmpty();
     String zipName = contentService.collectionZipFilename(collection.getSlug(), collection.getId());
+    if (isSubset) {
+      // Distinguish a selected-subset ZIP from the whole-collection one so a client who downloads
+      // "all" and then a subset doesn't get two identically named files. Count is an int -- safe.
+      zipName = zipName.replaceFirst("\\.zip$", "-selection-" + imageIds.size() + ".zip");
+    }
     response.setContentType("application/zip");
     response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + zipName + "\"");
 

--- a/src/main/java/edens/zac/portfolio/backend/services/ContentService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/ContentService.java
@@ -31,6 +31,7 @@ import edens.zac.portfolio.backend.services.validator.ContentImageUpdateValidato
 import edens.zac.portfolio.backend.services.validator.ContentValidator;
 import edens.zac.portfolio.backend.types.ContentType;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -755,9 +756,39 @@ public class ContentService {
   @Transactional(readOnly = true)
   public List<DownloadResolution> resolveCollectionDownloadEntries(
       Long collectionId, String format) {
+    return resolveCollectionDownloadEntries(collectionId, format, null);
+  }
+
+  /**
+   * Resolve the per-image download targets for a collection ZIP, optionally restricted to a subset
+   * of image ids. When {@code imageIds} is {@code null} or empty the whole collection is resolved
+   * (identical to the 2-arg overload); otherwise the collection's images are filtered to those
+   * whose id is in {@code imageIds}, preserving collection display order. Filtering only ever
+   * narrows the collection's own images, so an id that does not belong to this collection is
+   * silently dropped -- this is the auth boundary, and no image outside the authorized collection
+   * can be requested.
+   *
+   * <p>Format resolution semantics are unchanged: for {@code format=original}, prefers {@code
+   * imageUrlOriginal} per image but transparently falls back to {@code imageUrlWeb} (and the {@code
+   * .webp} extension) when an original is not stored, so the ZIP is always complete. Images whose
+   * configured CloudFront URL cannot be parsed into an S3 key are skipped with a WARN log.
+   *
+   * <p>Throws {@link IllegalArgumentException} for unsupported formats.
+   */
+  @Transactional(readOnly = true)
+  public List<DownloadResolution> resolveCollectionDownloadEntries(
+      Long collectionId, String format, Collection<Long> imageIds) {
     requireSupportedFormat(format);
     boolean isOriginal = FORMAT_ORIGINAL.equalsIgnoreCase(format);
     List<ContentImageEntity> images = findImagesForCollection(collectionId);
+
+    // Subset filter: when imageIds is non-empty, keep only requested ids (membership-preserving,
+    // so an id not in this collection is silently dropped -- this is the auth boundary).
+    if (imageIds != null && !imageIds.isEmpty()) {
+      Set<Long> wanted = new HashSet<>(imageIds);
+      images = images.stream().filter(img -> wanted.contains(img.getId())).toList();
+    }
+
     List<DownloadResolution> resolutions = new ArrayList<>(images.size());
     for (ContentImageEntity image : images) {
       String url = image.getImageUrlWeb();

--- a/src/test/java/edens/zac/portfolio/backend/controller/prod/ContentDownloadControllerProdTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/prod/ContentDownloadControllerProdTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -269,7 +270,7 @@ class ContentDownloadControllerProdTest {
       when(collectionService.findEntityBySlug("smith-wedding")).thenReturn(gallery);
       when(clientGalleryAuthService.validateAccessToken("smith-wedding", "tok-123"))
           .thenReturn(true);
-      when(contentService.resolveCollectionDownloadEntries(1L, "web"))
+      when(contentService.resolveCollectionDownloadEntries(1L, "web", null))
           .thenReturn(List.of(webResolution("first.webp"), webResolution("second.webp")));
       when(s3Client.getObject(any(GetObjectRequest.class)))
           .thenReturn(fakeS3Stream("aaaa".getBytes()))
@@ -321,14 +322,14 @@ class ContentDownloadControllerProdTest {
           .perform(get("/api/read/collections/smith-wedding/download"))
           .andExpect(status().isUnauthorized());
 
-      verify(contentService, never()).resolveCollectionDownloadEntries(any(), any());
+      verify(contentService, never()).resolveCollectionDownloadEntries(any(), any(), any());
       verify(s3Client, never()).getObject(any(GetObjectRequest.class));
     }
 
     @Test
     void unprotectedCollection_noCookie_returns200() throws Exception {
       when(collectionService.findEntityBySlug("open-portfolio")).thenReturn(openCollection());
-      when(contentService.resolveCollectionDownloadEntries(2L, "web"))
+      when(contentService.resolveCollectionDownloadEntries(2L, "web", null))
           .thenReturn(List.of(webResolution("open.webp")));
       when(s3Client.getObject(any(GetObjectRequest.class)))
           .thenReturn(fakeS3Stream("zzzz".getBytes()));
@@ -344,7 +345,7 @@ class ContentDownloadControllerProdTest {
       when(collectionService.findEntityBySlug("smith-wedding")).thenReturn(protectedGallery());
       when(clientGalleryAuthService.validateAccessToken("smith-wedding", "tok-123"))
           .thenReturn(true);
-      when(contentService.resolveCollectionDownloadEntries(1L, "original"))
+      when(contentService.resolveCollectionDownloadEntries(1L, "original", null))
           .thenReturn(List.of(jpegResolution("first.jpg"), jpegResolution("second.jpg")));
       when(s3Client.getObject(any(GetObjectRequest.class)))
           .thenReturn(fakeS3Stream("JPEG1".getBytes()))
@@ -374,7 +375,7 @@ class ContentDownloadControllerProdTest {
     @Test
     void formatUnsupported_serviceThrowsIllegalArgument_returns400() throws Exception {
       when(collectionService.findEntityBySlug("open-portfolio")).thenReturn(openCollection());
-      when(contentService.resolveCollectionDownloadEntries(eq(2L), eq("raw")))
+      when(contentService.resolveCollectionDownloadEntries(eq(2L), eq("raw"), eq(null)))
           .thenThrow(new IllegalArgumentException("Unsupported download format: raw"));
 
       mockMvc
@@ -387,7 +388,7 @@ class ContentDownloadControllerProdTest {
     @Test
     void zipsRemainingImagesWhenOneS3FetchFails() throws Exception {
       when(collectionService.findEntityBySlug("open-portfolio")).thenReturn(openCollection());
-      when(contentService.resolveCollectionDownloadEntries(2L, "web"))
+      when(contentService.resolveCollectionDownloadEntries(2L, "web", null))
           .thenReturn(
               List.of(
                   webResolution("first.webp"),
@@ -434,7 +435,7 @@ class ContentDownloadControllerProdTest {
     @Test
     void emptyCollection_returnsEmptyZip() throws Exception {
       when(collectionService.findEntityBySlug("open-portfolio")).thenReturn(openCollection());
-      when(contentService.resolveCollectionDownloadEntries(2L, "web")).thenReturn(List.of());
+      when(contentService.resolveCollectionDownloadEntries(2L, "web", null)).thenReturn(List.of());
 
       MvcResult result =
           mockMvc
@@ -446,6 +447,58 @@ class ContentDownloadControllerProdTest {
       try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipBytes))) {
         assertThat(zis.getNextEntry()).isNull();
       }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void imageIdsSubset_passesIdsToResolverAndUsesSelectionFilename() throws Exception {
+      CollectionEntity gallery = protectedGallery();
+      when(collectionService.findEntityBySlug("smith-wedding")).thenReturn(gallery);
+      when(clientGalleryAuthService.validateAccessToken("smith-wedding", "tok-123"))
+          .thenReturn(true);
+      when(contentService.resolveCollectionDownloadEntries(eq(1L), eq("web"), any()))
+          .thenReturn(List.of(webResolution("first.webp"), webResolution("third.webp")));
+      when(contentService.collectionZipFilename("smith-wedding", 1L))
+          .thenReturn("smith-wedding-1.zip");
+      when(s3Client.getObject(any(GetObjectRequest.class)))
+          .thenReturn(fakeS3Stream("aaaa".getBytes()))
+          .thenReturn(fakeS3Stream("cccc".getBytes()));
+
+      mockMvc
+          .perform(
+              get("/api/read/collections/smith-wedding/download")
+                  .param("format", "web")
+                  .param("imageIds", "1", "3")
+                  .cookie(new Cookie("gallery_access_smith-wedding", "tok-123")))
+          .andExpect(status().isOk())
+          .andExpect(header().string("Content-Type", "application/zip"))
+          // Subset ZIPs carry a -selection-<count> suffix so they don't collide with the "all" ZIP.
+          .andExpect(
+              header()
+                  .string(
+                      "Content-Disposition",
+                      org.hamcrest.Matchers.containsString("smith-wedding-1-selection-2.zip")));
+
+      ArgumentCaptor<List<Long>> idsCaptor = ArgumentCaptor.forClass(List.class);
+      verify(contentService)
+          .resolveCollectionDownloadEntries(eq(1L), eq("web"), idsCaptor.capture());
+      assertThat(idsCaptor.getValue()).containsExactly(1L, 3L);
+    }
+
+    @Test
+    void protectedCollection_noCookie_withImageIds_returns401() throws Exception {
+      when(collectionService.findEntityBySlug("smith-wedding")).thenReturn(protectedGallery());
+
+      // Auth gate precedes resolution: a subset request from an unauthorized client is still 401.
+      mockMvc
+          .perform(
+              get("/api/read/collections/smith-wedding/download")
+                  .param("format", "web")
+                  .param("imageIds", "1", "3"))
+          .andExpect(status().isUnauthorized());
+
+      verify(contentService, never()).resolveCollectionDownloadEntries(any(), any(), any());
+      verify(s3Client, never()).getObject(any(GetObjectRequest.class));
     }
   }
 }

--- a/src/test/java/edens/zac/portfolio/backend/services/ContentServiceDownloadTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/ContentServiceDownloadTest.java
@@ -259,5 +259,60 @@ class ContentServiceDownloadTest {
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining("Unsupported download format");
     }
+
+    @Test
+    void imageIdsSubset_returnsOnlyRequestedInCollectionOrder() {
+      stubCollectionImages(
+          1L,
+          List.of(
+              image(1L, "first.jpg", "first.webp"),
+              image(2L, "second.jpg", "second.webp"),
+              image(3L, "third.jpg", "third.webp")));
+
+      List<DownloadResolution> entries =
+          service.resolveCollectionDownloadEntries(1L, "web", List.of(1L, 3L));
+
+      // Exactly ids 1 and 3, in collection (order_index) order — not request order.
+      assertThat(entries).hasSize(2);
+      assertThat(entries.get(0).s3Key()).contains("first.webp");
+      assertThat(entries.get(1).s3Key()).contains("third.webp");
+    }
+
+    @Test
+    void imageIdsNull_returnsFullSet() {
+      stubCollectionImages(
+          1L,
+          List.of(image(1L, "first.jpg", "first.webp"), image(2L, "second.jpg", "second.webp")));
+
+      List<DownloadResolution> entries = service.resolveCollectionDownloadEntries(1L, "web", null);
+
+      assertThat(entries).hasSize(2);
+    }
+
+    @Test
+    void imageIdsEmpty_returnsFullSet() {
+      stubCollectionImages(
+          1L,
+          List.of(image(1L, "first.jpg", "first.webp"), image(2L, "second.jpg", "second.webp")));
+
+      List<DownloadResolution> entries =
+          service.resolveCollectionDownloadEntries(1L, "web", List.of());
+
+      assertThat(entries).hasSize(2);
+    }
+
+    @Test
+    void imageIdsNotInCollection_areDroppedNotLeaked() {
+      stubCollectionImages(
+          1L,
+          List.of(image(1L, "first.jpg", "first.webp"), image(2L, "second.jpg", "second.webp")));
+
+      // id 99 does not belong to this collection: silently dropped, no throw, never leaked.
+      List<DownloadResolution> entries =
+          service.resolveCollectionDownloadEntries(1L, "web", List.of(1L, 99L));
+
+      assertThat(entries).hasSize(1);
+      assertThat(entries.get(0).s3Key()).contains("first.webp");
+    }
   }
 }


### PR DESCRIPTION
Backs the frontend client-gallery **Select → Download** flow (frontend PR: themancalledzac/edens.zac#164).

## What

Adds an optional `imageIds` query param to the existing collection ZIP endpoint so a client gallery can download just a chosen subset:

`GET /api/read/collections/{slug}/download?format=web|original&imageIds=1,2,3`

- **`ContentService.resolveCollectionDownloadEntries`** — the 2-arg method now delegates to a new 3-arg overload `(Long, String, Collection<Long>)` that filters the collection's images to the requested ids (collection order preserved). Filtering only ever narrows the collection's *own* images, so an id outside the collection is silently dropped — **the auth boundary is unchanged**.
- **`ContentDownloadControllerProd`** — accepts `@RequestParam(required = false) List<Long> imageIds`, passes it through, and gives subset ZIPs a `-selection-N` filename suffix so they don't collide with the whole-collection download. The gallery-access cookie gate is unchanged and still runs **before** resolution.

## Compatibility

Fully backward-compatible — absent/empty `imageIds` returns the whole-collection ZIP exactly as before. No DB or migration change.

## Tests

Extended the existing `ContentServiceDownloadTest` and `ContentDownloadControllerProdTest`:
- subset returns requested ids in collection order; `null` and `[]` → full set; id not in the collection is dropped (no throw, not leaked)
- controller passes `[1,3]` to the resolver and streams a ZIP with the `-selection-N` filename; password-protected collection without a cookie → 401 even with `imageIds` present (auth precedes resolution)

`mvn -o test` → **658 pass** (1 pre-existing skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)