### PR TITLE
feat(collection): full disassociation on delete + success response

### DIFF
--- a/src/main/java/edens/zac/portfolio/backend/controller/dev/AdminController.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/dev/AdminController.java
@@ -120,10 +120,10 @@ class AdminController {
   }
 
   @DeleteMapping("/collections/{id}")
-  public ResponseEntity<Void> deleteCollection(@PathVariable Long id) {
+  public ResponseEntity<Map<String, Boolean>> deleteCollection(@PathVariable Long id) {
     collectionService.deleteCollection(id);
     log.info("Deleted collection: {}", id);
-    return ResponseEntity.noContent().build();
+    return ResponseEntity.ok(Map.of("success", true));
   }
 
   /** All collections paginated, ordered by collection date DESC. Visibility is not filtered. */

--- a/src/main/java/edens/zac/portfolio/backend/dao/ContentRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/ContentRepository.java
@@ -1047,4 +1047,25 @@ public class ContentRepository extends BaseDao {
     String contentSql = "DELETE FROM content WHERE id = :id";
     update(contentSql, params);
   }
+
+  /**
+   * Delete every {@code content_collection} block that references the given collection. Unlinks the
+   * blocks from any parent collection ({@code collection_content}), removes the {@code
+   * content_collection} rows, and deletes the underlying {@code content} rows. Used when a
+   * collection is deleted so parent collections no longer hold a dangling reference to it.
+   */
+  @Transactional
+  public void deleteContentCollectionsReferencing(Long referencedCollectionId) {
+    String findSql = "SELECT id FROM content_collection WHERE referenced_collection_id = :refId";
+    MapSqlParameterSource refParams =
+        createParameterSource().addValue("refId", referencedCollectionId);
+    List<Long> blockIds = namedParameterJdbcTemplate.queryForList(findSql, refParams, Long.class);
+    if (blockIds.isEmpty()) {
+      return;
+    }
+    MapSqlParameterSource idParams = createParameterSource().addValue("ids", blockIds);
+    update("DELETE FROM collection_content WHERE content_id IN (:ids)", idParams);
+    update("DELETE FROM content_collection WHERE referenced_collection_id = :refId", refParams);
+    update("DELETE FROM content WHERE id IN (:ids)", idParams);
+  }
 }

--- a/src/main/java/edens/zac/portfolio/backend/services/CollectionService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/CollectionService.java
@@ -571,10 +571,21 @@ public class CollectionService {
       throw new ResourceNotFoundException("Collection not found with ID: " + id);
     }
 
-    // Delete all join table entries (dissociate content from collection)
-    // This does NOT delete the content itself - content is reusable!
+    // Disassociate this collection from any parent collections that reference it as a child.
+    // Capture the parents before removing the back-references, then recount each parent's
+    // totalContent so their stored counts stay accurate.
+    List<CollectionEntity> parents = collectionRepository.findAllParentCollectionsByChildId(id);
+    contentRepository.deleteContentCollectionsReferencing(id);
+    for (CollectionEntity parent : parents) {
+      recountParentTotalContent(parent);
+    }
+
+    // Dissociate this collection's own content membership and its tags. Content itself is reusable
+    // and is NOT deleted. collection_locations, collection_people, and collection_sibling rows are
+    // removed by ON DELETE CASCADE when the collection row is deleted.
     collectionRepository.deleteContentByCollectionId(id);
-    log.debug("Deleted all join table entries for collection ID: {}", id);
+    tagRepository.deleteCollectionTags(id);
+    log.debug("Disassociated content, tags, and parent references for collection ID: {}", id);
 
     // Delete collection
     collectionRepository.deleteById(id);

--- a/src/test/java/edens/zac/portfolio/backend/controller/dev/CollectionControllerDevTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/dev/CollectionControllerDevTest.java
@@ -222,7 +222,10 @@ class CollectionControllerDevTest {
     doNothing().when(collectionService).deleteCollection(1L);
 
     // Act & Assert
-    mockMvc.perform(delete("/api/admin/collections/1")).andExpect(status().isNoContent());
+    mockMvc
+        .perform(delete("/api/admin/collections/1"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.success").value(true));
 
     verify(collectionService).deleteCollection(1L);
   }

--- a/src/test/java/edens/zac/portfolio/backend/services/CollectionServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/CollectionServiceTest.java
@@ -161,13 +161,15 @@ class CollectionServiceTest {
   class DeleteCollection {
 
     @Test
-    void deleteCollection_happyPath_deletesJoinEntriesThenCollection() {
+    void deleteCollection_happyPath_disassociatesAllRelationshipsThenDeletes() {
       Long collectionId = 1L;
       when(collectionRepository.findById(collectionId)).thenReturn(Optional.of(testCollection));
 
       service.deleteCollection(collectionId);
 
+      verify(contentRepository).deleteContentCollectionsReferencing(collectionId);
       verify(collectionRepository).deleteContentByCollectionId(collectionId);
+      verify(tagRepository).deleteCollectionTags(collectionId);
       verify(collectionRepository).deleteById(collectionId);
     }
 
@@ -180,21 +182,47 @@ class CollectionServiceTest {
           .isInstanceOf(ResourceNotFoundException.class)
           .hasMessageContaining("Collection not found with ID: 999");
 
+      verify(contentRepository, never()).deleteContentCollectionsReferencing(any());
       verify(collectionRepository, never()).deleteContentByCollectionId(any());
+      verify(tagRepository, never()).deleteCollectionTags(any());
       verify(collectionRepository, never()).deleteById(any());
     }
 
     @Test
-    void deleteCollection_deletesJoinEntriesBeforeCollection() {
+    void deleteCollection_removesBackReferencesAndTagsBeforeDeletingCollection() {
       Long collectionId = 1L;
       when(collectionRepository.findById(collectionId)).thenReturn(Optional.of(testCollection));
 
       service.deleteCollection(collectionId);
 
-      // Verify order: join entries deleted first, then collection
-      var inOrder = org.mockito.Mockito.inOrder(collectionRepository);
+      // Back-references, own content, and tags must all be cleared before the collection row.
+      var inOrder =
+          org.mockito.Mockito.inOrder(collectionRepository, contentRepository, tagRepository);
+      inOrder.verify(contentRepository).deleteContentCollectionsReferencing(collectionId);
       inOrder.verify(collectionRepository).deleteContentByCollectionId(collectionId);
+      inOrder.verify(tagRepository).deleteCollectionTags(collectionId);
       inOrder.verify(collectionRepository).deleteById(collectionId);
+    }
+
+    @Test
+    void deleteCollection_withParentReferences_recountsEachParentTotalContent() {
+      Long collectionId = 1L;
+      CollectionEntity parentA = CollectionEntity.builder().id(10L).totalContent(99).build();
+      CollectionEntity parentB = CollectionEntity.builder().id(11L).totalContent(99).build();
+      when(collectionRepository.findById(collectionId)).thenReturn(Optional.of(testCollection));
+      when(collectionRepository.findAllParentCollectionsByChildId(collectionId))
+          .thenReturn(List.of(parentA, parentB));
+      when(collectionRepository.countContentByCollectionId(10L)).thenReturn(3L);
+      when(collectionRepository.countContentByCollectionId(11L)).thenReturn(5L);
+
+      service.deleteCollection(collectionId);
+
+      // Back-references removed, then each parent's stored count recomputed and persisted.
+      verify(contentRepository).deleteContentCollectionsReferencing(collectionId);
+      assertThat(parentA.getTotalContent()).isEqualTo(3);
+      assertThat(parentB.getTotalContent()).isEqualTo(5);
+      verify(collectionRepository).save(parentA);
+      verify(collectionRepository).save(parentB);
     }
   }
 


### PR DESCRIPTION
## Summary

- Audited and fixed `DELETE /api/admin/collections/{id}` which predated several schema additions and only removed own-content membership + the row
- Remove parent `content_collection` back-references (this collection referenced as a child) and recount each affected parent's `totalContent`
- Clean `collection_tags` on delete (`deleteCollectionTags` was dead code, now wired)
- `people` / `sibling` / `locations` join rows removed via `ON DELETE CASCADE`
- New `ContentRepository.deleteContentCollectionsReferencing` unlinks back-ref blocks from parents and deletes orphaned `content_collection` rows
- Return `200 {"success": true}` (was `204 Void`), matching the `deleteTag` / `deletePerson` / `deleteLocation` pattern so the frontend can reload on success
- Content (images) intentionally orphaned, not deleted, per spec

## Test plan

- [ ] Extended `CollectionServiceTest` — disassociation logic, ordering, parent recount after delete
- [ ] Updated `CollectionControllerDevTest` — expects `200` with `{"success": true}` body (was `204`)
- [ ] Full `mvnw clean verify` green: 661 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)