### PR TITLE
perf(content): batch-convert searchImages results to kill N+1

### DIFF
--- a/src/main/java/edens/zac/portfolio/backend/services/ContentService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/ContentService.java
@@ -391,10 +391,10 @@ public class ContentService {
     long totalElements = contentRepository.countSearchImages(request);
     int totalPages = limit > 0 ? (int) Math.ceil((double) totalElements / limit) : 0;
 
+    // Batch-convert (3 queries total for tags/people/locations) instead of mapping each entity
+    // through the singular converter, which fires 3 per-image queries -> N+1 on large pages.
     List<ContentModels.Image> images =
-        entities.stream()
-            .map(contentModelConverter::convertImageEntityToModel)
-            .collect(Collectors.toList());
+        contentModelConverter.batchConvertImageEntitiesToModels(entities);
 
     return new ImageSearchResponse(images, totalElements, totalPages);
   }

--- a/src/test/java/edens/zac/portfolio/backend/services/ContentServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/ContentServiceTest.java
@@ -3,6 +3,7 @@ package edens.zac.portfolio.backend.services;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -20,6 +21,8 @@ import edens.zac.portfolio.backend.model.CollectionRequests;
 import edens.zac.portfolio.backend.model.ContentImageUpdateRequest;
 import edens.zac.portfolio.backend.model.ContentModels;
 import edens.zac.portfolio.backend.model.ContentRequests;
+import edens.zac.portfolio.backend.model.ImageSearchRequest;
+import edens.zac.portfolio.backend.model.ImageSearchResponse;
 import edens.zac.portfolio.backend.services.validator.ContentImageUpdateValidator;
 import edens.zac.portfolio.backend.services.validator.ContentValidator;
 import edens.zac.portfolio.backend.types.ContentType;
@@ -72,6 +75,35 @@ class ContentServiceTest {
             contentValidator,
             metadataService,
             "cloudfront.example.com");
+  }
+
+  @Test
+  @DisplayName("searchImages converts via the batch path, never the per-image N+1 path")
+  void searchImages_usesBatchConverter() {
+    ImageSearchRequest request =
+        new ImageSearchRequest(null, null, null, null, null, null, null, null, null, null, 0, 50);
+
+    ContentImageEntity image1 =
+        ContentImageEntity.builder().id(1L).contentType(ContentType.IMAGE).build();
+    ContentImageEntity image2 =
+        ContentImageEntity.builder().id(2L).contentType(ContentType.IMAGE).build();
+    List<ContentImageEntity> entities = List.of(image1, image2);
+
+    when(contentRepository.searchImages(request, 50, 0)).thenReturn(entities);
+    when(contentRepository.countSearchImages(request)).thenReturn(2L);
+    when(contentModelConverter.batchConvertImageEntitiesToModels(entities))
+        .thenReturn(List.of(stubImageModel(1L), stubImageModel(2L)));
+
+    ImageSearchResponse response = service.searchImages(request);
+
+    assertThat(response.content()).hasSize(2);
+    assertThat(response.totalElements()).isEqualTo(2L);
+    assertThat(response.totalPages()).isEqualTo(1);
+
+    // Batch conversion (3 queries total) must be used; the per-image path (3 queries/image) must
+    // never be hit, otherwise a page of N images costs 3N queries against the remote database.
+    verify(contentModelConverter).batchConvertImageEntitiesToModels(entities);
+    verify(contentModelConverter, never()).convertImageEntityToModel(any());
   }
 
   @Test


### PR DESCRIPTION
ContentService.searchImages mapped each entity through the singular convertImageEntityToModel, which fires 3 per-image queries (tags, people, locations). A page of N images cost 2 + 3N queries against the remote DB -- 602 at the max page size of 200 -- making the /all-images initial load take seconds.

Switch to the existing batchConvertImageEntitiesToModels (already used by the orphan-images path), which batch-loads tags/people/ locations in 3 queries total. Per-page cost drops to a constant 5 regardless of page size.

Add ContentServiceTest.searchImages_usesBatchConverter asserting the batch path is used and the per-image path never is.