### PR TITLE
feat(collection): include coverImageUrl in siblings DTO

### DIFF
--- a/src/main/java/edens/zac/portfolio/backend/dao/CollectionSiblingRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/CollectionSiblingRepository.java
@@ -18,13 +18,16 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 public class CollectionSiblingRepository extends BaseDao {
 
-  private static final RowMapper<Records.CollectionList> SIBLING_ROW_MAPPER =
-      (rs, rowNum) ->
-          new Records.CollectionList(
-              rs.getLong("id"),
-              rs.getString("name"),
-              rs.getString("slug"),
-              CollectionType.valueOf(rs.getString("type")));
+  private static final RowMapper<Records.SiblingRow> SIBLING_ROW_MAPPER =
+      (rs, rowNum) -> {
+        long coverImageId = rs.getLong("cover_image_id");
+        return new Records.SiblingRow(
+            rs.getLong("id"),
+            rs.getString("name"),
+            rs.getString("slug"),
+            CollectionType.valueOf(rs.getString("type")),
+            rs.wasNull() ? null : coverImageId);
+      };
 
   public CollectionSiblingRepository(JdbcTemplate jdbcTemplate) {
     super(jdbcTemplate);
@@ -54,14 +57,16 @@ public class CollectionSiblingRepository extends BaseDao {
   }
 
   /**
-   * Siblings of one collection as {@link Records.CollectionList} rows, ordered by title. When
-   * {@code listedOnly} is true, only LISTED siblings are returned (public read path); when false,
-   * every sibling regardless of visibility is returned (admin manage payload).
+   * Siblings of one collection as {@link Records.SiblingRow} projections (including the raw {@code
+   * cover_image_id}), ordered by title. When {@code listedOnly} is true, only LISTED siblings are
+   * returned (public read path); when false, every sibling regardless of visibility is returned
+   * (admin manage payload). Cover image URLs are resolved separately in a batch by the caller to
+   * avoid N+1.
    */
   @Transactional(readOnly = true)
-  public List<Records.CollectionList> findSiblings(Long collectionId, boolean listedOnly) {
+  public List<Records.SiblingRow> findSiblings(Long collectionId, boolean listedOnly) {
     String sql =
-        "SELECT c.id, c.title AS name, c.slug, c.type "
+        "SELECT c.id, c.title AS name, c.slug, c.type, c.cover_image_id "
             + "FROM collection_sibling cs "
             + "JOIN collection c ON c.id = cs.sibling_collection_id "
             + "WHERE cs.collection_id = :id "

--- a/src/main/java/edens/zac/portfolio/backend/model/Records.java
+++ b/src/main/java/edens/zac/portfolio/backend/model/Records.java
@@ -65,16 +65,41 @@ public final class Records {
 
   /**
    * Model representing a collection for list views. Contains the collection's ID, name, slug, type,
-   * and collection date (serialized as an ISO date string; null when not projected).
+   * collection date (serialized as an ISO date string; null when not projected), and an optional
+   * cover image URL (null when the collection has no cover image or it was not projected). The
+   * cover image lets the frontend render related/sibling collections as image cards rather than
+   * text links.
    */
   public record CollectionList(
-      Long id, String name, String slug, CollectionType type, LocalDate collectionDate) {
+      Long id,
+      String name,
+      String slug,
+      CollectionType type,
+      LocalDate collectionDate,
+      String coverImageUrl) {
 
-    /** Backwards-compatible constructor for callers that omit the collection date. */
+    /** Backwards-compatible constructor for callers that omit the cover image URL. */
+    public CollectionList(
+        Long id, String name, String slug, CollectionType type, LocalDate collectionDate) {
+      this(id, name, slug, type, collectionDate, null);
+    }
+
+    /**
+     * Backwards-compatible constructor for callers that omit the collection date and cover image.
+     */
     public CollectionList(Long id, String name, String slug, CollectionType type) {
-      this(id, name, slug, type, null);
+      this(id, name, slug, type, null, null);
     }
   }
+
+  /**
+   * Internal projection of a sibling collection row. Carries the raw {@code coverImageId} (FK to
+   * the content image table) instead of a resolved URL so the cover image URLs can be batch-loaded
+   * in a single query (avoiding N+1), then mapped into {@link CollectionList} records. Not
+   * serialized to API responses directly.
+   */
+  public record SiblingRow(
+      Long id, String name, String slug, CollectionType type, Long coverImageId) {}
 
   /** DTO for admin hub tile configuration. coverImageUrl is null when no image is assigned. */
   public record AdminHomeTileResponse(String tileKey, String coverImageUrl, int displayOrder) {}

--- a/src/main/java/edens/zac/portfolio/backend/services/CollectionProcessingUtil.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/CollectionProcessingUtil.java
@@ -416,12 +416,50 @@ public class CollectionProcessingUtil {
    * Populate {@code model.siblings} from the collection_sibling join. {@code listedOnly=true} on
    * the public read path (LISTED siblings only — no dead links leak); {@code listedOnly=false} on
    * the admin manage payload. No-op when the model or its id is null.
+   *
+   * <p>Cover image URLs are batch-loaded in a single query (mirroring {@link
+   * #convertToChildCollection}) so siblings can be rendered as cover-image cards on the frontend
+   * without an N+1. The {@code coverImageUrl} on each {@link Records.CollectionList} is null when
+   * the sibling has no cover image assigned.
    */
   public void populateSiblings(CollectionModel model, boolean listedOnly) {
     if (model == null || model.getId() == null) {
       return;
     }
-    model.setSiblings(collectionSiblingRepository.findSiblings(model.getId(), listedOnly));
+
+    List<Records.SiblingRow> siblingRows =
+        collectionSiblingRepository.findSiblings(model.getId(), listedOnly);
+
+    // Batch-load cover image URLs for all siblings that have a cover image.
+    List<Long> coverImageIds =
+        siblingRows.stream()
+            .map(Records.SiblingRow::coverImageId)
+            .filter(Objects::nonNull)
+            .distinct()
+            .toList();
+
+    Map<Long, String> coverImageUrlsById =
+        coverImageIds.isEmpty()
+            ? Collections.emptyMap()
+            : contentRepository.findImagesByIds(coverImageIds).stream()
+                .collect(
+                    Collectors.toMap(
+                        ContentImageEntity::getId, ContentImageEntity::getImageUrlWeb));
+
+    List<Records.CollectionList> siblings =
+        siblingRows.stream()
+            .map(
+                row -> {
+                  String coverImageUrl =
+                      row.coverImageId() != null
+                          ? coverImageUrlsById.get(row.coverImageId())
+                          : null;
+                  return new Records.CollectionList(
+                      row.id(), row.name(), row.slug(), row.type(), null, coverImageUrl);
+                })
+            .toList();
+
+    model.setSiblings(siblings);
   }
 
   /**

--- a/src/test/java/edens/zac/portfolio/backend/controller/prod/CollectionControllerProdTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/prod/CollectionControllerProdTest.java
@@ -257,7 +257,14 @@ class CollectionControllerProdTest {
             .siblings(
                 List.of(
                     new Records.CollectionList(
-                        2L, "Dolomites Film", "dolomites-film", CollectionType.PORTFOLIO)))
+                        2L,
+                        "Dolomites Film",
+                        "dolomites-film",
+                        CollectionType.PORTFOLIO,
+                        null,
+                        "https://cdn.example.com/dolomites-film-cover.jpg"),
+                    new Records.CollectionList(
+                        3L, "Alps Digital", "alps-digital", CollectionType.PORTFOLIO)))
             .build();
     when(collectionService.getCollectionWithPagination(eq("dolomites"), anyInt(), anyInt()))
         .thenReturn(model);
@@ -266,9 +273,16 @@ class CollectionControllerProdTest {
     mockMvc
         .perform(get("/api/read/collections/dolomites"))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.siblings", hasSize(1)))
+        .andExpect(jsonPath("$.siblings", hasSize(2)))
         .andExpect(jsonPath("$.siblings[0].slug", is("dolomites-film")))
-        .andExpect(jsonPath("$.siblings[0].name", is("Dolomites Film")));
+        .andExpect(jsonPath("$.siblings[0].name", is("Dolomites Film")))
+        .andExpect(jsonPath("$.siblings[0].type", is("PORTFOLIO")))
+        .andExpect(
+            jsonPath(
+                "$.siblings[0].coverImageUrl",
+                is("https://cdn.example.com/dolomites-film-cover.jpg")))
+        .andExpect(jsonPath("$.siblings[1].slug", is("alps-digital")))
+        .andExpect(jsonPath("$.siblings[1].coverImageUrl").value(nullValue()));
   }
 
   @Test

--- a/src/test/java/edens/zac/portfolio/backend/dao/CollectionSiblingRepositoryTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/dao/CollectionSiblingRepositoryTest.java
@@ -94,12 +94,13 @@ class CollectionSiblingRepositoryTest {
       when(namedParameterJdbcTemplate.query(
               anyString(), any(MapSqlParameterSource.class), any(RowMapper.class)))
           .thenReturn(List.of());
-      List<Records.CollectionList> result = repository.findSiblings(7L, true);
+      List<Records.SiblingRow> result = repository.findSiblings(7L, true);
       assertThat(result).isEmpty();
       verify(namedParameterJdbcTemplate)
           .query(sqlCaptor.capture(), paramsCaptor.capture(), any(RowMapper.class));
       String sql = sqlCaptor.getValue();
-      assertThat(sql).containsIgnoringCase("SELECT c.id, c.title AS name, c.slug, c.type");
+      assertThat(sql)
+          .containsIgnoringCase("SELECT c.id, c.title AS name, c.slug, c.type, c.cover_image_id");
       assertThat(sql).containsIgnoringCase("FROM collection_sibling cs");
       assertThat(sql).containsIgnoringCase("JOIN collection c ON c.id = cs.sibling_collection_id");
       assertThat(sql).containsIgnoringCase("WHERE cs.collection_id = :id");

--- a/src/test/java/edens/zac/portfolio/backend/services/CollectionProcessingUtilTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/CollectionProcessingUtilTest.java
@@ -2,6 +2,7 @@ package edens.zac.portfolio.backend.services;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.*;
 
 import edens.zac.portfolio.backend.dao.CollectionPeopleRepository;
@@ -13,6 +14,7 @@ import edens.zac.portfolio.backend.dao.PersonRepository;
 import edens.zac.portfolio.backend.dao.TagRepository;
 import edens.zac.portfolio.backend.entity.CollectionEntity;
 import edens.zac.portfolio.backend.entity.ContentEntity;
+import edens.zac.portfolio.backend.entity.ContentImageEntity;
 import edens.zac.portfolio.backend.entity.ContentTextEntity;
 import edens.zac.portfolio.backend.model.CollectionModel;
 import edens.zac.portfolio.backend.model.Records;
@@ -157,18 +159,58 @@ class CollectionProcessingUtilTest {
   }
 
   @Test
-  void populateSiblings_listedOnlyTrue_setsResultFromRepository() {
+  void populateSiblings_listedOnlyTrue_resolvesCoverImageUrlInBatch() {
     CollectionModel model = CollectionModel.builder().id(5L).build();
-    List<Records.CollectionList> siblings =
+    // Sibling 9 has cover image 100; sibling 11 has none.
+    List<Records.SiblingRow> rows =
         List.of(
-            new Records.CollectionList(
-                9L, "Dolomites Film", "dolomites-film", CollectionType.PORTFOLIO));
-    when(collectionSiblingRepository.findSiblings(5L, true)).thenReturn(siblings);
+            new Records.SiblingRow(
+                9L, "Dolomites Film", "dolomites-film", CollectionType.PORTFOLIO, 100L),
+            new Records.SiblingRow(
+                11L, "Alps Digital", "alps-digital", CollectionType.PORTFOLIO, null));
+    when(collectionSiblingRepository.findSiblings(5L, true)).thenReturn(rows);
+
+    ContentImageEntity cover =
+        ContentImageEntity.builder()
+            .id(100L)
+            .imageUrlWeb("https://cdn.example.com/dolomites-film-cover.jpg")
+            .build();
+    when(contentRepository.findImagesByIds(List.of(100L))).thenReturn(List.of(cover));
 
     util.populateSiblings(model, true);
 
-    assertThat(model.getSiblings()).isEqualTo(siblings);
+    assertThat(model.getSiblings()).hasSize(2);
+    Records.CollectionList withCover = model.getSiblings().get(0);
+    assertThat(withCover.id()).isEqualTo(9L);
+    assertThat(withCover.name()).isEqualTo("Dolomites Film");
+    assertThat(withCover.slug()).isEqualTo("dolomites-film");
+    assertThat(withCover.type()).isEqualTo(CollectionType.PORTFOLIO);
+    assertThat(withCover.coverImageUrl())
+        .isEqualTo("https://cdn.example.com/dolomites-film-cover.jpg");
+
+    Records.CollectionList withoutCover = model.getSiblings().get(1);
+    assertThat(withoutCover.id()).isEqualTo(11L);
+    assertThat(withoutCover.coverImageUrl()).isNull();
+
     verify(collectionSiblingRepository).findSiblings(5L, true);
+    verify(contentRepository).findImagesByIds(List.of(100L));
+  }
+
+  @Test
+  void populateSiblings_noCoverImages_skipsImageLookup() {
+    CollectionModel model = CollectionModel.builder().id(5L).build();
+    List<Records.SiblingRow> rows =
+        List.of(
+            new Records.SiblingRow(
+                11L, "Alps Digital", "alps-digital", CollectionType.PORTFOLIO, null));
+    when(collectionSiblingRepository.findSiblings(5L, false)).thenReturn(rows);
+
+    util.populateSiblings(model, false);
+
+    assertThat(model.getSiblings()).hasSize(1);
+    assertThat(model.getSiblings().get(0).coverImageUrl()).isNull();
+    // No cover image ids -> no batch image lookup at all.
+    verify(contentRepository, never()).findImagesByIds(anyList());
   }
 
   @Test


### PR DESCRIPTION
Adds `coverImageUrl` to the **siblings** (related collections) DTO so the frontend can render related collections as cover-image cards instead of plain text links. Pairs with frontend PR themancalledzac/edens.zac#183.

## Changes
- `Records.CollectionList` gains a nullable `String coverImageUrl` (back-compat constructors keep the other callers — parents/metadata/admin — compiling with `null`). `CollectionType type` was already present (used for labeling).
- `CollectionSiblingRepository.findSiblings` now selects `c.cover_image_id` and returns `Records.SiblingRow` (internal projection).
- `CollectionProcessingUtil.populateSiblings` batch-loads cover-image URLs in **one** query (`findImagesByIds`) and resolves each sibling's `coverImageUrl` — no N+1, mirroring `convertToChildCollection`.

## Tests
Full suite **669 green** (0 failures); targeted siblings tests assert `coverImageUrl` is resolved when a sibling has a cover image and `null` otherwise, plus controller JSON serialization of `siblings[].coverImageUrl` + `.type`.

## Notes
- Supersedes the original siblings branch `0144-sibling-collections` (which had no cover-image-on-sibling work).
- Null `coverImageUrl` serializes as explicit JSON `null` (no `NON_NULL` config); the frontend treats null/absent identically → text-link fallback.
- **Deploy this before the frontend cards render real images.** Cover URLs are CloudFront (`imageUrlWeb`), which the frontend `next/image` already whitelists.
