### PR TITLE
feat(auth): Auth Foundation (Phase F) — Spring Security, DB sessions, passkeys

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,11 @@
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.webauthn4j</groupId>
+            <artifactId>webauthn4j-core</artifactId>
+            <version>0.29.7.RELEASE</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,30 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- WebP ImageIO plugin with read AND write support -->
         <dependency>
             <groupId>org.sejda.imageio</groupId>

--- a/src/main/java/edens/zac/portfolio/backend/config/AuthLoginLimiter.java
+++ b/src/main/java/edens/zac/portfolio/backend/config/AuthLoginLimiter.java
@@ -1,0 +1,59 @@
+package edens.zac.portfolio.backend.config;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.time.Duration;
+import java.util.Locale;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthLoginLimiter {
+
+  private final int maxAttempts;
+  private final Cache<String, Integer> failures;
+
+  @Autowired
+  public AuthLoginLimiter(
+      @Value("${app.auth.login.max-attempts:5}") int maxAttempts,
+      @Value("${app.auth.login.window-minutes:15}") int windowMinutes) {
+    this.maxAttempts = maxAttempts;
+    this.failures =
+        Caffeine.newBuilder()
+            .expireAfterWrite(Duration.ofMinutes(windowMinutes))
+            .maximumSize(10_000)
+            .build();
+  }
+
+  public boolean isBlocked(String ip, String email) {
+    String key = key(ip, email);
+    if (key == null) {
+      return false;
+    }
+    Integer count = failures.getIfPresent(key);
+    return count != null && count >= maxAttempts;
+  }
+
+  public void recordFailure(String ip, String email) {
+    String key = key(ip, email);
+    if (key == null) {
+      return;
+    }
+    failures.asMap().merge(key, 1, Integer::sum);
+  }
+
+  public void reset(String ip, String email) {
+    String key = key(ip, email);
+    if (key != null) {
+      failures.invalidate(key);
+    }
+  }
+
+  private static String key(String ip, String email) {
+    if (ip == null || ip.isBlank() || email == null || email.isBlank()) {
+      return null;
+    }
+    return ip.trim() + "|" + email.trim().toLowerCase(Locale.ROOT);
+  }
+}

--- a/src/main/java/edens/zac/portfolio/backend/config/InternalSecretFilter.java
+++ b/src/main/java/edens/zac/portfolio/backend/config/InternalSecretFilter.java
@@ -24,7 +24,7 @@ import org.springframework.stereotype.Component;
  * or {@code internal.api.secret.next} (the rotation candidate). Both are compared in constant time.
  */
 @Component
-@Order(1)
+@Order(-200)
 @Profile("prod")
 @Slf4j
 public class InternalSecretFilter implements Filter {

--- a/src/main/java/edens/zac/portfolio/backend/config/JdbcPublicKeyCredentialUserEntityRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/config/JdbcPublicKeyCredentialUserEntityRepository.java
@@ -1,0 +1,96 @@
+package edens.zac.portfolio.backend.config;
+
+import edens.zac.portfolio.backend.dao.AppUserRepository;
+import edens.zac.portfolio.backend.entity.AppUserEntity;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.web.webauthn.api.Bytes;
+import org.springframework.security.web.webauthn.api.ImmutablePublicKeyCredentialUserEntity;
+import org.springframework.security.web.webauthn.api.PublicKeyCredentialUserEntity;
+import org.springframework.security.web.webauthn.management.PublicKeyCredentialUserEntityRepository;
+import org.springframework.stereotype.Component;
+
+/**
+ * Adapts Spring Security's {@link PublicKeyCredentialUserEntityRepository} onto {@code app_user}.
+ * The WebAuthn user handle is {@code app_user.webauthn_user_handle} (a UUID) encoded as UTF-8 bytes
+ * so the WebAuthn {@link Bytes} id round-trips to the UUID; the user {@code name} is the email (no
+ * separate username concept — admin/client identity is the email).
+ *
+ * <p>{@code app_user} rows are provisioned out-of-band (AdminBootstrap / client onboarding), so
+ * {@link #save(PublicKeyCredentialUserEntity)} and {@link #delete(Bytes)} are no-ops here, but the
+ * SPI requires the methods. The operations engine calls {@code save} for an unknown username when
+ * minting login options; the no-op (combined with the credential-less allow-list) keeps login
+ * anti-enumeration intact without creating a row.
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class JdbcPublicKeyCredentialUserEntityRepository
+    implements PublicKeyCredentialUserEntityRepository {
+
+  private final AppUserRepository appUserRepository;
+
+  private static PublicKeyCredentialUserEntity toEntity(AppUserEntity user) {
+    return ImmutablePublicKeyCredentialUserEntity.builder()
+        .id(new Bytes(user.getWebauthnUserHandle().toString().getBytes(StandardCharsets.UTF_8)))
+        .name(user.getEmail())
+        .displayName(user.getDisplayName() != null ? user.getDisplayName() : user.getEmail())
+        .build();
+  }
+
+  @Override
+  public PublicKeyCredentialUserEntity findById(Bytes id) {
+    return parseHandle(id)
+        .flatMap(appUserRepository::findByWebauthnUserHandle)
+        .map(JdbcPublicKeyCredentialUserEntityRepository::toEntity)
+        .orElse(null);
+  }
+
+  @Override
+  public PublicKeyCredentialUserEntity findByUsername(String username) {
+    return appUserRepository
+        .findByEmail(username)
+        .map(JdbcPublicKeyCredentialUserEntityRepository::toEntity)
+        .orElse(null);
+  }
+
+  @Override
+  public void save(PublicKeyCredentialUserEntity userEntity) {
+    // No-op: app_user rows are provisioned by AdminBootstrap / client onboarding, not by the
+    // WebAuthn ceremony. The user must already exist before registration starts. The operations
+    // engine also invokes save() for an unknown username while minting login options; we do not
+    // persist here (anti-enumeration: no account is created from a login attempt).
+    Optional.ofNullable(userEntity)
+        .ifPresent(
+            u -> log.debug("WebAuthn save() ignored for user handle (provisioned out-of-band)"));
+  }
+
+  @Override
+  public void delete(Bytes id) {
+    // No-op: WebAuthn user-entity deletion is an out-of-band credential-management concern.
+    log.debug("WebAuthn user-entity delete() ignored");
+  }
+
+  /**
+   * Decode a WebAuthn {@link Bytes} id back to our {@code webauthn_user_handle} UUID. Returns empty
+   * when the bytes are not a valid UUID string (e.g. the random handle the operations engine mints
+   * for an unknown username during login-options) so callers resolve to "not found" rather than
+   * throwing — this preserves login anti-enumeration.
+   *
+   * @param id the WebAuthn user-handle bytes
+   * @return the decoded UUID, or empty if the bytes are not a UUID string
+   */
+  static Optional<UUID> parseHandle(Bytes id) {
+    if (id == null) {
+      return Optional.empty();
+    }
+    try {
+      return Optional.of(UUID.fromString(new String(id.getBytes(), StandardCharsets.UTF_8)));
+    } catch (IllegalArgumentException ex) {
+      return Optional.empty();
+    }
+  }
+}

--- a/src/main/java/edens/zac/portfolio/backend/config/JdbcUserCredentialRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/config/JdbcUserCredentialRepository.java
@@ -1,0 +1,119 @@
+package edens.zac.portfolio.backend.config;
+
+import edens.zac.portfolio.backend.dao.AppUserRepository;
+import edens.zac.portfolio.backend.dao.WebAuthnCredentialRepository;
+import edens.zac.portfolio.backend.entity.AppUserEntity;
+import edens.zac.portfolio.backend.entity.WebAuthnCredentialEntity;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.web.webauthn.api.Bytes;
+import org.springframework.security.web.webauthn.api.CredentialRecord;
+import org.springframework.security.web.webauthn.api.ImmutableCredentialRecord;
+import org.springframework.security.web.webauthn.api.ImmutablePublicKeyCose;
+import org.springframework.security.web.webauthn.api.PublicKeyCredentialType;
+import org.springframework.security.web.webauthn.management.UserCredentialRepository;
+import org.springframework.stereotype.Component;
+
+/**
+ * Adapts Spring Security's {@link UserCredentialRepository} onto {@code webauthn_credential} (via
+ * the JDBC {@link WebAuthnCredentialRepository}) and {@code app_user} (to map our {@code user_id}
+ * back to the WebAuthn user handle).
+ *
+ * <p>{@link #save(CredentialRecord)} handles both registration (insert) and assertion sign-count
+ * bumps (update). {@link #delete(Bytes)} is a no-op (credential management is an out-of-band
+ * concern). The WebAuthn user handle is {@code webauthn_user_handle} encoded as UTF-8 bytes; an id
+ * that is not a valid UUID string (e.g. the random handle the operations engine mints for an
+ * unknown username while building login options) resolves to an empty credential list rather than
+ * throwing — this keeps login anti-enumeration intact.
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class JdbcUserCredentialRepository implements UserCredentialRepository {
+
+  private final WebAuthnCredentialRepository credentialRepository;
+  private final AppUserRepository appUserRepository;
+
+  private CredentialRecord toRecord(WebAuthnCredentialEntity entity) {
+    AppUserEntity user =
+        appUserRepository
+            .findById(entity.getUserId())
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "Credential references missing app_user: " + entity.getUserId()));
+    Bytes userHandle =
+        new Bytes(user.getWebauthnUserHandle().toString().getBytes(StandardCharsets.UTF_8));
+    return ImmutableCredentialRecord.builder()
+        .credentialType(PublicKeyCredentialType.PUBLIC_KEY)
+        .credentialId(new Bytes(entity.getCredentialId()))
+        .userEntityUserId(userHandle)
+        .publicKey(new ImmutablePublicKeyCose(entity.getPublicKey()))
+        .signatureCount(entity.getSignCount())
+        .build();
+  }
+
+  @Override
+  public void save(CredentialRecord record) {
+    byte[] credId = record.getCredentialId().getBytes();
+    UUID handle =
+        JdbcPublicKeyCredentialUserEntityRepository.parseHandle(record.getUserEntityUserId())
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "WebAuthn credential has no valid user handle: "
+                            + record.getUserEntityUserId()));
+    AppUserEntity user =
+        appUserRepository
+            .findByWebauthnUserHandle(handle)
+            .orElseThrow(
+                () -> new IllegalStateException("No app_user for WebAuthn handle: " + handle));
+
+    credentialRepository
+        .findByCredentialId(credId)
+        .ifPresentOrElse(
+            existing ->
+                credentialRepository.updateSignCountAndLastUsed(
+                    existing.getId(),
+                    record.getSignatureCount(),
+                    LocalDateTime.now(ZoneOffset.UTC)),
+            () ->
+                credentialRepository.insert(
+                    WebAuthnCredentialEntity.builder()
+                        .userId(user.getId())
+                        .credentialId(credId)
+                        .publicKey(record.getPublicKey().getBytes())
+                        .signCount(record.getSignatureCount())
+                        .label(record.getLabel())
+                        .build()));
+  }
+
+  @Override
+  public void delete(Bytes credentialId) {
+    log.debug("WebAuthn credential delete() ignored");
+  }
+
+  @Override
+  public CredentialRecord findByCredentialId(Bytes credentialId) {
+    return credentialRepository
+        .findByCredentialId(credentialId.getBytes())
+        .map(this::toRecord)
+        .orElse(null);
+  }
+
+  @Override
+  public List<CredentialRecord> findByUserId(Bytes userId) {
+    return JdbcPublicKeyCredentialUserEntityRepository.parseHandle(userId)
+        .flatMap(appUserRepository::findByWebauthnUserHandle)
+        .map(user -> credentialRepository.findByUserId(user.getId()))
+        .orElseGet(List::of)
+        .stream()
+        .map(this::toRecord)
+        .toList();
+  }
+}

--- a/src/main/java/edens/zac/portfolio/backend/config/SecurityConfig.java
+++ b/src/main/java/edens/zac/portfolio/backend/config/SecurityConfig.java
@@ -1,0 +1,73 @@
+package edens.zac.portfolio.backend.config;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.intercept.AuthorizationFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+public class SecurityConfig {
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http, SessionAuthenticationFilter saf)
+      throws Exception {
+    http
+        // CSRF defense for the API is provided by SameSite=Strict cookies + the BFF write-method
+        // Origin allowlist; the stateless API has no server-side CSRF token to validate.
+        .csrf(csrf -> csrf.disable())
+        .formLogin(form -> form.disable())
+        .httpBasic(basic -> basic.disable())
+        .logout(logout -> logout.disable())
+        .sessionManagement(
+            session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .authorizeHttpRequests(
+            auth ->
+                auth.requestMatchers(HttpMethod.POST, "/api/auth/login")
+                    .permitAll()
+                    .requestMatchers("/api/auth/webauthn/login/**")
+                    .permitAll()
+                    .requestMatchers("/api/auth/me", "/api/auth/logout")
+                    .authenticated()
+                    .requestMatchers("/api/auth/webauthn/register/**")
+                    .authenticated()
+                    .anyRequest()
+                    .permitAll())
+        .addFilterBefore(saf, AuthorizationFilter.class)
+        .exceptionHandling(
+            ex ->
+                ex.authenticationEntryPoint(
+                    (request, response, authException) -> response.sendError(401)));
+    return http.build();
+  }
+
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+  }
+
+  /**
+   * Suppress Spring Boot's automatic standalone servlet-filter registration of
+   * SessionAuthenticationFilter. Without this, the @Component annotation causes the filter to be
+   * registered as a raw servlet filter for ALL requests AND also inside the SecurityFilterChain via
+   * addFilterBefore — running it twice. Disabling the auto-registration ensures the filter runs
+   * exactly once, inside the chain only.
+   */
+  @Bean
+  public FilterRegistrationBean<SessionAuthenticationFilter>
+      sessionAuthenticationFilterRegistration(SessionAuthenticationFilter filter) {
+    FilterRegistrationBean<SessionAuthenticationFilter> registration =
+        new FilterRegistrationBean<>(filter);
+    registration.setEnabled(false);
+    return registration;
+  }
+}

--- a/src/main/java/edens/zac/portfolio/backend/config/SessionAuthenticationFilter.java
+++ b/src/main/java/edens/zac/portfolio/backend/config/SessionAuthenticationFilter.java
@@ -1,0 +1,61 @@
+package edens.zac.portfolio.backend.config;
+
+import edens.zac.portfolio.backend.model.AuthPrincipal;
+import edens.zac.portfolio.backend.services.SessionService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class SessionAuthenticationFilter extends OncePerRequestFilter {
+
+  private static final String COOKIE_NAME = "ezac_session";
+
+  private final SessionService sessionService;
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    String token = readCookie(request);
+    if (token != null) {
+      Optional<AuthPrincipal> principal = sessionService.resolve(token);
+      principal.ifPresent(
+          p -> {
+            var auth =
+                new UsernamePasswordAuthenticationToken(
+                    p, null, List.of(new SimpleGrantedAuthority("ROLE_" + p.role().name())));
+            SecurityContext context = SecurityContextHolder.createEmptyContext();
+            context.setAuthentication(auth);
+            SecurityContextHolder.setContext(context);
+          });
+    }
+    filterChain.doFilter(request, response);
+  }
+
+  private static String readCookie(HttpServletRequest request) {
+    Cookie[] cookies = request.getCookies();
+    if (cookies == null) {
+      return null;
+    }
+    for (Cookie cookie : cookies) {
+      if (COOKIE_NAME.equals(cookie.getName())) {
+        return cookie.getValue();
+      }
+    }
+    return null;
+  }
+}

--- a/src/main/java/edens/zac/portfolio/backend/config/WebAuthnConfig.java
+++ b/src/main/java/edens/zac/portfolio/backend/config/WebAuthnConfig.java
@@ -1,0 +1,89 @@
+package edens.zac.portfolio.backend.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.web.webauthn.api.PublicKeyCredentialRpEntity;
+import org.springframework.security.web.webauthn.jackson.WebauthnJackson2Module;
+import org.springframework.security.web.webauthn.management.PublicKeyCredentialUserEntityRepository;
+import org.springframework.security.web.webauthn.management.UserCredentialRepository;
+import org.springframework.security.web.webauthn.management.WebAuthnRelyingPartyOperations;
+import org.springframework.security.web.webauthn.management.Webauthn4JRelyingPartyOperations;
+
+/**
+ * Wires the programmatic Spring Security WebAuthn engine (NOT the {@code http.webAuthn()} DSL): the
+ * relying-party entity (from {@code app.auth.webauthn.rp-id}/{@code rp-name}), the allowed-origins
+ * set (from {@code app.auth.webauthn.allowed-origins}), the {@link WebAuthnRelyingPartyOperations}
+ * bean, and a WebAuthn-aware {@link ObjectMapper} for (de)serializing the W3C ceremony JSON bodies.
+ */
+@Configuration
+public class WebAuthnConfig {
+
+  /**
+   * The relying-party entity (rp-id + display name) used by the operations engine.
+   *
+   * @param rpId the relying-party id (effective domain, e.g. {@code localhost} in dev)
+   * @param rpName the human-readable relying-party display name
+   * @return the immutable RP entity
+   */
+  @Bean
+  public PublicKeyCredentialRpEntity webAuthnRpEntity(
+      @Value("${app.auth.webauthn.rp-id}") String rpId,
+      @Value("${app.auth.webauthn.rp-name}") String rpName) {
+    return PublicKeyCredentialRpEntity.builder().id(rpId).name(rpName).build();
+  }
+
+  /**
+   * The set of allowed origins the operations engine validates assertions/attestations against.
+   *
+   * @param allowedOriginsCsv comma-separated list of allowed origins
+   * @return an ordered set of trimmed, non-empty origins
+   */
+  @Bean("webAuthnAllowedOrigins")
+  public Set<String> webAuthnAllowedOrigins(
+      @Value("${app.auth.webauthn.allowed-origins}") String allowedOriginsCsv) {
+    Set<String> origins = new LinkedHashSet<>();
+    Arrays.stream(allowedOriginsCsv.split(","))
+        .map(String::trim)
+        .filter(s -> !s.isEmpty())
+        .forEach(origins::add);
+    return origins;
+  }
+
+  /**
+   * The WebAuthn relying-party operations engine, backed by our two JDBC SPI adapters.
+   *
+   * @param userEntities the {@code app_user}-backed user-entity repository
+   * @param userCredentials the {@code webauthn_credential}-backed credential repository
+   * @param rpEntity the relying-party entity
+   * @param allowedOrigins the allowed-origins set
+   * @return the configured operations engine
+   */
+  @Bean
+  public WebAuthnRelyingPartyOperations webAuthnRelyingPartyOperations(
+      PublicKeyCredentialUserEntityRepository userEntities,
+      UserCredentialRepository userCredentials,
+      PublicKeyCredentialRpEntity rpEntity,
+      @Qualifier("webAuthnAllowedOrigins") Set<String> allowedOrigins) {
+    return new Webauthn4JRelyingPartyOperations(
+        userEntities, userCredentials, rpEntity, allowedOrigins);
+  }
+
+  /**
+   * An {@link ObjectMapper} with the WebAuthn Jackson module registered, for (de)serializing the
+   * W3C {@code PublicKeyCredential<...>} ceremony JSON bodies.
+   *
+   * @return the WebAuthn-aware object mapper
+   */
+  @Bean("webAuthnObjectMapper")
+  public ObjectMapper webAuthnObjectMapper() {
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.registerModule(new WebauthnJackson2Module());
+    return mapper;
+  }
+}

--- a/src/main/java/edens/zac/portfolio/backend/config/WebAuthnConfig.java
+++ b/src/main/java/edens/zac/portfolio/backend/config/WebAuthnConfig.java
@@ -1,6 +1,6 @@
 package edens.zac.portfolio.backend.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.Module;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -19,7 +19,9 @@ import org.springframework.security.web.webauthn.management.Webauthn4JRelyingPar
  * Wires the programmatic Spring Security WebAuthn engine (NOT the {@code http.webAuthn()} DSL): the
  * relying-party entity (from {@code app.auth.webauthn.rp-id}/{@code rp-name}), the allowed-origins
  * set (from {@code app.auth.webauthn.allowed-origins}), the {@link WebAuthnRelyingPartyOperations}
- * bean, and a WebAuthn-aware {@link ObjectMapper} for (de)serializing the W3C ceremony JSON bodies.
+ * bean, and the {@link WebauthnJackson2Module} registered onto the application's primary {@link
+ * com.fasterxml.jackson.databind.ObjectMapper} via a {@link Module} bean (Spring Boot auto-applies
+ * all {@link Module} beans to its primary mapper, so no qualifier is needed at injection sites).
  */
 @Configuration
 public class WebAuthnConfig {
@@ -75,15 +77,16 @@ public class WebAuthnConfig {
   }
 
   /**
-   * An {@link ObjectMapper} with the WebAuthn Jackson module registered, for (de)serializing the
-   * W3C {@code PublicKeyCredential<...>} ceremony JSON bodies.
+   * Registers the {@link WebauthnJackson2Module} onto the application's primary {@link
+   * com.fasterxml.jackson.databind.ObjectMapper}. Spring Boot's {@code JacksonAutoConfiguration}
+   * applies every {@link Module} bean to its primary mapper, so all injection sites receive the
+   * same, fully-configured mapper with WebAuthn (de)serialization support — without suppressing the
+   * auto-configured primary mapper or changing any app-wide Jackson settings.
    *
-   * @return the WebAuthn-aware object mapper
+   * @return the WebAuthn Jackson module
    */
-  @Bean("webAuthnObjectMapper")
-  public ObjectMapper webAuthnObjectMapper() {
-    ObjectMapper mapper = new ObjectMapper();
-    mapper.registerModule(new WebauthnJackson2Module());
-    return mapper;
+  @Bean
+  public Module webauthnJackson2Module() {
+    return new WebauthnJackson2Module();
   }
 }

--- a/src/main/java/edens/zac/portfolio/backend/controller/auth/AuthController.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/auth/AuthController.java
@@ -1,0 +1,114 @@
+package edens.zac.portfolio.backend.controller.auth;
+
+import edens.zac.portfolio.backend.config.AuthLoginLimiter;
+import edens.zac.portfolio.backend.dao.AppUserRepository;
+import edens.zac.portfolio.backend.dao.GalleryAccessRepository;
+import edens.zac.portfolio.backend.entity.AppUserEntity;
+import edens.zac.portfolio.backend.model.AuthPrincipal;
+import edens.zac.portfolio.backend.model.GalleryAccessSummary;
+import edens.zac.portfolio.backend.model.LoginRequest;
+import edens.zac.portfolio.backend.model.MeResponse;
+import edens.zac.portfolio.backend.services.SessionService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+  private static final String COOKIE_NAME = "ezac_session";
+
+  private final SessionService sessionService;
+  private final AuthLoginLimiter loginLimiter;
+  private final AppUserRepository appUserRepository;
+  private final GalleryAccessRepository galleryAccessRepository;
+  private final PasswordEncoder passwordEncoder;
+
+  @PostMapping("/login")
+  public ResponseEntity<Void> login(
+      @Valid @RequestBody LoginRequest body,
+      HttpServletRequest request,
+      HttpServletResponse response) {
+    String ip = resolveClientIp(request);
+    String email = body.email();
+
+    if (loginLimiter.isBlocked(ip, email)) {
+      log.warn("Auth login rate-limited for email={} ip={}", email, ip);
+      return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).build();
+    }
+
+    Optional<AppUserEntity> maybeUser = appUserRepository.findByEmail(email);
+    if (maybeUser.isEmpty()
+        || maybeUser.get().getPasswordHash() == null
+        || !passwordEncoder.matches(body.password(), maybeUser.get().getPasswordHash())) {
+      loginLimiter.recordFailure(ip, email);
+      log.warn("Failed auth login for email={} ip={}", email, ip);
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+
+    loginLimiter.reset(ip, email);
+    sessionService.create(maybeUser.get(), false, request, response);
+    return ResponseEntity.noContent().build();
+  }
+
+  @PostMapping("/logout")
+  public ResponseEntity<Void> logout(HttpServletRequest request, HttpServletResponse response) {
+    sessionService.revoke(readCookie(request), response);
+    return ResponseEntity.noContent().build();
+  }
+
+  @GetMapping("/me")
+  public ResponseEntity<MeResponse> me() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication == null
+        || !(authentication.getPrincipal() instanceof AuthPrincipal principal)) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+    List<GalleryAccessSummary> galleries =
+        galleryAccessRepository.findByUserId(principal.userId()).stream()
+            .map(
+                g -> new GalleryAccessSummary(g.getCollectionId(), g.isCanDownload(), g.isCanTag()))
+            .toList();
+    return ResponseEntity.ok(
+        new MeResponse(principal.email(), principal.role(), principal.mfaSatisfied(), galleries));
+  }
+
+  private static String readCookie(HttpServletRequest request) {
+    Cookie[] cookies = request.getCookies();
+    if (cookies == null) {
+      return null;
+    }
+    for (Cookie cookie : cookies) {
+      if (COOKIE_NAME.equals(cookie.getName())) {
+        return cookie.getValue();
+      }
+    }
+    return null;
+  }
+
+  private static String resolveClientIp(HttpServletRequest request) {
+    String realIp = request.getHeader("X-Real-IP");
+    if (realIp != null && !realIp.isBlank()) {
+      return realIp.trim();
+    }
+    return request.getRemoteAddr();
+  }
+}

--- a/src/main/java/edens/zac/portfolio/backend/controller/auth/AuthController.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/auth/AuthController.java
@@ -36,6 +36,15 @@ public class AuthController {
 
   private static final String COOKIE_NAME = "ezac_session";
 
+  /**
+   * Precomputed BCrypt hash used to equalize the response time of the unknown-email branch with the
+   * wrong-password branch. Without this, an attacker could distinguish "no such user" (fast) from
+   * "wrong password" (slow BCrypt) via timing — a user-enumeration oracle. We always call {@code
+   * passwordEncoder.matches} and discard the result so both branches pay the same BCrypt cost.
+   */
+  private static final String DUMMY_HASH =
+      "{bcrypt}$2a$10$7EqJtq98hPqEX7fNZaFWoOe4LqswmsWnGKD.QZEWMbwIQfRoZxNfy";
+
   private final SessionService sessionService;
   private final AuthLoginLimiter loginLimiter;
   private final AppUserRepository appUserRepository;
@@ -56,9 +65,15 @@ public class AuthController {
     }
 
     Optional<AppUserEntity> maybeUser = appUserRepository.findByEmail(email);
-    if (maybeUser.isEmpty()
-        || maybeUser.get().getPasswordHash() == null
-        || !passwordEncoder.matches(body.password(), maybeUser.get().getPasswordHash())) {
+    if (maybeUser.isEmpty() || maybeUser.get().getPasswordHash() == null) {
+      // Perform a dummy BCrypt check so unknown-email and wrong-password branches take the same
+      // time — prevents user-enumeration via timing side-channel. The result is discarded.
+      passwordEncoder.matches(body.password(), DUMMY_HASH);
+      loginLimiter.recordFailure(ip, email);
+      log.warn("Failed auth login for email={} ip={}", email, ip);
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+    if (!passwordEncoder.matches(body.password(), maybeUser.get().getPasswordHash())) {
       loginLimiter.recordFailure(ip, email);
       log.warn("Failed auth login for email={} ip={}", email, ip);
       return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();

--- a/src/main/java/edens/zac/portfolio/backend/controller/auth/WebAuthnController.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/auth/WebAuthnController.java
@@ -1,0 +1,164 @@
+package edens.zac.portfolio.backend.controller.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edens.zac.portfolio.backend.model.AuthPrincipal;
+import edens.zac.portfolio.backend.services.WebAuthnService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.time.Duration;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.web.webauthn.api.PublicKeyCredentialCreationOptions;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * The four WebAuthn ceremony endpoints. Register endpoints require an authenticated principal
+ * (enforced by SecurityConfig's {@code /register/**} authenticated matcher); login endpoints are
+ * public (SecurityConfig's {@code /login/**} permitAll matcher). Options bodies are serialized with
+ * the WebAuthn {@link ObjectMapper} so the W3C field shapes survive. The login per-attempt id
+ * round-trips via a short-lived HttpOnly cookie ({@code ezac_webauthn_attempt}) so the frontend
+ * never couples to a custom header.
+ */
+@RestController
+@RequestMapping("/api/auth/webauthn")
+@Slf4j
+public class WebAuthnController {
+
+  private static final String ATTEMPT_COOKIE = "ezac_webauthn_attempt";
+  private static final String ATTEMPT_COOKIE_PATH = "/api/auth/webauthn";
+  private static final Duration ATTEMPT_COOKIE_TTL = Duration.ofMinutes(5);
+
+  private final WebAuthnService webAuthnService;
+  private final ObjectMapper webAuthnObjectMapper;
+
+  /**
+   * Whether the attempt cookie is set Secure. Mirrors SessionService's flag (true in prod; the dev
+   * profile overrides it to false so the cookie survives plain {@code http://localhost}).
+   */
+  private final boolean cookieSecure;
+
+  /**
+   * Constructor.
+   *
+   * @param webAuthnService the ceremony orchestration service
+   * @param webAuthnObjectMapper the WebAuthn-aware mapper for serializing the options bodies
+   * @param cookieSecure whether the attempt cookie is set Secure
+   */
+  public WebAuthnController(
+      WebAuthnService webAuthnService,
+      @Qualifier("webAuthnObjectMapper") ObjectMapper webAuthnObjectMapper,
+      @Value("${app.auth.cookie-secure:true}") boolean cookieSecure) {
+    this.webAuthnService = webAuthnService;
+    this.webAuthnObjectMapper = webAuthnObjectMapper;
+    this.cookieSecure = cookieSecure;
+  }
+
+  /**
+   * Mint registration (attestation) options for the authenticated admin.
+   *
+   * @param principal the authenticated principal (null if unauthenticated)
+   * @return 200 with the W3C creation options JSON, or 401 if unauthenticated
+   * @throws Exception if the options cannot be serialized
+   */
+  @PostMapping(value = "/register/start", produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<String> registerStart(@AuthenticationPrincipal AuthPrincipal principal)
+      throws Exception {
+    if (principal == null) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+    PublicKeyCredentialCreationOptions options = webAuthnService.startRegistration(principal);
+    return ResponseEntity.ok(webAuthnObjectMapper.writeValueAsString(options));
+  }
+
+  /**
+   * Verify and persist the newly registered credential for the authenticated admin.
+   *
+   * @param principal the authenticated principal (null if unauthenticated)
+   * @param credentialJson the raw W3C attestation credential JSON
+   * @return 204 on success, or 401 if unauthenticated
+   */
+  @PostMapping(value = "/register/finish", consumes = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<Void> registerFinish(
+      @AuthenticationPrincipal AuthPrincipal principal, @RequestBody String credentialJson) {
+    if (principal == null) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+    webAuthnService.finishRegistration(principal, credentialJson);
+    return ResponseEntity.noContent().build();
+  }
+
+  /**
+   * Mint assertion (login) options for the typed email and set the per-attempt cookie. The body is
+   * a clean W3C {@code PublicKeyCredentialRequestOptions} document; the per-attempt id rides the
+   * short-lived HttpOnly {@code ezac_webauthn_attempt} cookie so the client returns it on {@code
+   * /login/finish}.
+   *
+   * @param body the JSON body {@code {"email": "..."}}
+   * @return 200 with the options JSON and a Set-Cookie for the attempt id
+   * @throws Exception if the options cannot be serialized
+   */
+  @PostMapping(
+      value = "/login/start",
+      consumes = MediaType.APPLICATION_JSON_VALUE,
+      produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<String> loginStart(@RequestBody Map<String, String> body) throws Exception {
+    String email = body.get("email");
+    WebAuthnService.LoginStart start = webAuthnService.startLogin(email);
+    String optionsJson = webAuthnObjectMapper.writeValueAsString(start.options());
+    ResponseCookie cookie =
+        ResponseCookie.from(ATTEMPT_COOKIE, start.attemptId())
+            .httpOnly(true)
+            .secure(cookieSecure)
+            .sameSite("Strict")
+            .path(ATTEMPT_COOKIE_PATH)
+            .maxAge(ATTEMPT_COOKIE_TTL)
+            .build();
+    return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, cookie.toString()).body(optionsJson);
+  }
+
+  /**
+   * Verify the assertion and mint the session. Reads the per-attempt id from the {@code
+   * ezac_webauthn_attempt} cookie (401 if absent), delegates to the service (which sets the session
+   * cookie via {@code SessionService.create}), then clears the single-use attempt cookie.
+   *
+   * @param attemptId the per-attempt id from the cookie (null if absent)
+   * @param credentialJson the raw W3C assertion credential JSON
+   * @param request the servlet request
+   * @param response the Set-Cookie sink
+   * @return 204 on success, or 401 if the attempt cookie is absent
+   */
+  @PostMapping(value = "/login/finish", consumes = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<Void> loginFinish(
+      @CookieValue(value = ATTEMPT_COOKIE, required = false) String attemptId,
+      @RequestBody String credentialJson,
+      HttpServletRequest request,
+      HttpServletResponse response) {
+    if (attemptId == null || attemptId.isBlank()) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+    webAuthnService.finishLogin(attemptId, credentialJson, request, response);
+    // Clear the single-use attempt cookie once it has been consumed.
+    ResponseCookie cleared =
+        ResponseCookie.from(ATTEMPT_COOKIE, "")
+            .httpOnly(true)
+            .secure(cookieSecure)
+            .sameSite("Strict")
+            .path(ATTEMPT_COOKIE_PATH)
+            .maxAge(0)
+            .build();
+    response.addHeader(HttpHeaders.SET_COOKIE, cleared.toString());
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/edens/zac/portfolio/backend/controller/auth/WebAuthnController.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/auth/WebAuthnController.java
@@ -8,7 +8,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.time.Duration;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -53,15 +52,17 @@ public class WebAuthnController {
    * Constructor.
    *
    * @param webAuthnService the ceremony orchestration service
-   * @param webAuthnObjectMapper the WebAuthn-aware mapper for serializing the options bodies
+   * @param objectMapper the primary application mapper (the WebAuthn Jackson module is auto-applied
+   *     by Spring Boot via the {@link
+   *     edens.zac.portfolio.backend.config.WebAuthnConfig#webauthnJackson2Module()} bean)
    * @param cookieSecure whether the attempt cookie is set Secure
    */
   public WebAuthnController(
       WebAuthnService webAuthnService,
-      @Qualifier("webAuthnObjectMapper") ObjectMapper webAuthnObjectMapper,
+      ObjectMapper objectMapper,
       @Value("${app.auth.cookie-secure:true}") boolean cookieSecure) {
     this.webAuthnService = webAuthnService;
-    this.webAuthnObjectMapper = webAuthnObjectMapper;
+    this.webAuthnObjectMapper = objectMapper;
     this.cookieSecure = cookieSecure;
   }
 

--- a/src/main/java/edens/zac/portfolio/backend/controller/auth/WebAuthnController.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/auth/WebAuthnController.java
@@ -1,6 +1,7 @@
 package edens.zac.portfolio.backend.controller.auth;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edens.zac.portfolio.backend.config.AuthLoginLimiter;
 import edens.zac.portfolio.backend.model.AuthPrincipal;
 import edens.zac.portfolio.backend.services.WebAuthnService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -41,6 +42,7 @@ public class WebAuthnController {
 
   private final WebAuthnService webAuthnService;
   private final ObjectMapper webAuthnObjectMapper;
+  private final AuthLoginLimiter loginLimiter;
 
   /**
    * Whether the attempt cookie is set Secure. Mirrors SessionService's flag (true in prod; the dev
@@ -55,14 +57,17 @@ public class WebAuthnController {
    * @param objectMapper the primary application mapper (the WebAuthn Jackson module is auto-applied
    *     by Spring Boot via the {@link
    *     edens.zac.portfolio.backend.config.WebAuthnConfig#webauthnJackson2Module()} bean)
+   * @param loginLimiter the shared login rate-limiter (mirrors {@code AuthController})
    * @param cookieSecure whether the attempt cookie is set Secure
    */
   public WebAuthnController(
       WebAuthnService webAuthnService,
       ObjectMapper objectMapper,
+      AuthLoginLimiter loginLimiter,
       @Value("${app.auth.cookie-secure:true}") boolean cookieSecure) {
     this.webAuthnService = webAuthnService;
     this.webAuthnObjectMapper = objectMapper;
+    this.loginLimiter = loginLimiter;
     this.cookieSecure = cookieSecure;
   }
 
@@ -106,16 +111,32 @@ public class WebAuthnController {
    * short-lived HttpOnly {@code ezac_webauthn_attempt} cookie so the client returns it on {@code
    * /login/finish}.
    *
+   * <p>Rate-limiting mirrors {@code AuthController.login}: if the IP+email pair is blocked, 429 is
+   * returned immediately before minting any options or setting a cookie. A failure counter is
+   * recorded on every non-blocked call so that repeated start attempts (without a matching
+   * successful finish) eventually trip the limiter. The limiter is reset on a successful {@link
+   * #loginFinish}.
+   *
    * @param body the JSON body {@code {"email": "..."}}
-   * @return 200 with the options JSON and a Set-Cookie for the attempt id
+   * @param request the servlet request (IP resolution)
+   * @return 200 with the options JSON and a Set-Cookie for the attempt id, or 429 if rate-limited
    * @throws Exception if the options cannot be serialized
    */
   @PostMapping(
       value = "/login/start",
       consumes = MediaType.APPLICATION_JSON_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<String> loginStart(@RequestBody Map<String, String> body) throws Exception {
+  public ResponseEntity<String> loginStart(
+      @RequestBody Map<String, String> body, HttpServletRequest request) throws Exception {
     String email = body.get("email");
+    String ip = resolveClientIp(request);
+
+    if (loginLimiter.isBlocked(ip, email)) {
+      log.warn("WebAuthn login/start rate-limited for email={} ip={}", email, ip);
+      return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).build();
+    }
+    loginLimiter.recordFailure(ip, email);
+
     WebAuthnService.LoginStart start = webAuthnService.startLogin(email);
     String optionsJson = webAuthnObjectMapper.writeValueAsString(start.options());
     ResponseCookie cookie =
@@ -134,6 +155,11 @@ public class WebAuthnController {
    * ezac_webauthn_attempt} cookie (401 if absent), delegates to the service (which sets the session
    * cookie via {@code SessionService.create}), then clears the single-use attempt cookie.
    *
+   * <p>The attempt cookie is cleared in a {@code finally} block so it is always expired — on both
+   * success and assertion failure — preventing the cookie from lingering until its 5-minute TTL on
+   * bad assertions. On success the limiter is reset so subsequent legitimate logins are not
+   * blocked.
+   *
    * @param attemptId the per-attempt id from the cookie (null if absent)
    * @param credentialJson the raw W3C assertion credential JSON
    * @param request the servlet request
@@ -149,17 +175,31 @@ public class WebAuthnController {
     if (attemptId == null || attemptId.isBlank()) {
       return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
     }
-    webAuthnService.finishLogin(attemptId, credentialJson, request, response);
-    // Clear the single-use attempt cookie once it has been consumed.
-    ResponseCookie cleared =
-        ResponseCookie.from(ATTEMPT_COOKIE, "")
-            .httpOnly(true)
-            .secure(cookieSecure)
-            .sameSite("Strict")
-            .path(ATTEMPT_COOKIE_PATH)
-            .maxAge(0)
-            .build();
-    response.addHeader(HttpHeaders.SET_COOKIE, cleared.toString());
-    return ResponseEntity.noContent().build();
+    String ip = resolveClientIp(request);
+    try {
+      String authenticatedEmail =
+          webAuthnService.finishLogin(attemptId, credentialJson, request, response);
+      loginLimiter.reset(ip, authenticatedEmail);
+      return ResponseEntity.noContent().build();
+    } finally {
+      // Always clear the single-use attempt cookie — on success and on assertion failure.
+      ResponseCookie cleared =
+          ResponseCookie.from(ATTEMPT_COOKIE, "")
+              .httpOnly(true)
+              .secure(cookieSecure)
+              .sameSite("Strict")
+              .path(ATTEMPT_COOKIE_PATH)
+              .maxAge(0)
+              .build();
+      response.addHeader(HttpHeaders.SET_COOKIE, cleared.toString());
+    }
+  }
+
+  private static String resolveClientIp(HttpServletRequest request) {
+    String realIp = request.getHeader("X-Real-IP");
+    if (realIp != null && !realIp.isBlank()) {
+      return realIp.trim();
+    }
+    return request.getRemoteAddr();
   }
 }

--- a/src/main/java/edens/zac/portfolio/backend/dao/AppUserRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/AppUserRepository.java
@@ -1,0 +1,100 @@
+package edens.zac.portfolio.backend.dao;
+
+import edens.zac.portfolio.backend.entity.AppUserEntity;
+import edens.zac.portfolio.backend.types.Role;
+import edens.zac.portfolio.backend.types.UserStatus;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Slf4j
+public class AppUserRepository extends BaseDao {
+
+  public AppUserRepository(JdbcTemplate jdbcTemplate) {
+    super(jdbcTemplate);
+  }
+
+  private static final String SELECT_APP_USER =
+      """
+      SELECT id, email, role, password_hash, webauthn_user_handle, display_name, status,
+             created_at, updated_at
+      FROM app_user
+      """;
+
+  private static final RowMapper<AppUserEntity> APP_USER_ROW_MAPPER =
+      (rs, rowNum) -> {
+        Object handle = rs.getObject("webauthn_user_handle");
+        return AppUserEntity.builder()
+            .id(rs.getLong("id"))
+            .email(rs.getString("email"))
+            .role(Role.valueOf(rs.getString("role")))
+            .passwordHash(rs.getString("password_hash"))
+            .webauthnUserHandle(handle != null ? (UUID) handle : null)
+            .displayName(rs.getString("display_name"))
+            .status(UserStatus.valueOf(rs.getString("status")))
+            .createdAt(getLocalDateTime(rs, "created_at"))
+            .updatedAt(getLocalDateTime(rs, "updated_at"))
+            .build();
+      };
+
+  @Transactional(readOnly = true)
+  public Optional<AppUserEntity> findByEmail(String email) {
+    String sql = SELECT_APP_USER + " WHERE email = :email";
+    MapSqlParameterSource params = createParameterSource().addValue("email", email);
+    return queryForObject(sql, APP_USER_ROW_MAPPER, params);
+  }
+
+  @Transactional(readOnly = true)
+  public Optional<AppUserEntity> findById(Long id) {
+    String sql = SELECT_APP_USER + " WHERE id = :id";
+    MapSqlParameterSource params = createParameterSource().addValue("id", id);
+    return queryForObject(sql, APP_USER_ROW_MAPPER, params);
+  }
+
+  @Transactional(readOnly = true)
+  public Optional<AppUserEntity> findByWebauthnUserHandle(UUID handle) {
+    String sql = SELECT_APP_USER + " WHERE webauthn_user_handle = :handle";
+    MapSqlParameterSource params = createParameterSource().addValue("handle", handle);
+    return queryForObject(sql, APP_USER_ROW_MAPPER, params);
+  }
+
+  @Transactional(readOnly = true)
+  public boolean existsByRole(Role role) {
+    String sql = "SELECT COUNT(*) FROM app_user WHERE role = :role";
+    MapSqlParameterSource params = createParameterSource().addValue("role", role.name());
+    Long count = namedParameterJdbcTemplate.queryForObject(sql, params, Long.class);
+    return count != null && count > 0;
+  }
+
+  @Transactional
+  public Long insert(AppUserEntity entity) {
+    String sql =
+        """
+        INSERT INTO app_user (email, role, password_hash, webauthn_user_handle, display_name, status)
+        VALUES (:email, :role, :passwordHash, :webauthnUserHandle, :displayName, :status)
+        """;
+    MapSqlParameterSource params =
+        createParameterSource()
+            .addValue("email", entity.getEmail())
+            .addValue("role", entity.getRole().name())
+            .addValue("passwordHash", entity.getPasswordHash())
+            .addValue("webauthnUserHandle", entity.getWebauthnUserHandle())
+            .addValue("displayName", entity.getDisplayName())
+            .addValue("status", entity.getStatus().name());
+    return insertAndReturnId(sql, "id", params);
+  }
+
+  @Transactional
+  public void updatePasswordHash(Long id, String hash) {
+    String sql = "UPDATE app_user SET password_hash = :hash, updated_at = now() WHERE id = :id";
+    MapSqlParameterSource params =
+        createParameterSource().addValue("hash", hash).addValue("id", id);
+    update(sql, params);
+  }
+}

--- a/src/main/java/edens/zac/portfolio/backend/dao/GalleryAccessRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/GalleryAccessRepository.java
@@ -1,0 +1,63 @@
+package edens.zac.portfolio.backend.dao;
+
+import edens.zac.portfolio.backend.entity.GalleryAccessEntity;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Slf4j
+public class GalleryAccessRepository extends BaseDao {
+
+  public GalleryAccessRepository(JdbcTemplate jdbcTemplate) {
+    super(jdbcTemplate);
+  }
+
+  private static final String SELECT_GALLERY_ACCESS =
+      """
+      SELECT id, user_id, collection_id, can_download, can_tag, granted_by, granted_at, expires_at
+      FROM gallery_access
+      """;
+
+  private static final RowMapper<GalleryAccessEntity> GALLERY_ACCESS_ROW_MAPPER =
+      (rs, rowNum) ->
+          GalleryAccessEntity.builder()
+              .id(rs.getLong("id"))
+              .userId(rs.getLong("user_id"))
+              .collectionId(rs.getLong("collection_id"))
+              .canDownload(rs.getBoolean("can_download"))
+              .canTag(rs.getBoolean("can_tag"))
+              .grantedBy(getLong(rs, "granted_by"))
+              .grantedAt(getLocalDateTime(rs, "granted_at"))
+              .expiresAt(getLocalDateTime(rs, "expires_at"))
+              .build();
+
+  @Transactional(readOnly = true)
+  public List<GalleryAccessEntity> findByUserId(Long userId) {
+    String sql = SELECT_GALLERY_ACCESS + " WHERE user_id = :userId ORDER BY granted_at ASC";
+    MapSqlParameterSource params = createParameterSource().addValue("userId", userId);
+    return query(sql, GALLERY_ACCESS_ROW_MAPPER, params);
+  }
+
+  @Transactional
+  public Long insert(GalleryAccessEntity entity) {
+    String sql =
+        """
+        INSERT INTO gallery_access (user_id, collection_id, can_download, can_tag, granted_by, expires_at)
+        VALUES (:userId, :collectionId, :canDownload, :canTag, :grantedBy, :expiresAt)
+        """;
+    MapSqlParameterSource params =
+        createParameterSource()
+            .addValue("userId", entity.getUserId())
+            .addValue("collectionId", entity.getCollectionId())
+            .addValue("canDownload", entity.isCanDownload())
+            .addValue("canTag", entity.isCanTag())
+            .addValue("grantedBy", entity.getGrantedBy())
+            .addValue("expiresAt", entity.getExpiresAt());
+    return insertAndReturnId(sql, "id", params);
+  }
+}

--- a/src/main/java/edens/zac/portfolio/backend/dao/UserSessionRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/UserSessionRepository.java
@@ -1,0 +1,87 @@
+package edens.zac.portfolio.backend.dao;
+
+import edens.zac.portfolio.backend.entity.UserSessionEntity;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Slf4j
+public class UserSessionRepository extends BaseDao {
+
+  public UserSessionRepository(JdbcTemplate jdbcTemplate) {
+    super(jdbcTemplate);
+  }
+
+  private static final String SELECT_USER_SESSION =
+      """
+      SELECT id, user_id, token_hash, mfa_satisfied, ip, user_agent,
+             created_at, last_seen_at, expires_at, revoked_at
+      FROM user_session
+      """;
+
+  private static final RowMapper<UserSessionEntity> USER_SESSION_ROW_MAPPER =
+      (rs, rowNum) ->
+          UserSessionEntity.builder()
+              .id(rs.getLong("id"))
+              .userId(rs.getLong("user_id"))
+              .tokenHash(rs.getString("token_hash"))
+              .mfaSatisfied(rs.getBoolean("mfa_satisfied"))
+              .ip(rs.getString("ip"))
+              .userAgent(rs.getString("user_agent"))
+              .createdAt(getLocalDateTime(rs, "created_at"))
+              .lastSeenAt(getLocalDateTime(rs, "last_seen_at"))
+              .expiresAt(getLocalDateTime(rs, "expires_at"))
+              .revokedAt(getLocalDateTime(rs, "revoked_at"))
+              .build();
+
+  @Transactional
+  public Long insert(UserSessionEntity entity) {
+    String sql =
+        """
+        INSERT INTO user_session (user_id, token_hash, mfa_satisfied, ip, user_agent, expires_at)
+        VALUES (:userId, :tokenHash, :mfaSatisfied, :ip, :userAgent, :expiresAt)
+        """;
+    MapSqlParameterSource params =
+        createParameterSource()
+            .addValue("userId", entity.getUserId())
+            .addValue("tokenHash", entity.getTokenHash())
+            .addValue("mfaSatisfied", entity.isMfaSatisfied())
+            .addValue("ip", entity.getIp())
+            .addValue("userAgent", entity.getUserAgent())
+            .addValue("expiresAt", entity.getExpiresAt());
+    return insertAndReturnId(sql, "id", params);
+  }
+
+  @Transactional(readOnly = true)
+  public Optional<UserSessionEntity> findByTokenHash(String tokenHash) {
+    String sql = SELECT_USER_SESSION + " WHERE token_hash = :tokenHash";
+    MapSqlParameterSource params = createParameterSource().addValue("tokenHash", tokenHash);
+    return queryForObject(sql, USER_SESSION_ROW_MAPPER, params);
+  }
+
+  @Transactional
+  public void touch(Long id, LocalDateTime lastSeenAt, LocalDateTime expiresAt) {
+    String sql =
+        "UPDATE user_session SET last_seen_at = :lastSeenAt, expires_at = :expiresAt WHERE id = :id";
+    MapSqlParameterSource params =
+        createParameterSource()
+            .addValue("lastSeenAt", lastSeenAt)
+            .addValue("expiresAt", expiresAt)
+            .addValue("id", id);
+    update(sql, params);
+  }
+
+  @Transactional
+  public void revokeByTokenHash(String tokenHash) {
+    String sql =
+        "UPDATE user_session SET revoked_at = now() WHERE token_hash = :tokenHash AND revoked_at IS NULL";
+    MapSqlParameterSource params = createParameterSource().addValue("tokenHash", tokenHash);
+    update(sql, params);
+  }
+}

--- a/src/main/java/edens/zac/portfolio/backend/dao/WebAuthnCredentialRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/WebAuthnCredentialRepository.java
@@ -1,0 +1,121 @@
+package edens.zac.portfolio.backend.dao;
+
+import edens.zac.portfolio.backend.entity.WebAuthnCredentialEntity;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/** JDBC repository for WebAuthn (passkey) credentials. BYTEA columns are bound/read as byte[]. */
+@Component
+@Slf4j
+public class WebAuthnCredentialRepository extends BaseDao {
+
+  public WebAuthnCredentialRepository(JdbcTemplate jdbcTemplate) {
+    super(jdbcTemplate);
+  }
+
+  private static final RowMapper<WebAuthnCredentialEntity> ROW_MAPPER =
+      (rs, rowNum) ->
+          WebAuthnCredentialEntity.builder()
+              .id(rs.getLong("id"))
+              .userId(rs.getLong("user_id"))
+              .credentialId(rs.getBytes("credential_id"))
+              .publicKey(rs.getBytes("public_key"))
+              .signCount(rs.getLong("sign_count"))
+              .transports(rs.getString("transports"))
+              .label(rs.getString("label"))
+              .createdAt(getLocalDateTime(rs, "created_at"))
+              .lastUsedAt(getLocalDateTime(rs, "last_used_at"))
+              .build();
+
+  private static final String SELECT_COLUMNS =
+      "id, user_id, credential_id, public_key, sign_count, transports, label, "
+          + "created_at, last_used_at";
+
+  /**
+   * Insert a new credential row and return the generated id.
+   *
+   * @param credential entity to insert
+   * @return generated primary-key id
+   */
+  @Transactional
+  public Long insert(WebAuthnCredentialEntity credential) {
+    String sql =
+        """
+        INSERT INTO webauthn_credential
+          (user_id, credential_id, public_key, sign_count, transports, label)
+        VALUES
+          (:userId, :credentialId, :publicKey, :signCount, :transports, :label)
+        """;
+    var params =
+        createParameterSource()
+            .addValue("userId", credential.getUserId())
+            .addValue("credentialId", credential.getCredentialId())
+            .addValue("publicKey", credential.getPublicKey())
+            .addValue("signCount", credential.getSignCount())
+            .addValue("transports", credential.getTransports())
+            .addValue("label", credential.getLabel());
+    return insertAndReturnId(sql, "id", params);
+  }
+
+  /**
+   * Find all credentials for a given user, ordered by creation time ascending.
+   *
+   * @param userId app_user primary key
+   * @return list of credentials (may be empty)
+   */
+  @Transactional(readOnly = true)
+  public List<WebAuthnCredentialEntity> findByUserId(Long userId) {
+    String sql =
+        "SELECT "
+            + SELECT_COLUMNS
+            + " FROM webauthn_credential WHERE user_id = :userId "
+            + "ORDER BY created_at ASC";
+    var params = createParameterSource().addValue("userId", userId);
+    return query(sql, ROW_MAPPER, params);
+  }
+
+  /**
+   * Find a credential by its raw credential-id bytes.
+   *
+   * @param credentialId raw BYTEA credential id
+   * @return credential if found
+   */
+  @Transactional(readOnly = true)
+  public Optional<WebAuthnCredentialEntity> findByCredentialId(byte[] credentialId) {
+    String sql =
+        "SELECT "
+            + SELECT_COLUMNS
+            + " FROM webauthn_credential WHERE credential_id = :credentialId";
+    var params = createParameterSource().addValue("credentialId", credentialId);
+    return queryForObject(sql, ROW_MAPPER, params);
+  }
+
+  /**
+   * Update the sign count and last-used timestamp after a successful assertion.
+   *
+   * @param id credential primary key
+   * @param signCount new sign count (must be strictly greater than stored value)
+   * @param lastUsedAt timestamp of the successful assertion
+   */
+  @Transactional
+  public void updateSignCountAndLastUsed(Long id, long signCount, LocalDateTime lastUsedAt) {
+    String sql =
+        """
+        UPDATE webauthn_credential
+        SET sign_count = :signCount, last_used_at = :lastUsedAt
+        WHERE id = :id
+        """;
+    var params =
+        createParameterSource()
+            .addValue("id", id)
+            .addValue("signCount", signCount)
+            .addValue("lastUsedAt", lastUsedAt);
+    update(sql, params);
+  }
+}

--- a/src/main/java/edens/zac/portfolio/backend/entity/AppUserEntity.java
+++ b/src/main/java/edens/zac/portfolio/backend/entity/AppUserEntity.java
@@ -1,0 +1,26 @@
+package edens.zac.portfolio.backend.entity;
+
+import edens.zac.portfolio.backend.types.Role;
+import edens.zac.portfolio.backend.types.UserStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AppUserEntity {
+  private Long id;
+  private String email;
+  private Role role;
+  private String passwordHash;
+  private UUID webauthnUserHandle;
+  private String displayName;
+  private UserStatus status;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+}

--- a/src/main/java/edens/zac/portfolio/backend/entity/GalleryAccessEntity.java
+++ b/src/main/java/edens/zac/portfolio/backend/entity/GalleryAccessEntity.java
@@ -1,0 +1,22 @@
+package edens.zac.portfolio.backend.entity;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GalleryAccessEntity {
+  private Long id;
+  private Long userId;
+  private Long collectionId;
+  private boolean canDownload;
+  private boolean canTag;
+  private Long grantedBy;
+  private LocalDateTime grantedAt;
+  private LocalDateTime expiresAt;
+}

--- a/src/main/java/edens/zac/portfolio/backend/entity/UserSessionEntity.java
+++ b/src/main/java/edens/zac/portfolio/backend/entity/UserSessionEntity.java
@@ -1,0 +1,24 @@
+package edens.zac.portfolio.backend.entity;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserSessionEntity {
+  private Long id;
+  private Long userId;
+  private String tokenHash;
+  private boolean mfaSatisfied;
+  private String ip;
+  private String userAgent;
+  private LocalDateTime createdAt;
+  private LocalDateTime lastSeenAt;
+  private LocalDateTime expiresAt;
+  private LocalDateTime revokedAt;
+}

--- a/src/main/java/edens/zac/portfolio/backend/entity/WebAuthnCredentialEntity.java
+++ b/src/main/java/edens/zac/portfolio/backend/entity/WebAuthnCredentialEntity.java
@@ -1,0 +1,27 @@
+package edens.zac.portfolio.backend.entity;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * A registered WebAuthn (passkey) credential belonging to an app_user. Mirrors webauthn_credential.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class WebAuthnCredentialEntity {
+
+  private Long id;
+  private Long userId;
+  private byte[] credentialId;
+  private byte[] publicKey;
+  private long signCount;
+  private String transports;
+  private String label;
+  private LocalDateTime createdAt;
+  private LocalDateTime lastUsedAt;
+}

--- a/src/main/java/edens/zac/portfolio/backend/model/AuthPrincipal.java
+++ b/src/main/java/edens/zac/portfolio/backend/model/AuthPrincipal.java
@@ -1,0 +1,5 @@
+package edens.zac.portfolio.backend.model;
+
+import edens.zac.portfolio.backend.types.Role;
+
+public record AuthPrincipal(Long userId, String email, Role role, boolean mfaSatisfied) {}

--- a/src/main/java/edens/zac/portfolio/backend/model/GalleryAccessSummary.java
+++ b/src/main/java/edens/zac/portfolio/backend/model/GalleryAccessSummary.java
@@ -1,0 +1,3 @@
+package edens.zac.portfolio.backend.model;
+
+public record GalleryAccessSummary(Long collectionId, boolean canDownload, boolean canTag) {}

--- a/src/main/java/edens/zac/portfolio/backend/model/LoginRequest.java
+++ b/src/main/java/edens/zac/portfolio/backend/model/LoginRequest.java
@@ -1,0 +1,5 @@
+package edens.zac.portfolio.backend.model;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(@NotBlank String email, @NotBlank String password) {}

--- a/src/main/java/edens/zac/portfolio/backend/model/MeResponse.java
+++ b/src/main/java/edens/zac/portfolio/backend/model/MeResponse.java
@@ -1,0 +1,7 @@
+package edens.zac.portfolio.backend.model;
+
+import edens.zac.portfolio.backend.types.Role;
+import java.util.List;
+
+public record MeResponse(
+    String email, Role role, boolean mfaSatisfied, List<GalleryAccessSummary> galleries) {}

--- a/src/main/java/edens/zac/portfolio/backend/services/AdminBootstrap.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/AdminBootstrap.java
@@ -1,0 +1,80 @@
+package edens.zac.portfolio.backend.services;
+
+import edens.zac.portfolio.backend.dao.AppUserRepository;
+import edens.zac.portfolio.backend.entity.AppUserEntity;
+import edens.zac.portfolio.backend.types.Role;
+import edens.zac.portfolio.backend.types.UserStatus;
+import jakarta.annotation.PostConstruct;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+/**
+ * Seeds the first ADMIN principal from environment variables on startup, so no admin secret lives
+ * in git. Idempotent: it inserts an admin only when none exists and both env values are present;
+ * once an admin exists it does nothing but logs a warning if the bootstrap password is still
+ * configured (the operator's cue to remove it). Never throws on normal paths.
+ */
+@Component
+@Slf4j
+public class AdminBootstrap {
+
+  private final AppUserRepository appUserRepository;
+  private final PasswordEncoder passwordEncoder;
+  private final String bootstrapEmail;
+  private final String bootstrapPassword;
+
+  /** Binds the repositories and the env-driven bootstrap email/password. */
+  public AdminBootstrap(
+      AppUserRepository appUserRepository,
+      PasswordEncoder passwordEncoder,
+      @Value("${app.auth.admin.bootstrap-email:}") String bootstrapEmail,
+      @Value("${app.auth.admin.bootstrap-password:}") String bootstrapPassword) {
+    this.appUserRepository = appUserRepository;
+    this.passwordEncoder = passwordEncoder;
+    this.bootstrapEmail = bootstrapEmail;
+    this.bootstrapPassword = bootstrapPassword;
+  }
+
+  /** Runs once on startup; seeds or skips the admin per the class contract. */
+  @PostConstruct
+  void init() {
+    if (isBlank(bootstrapEmail) && isBlank(bootstrapPassword)) {
+      return;
+    }
+
+    boolean adminExists = appUserRepository.existsByRole(Role.ADMIN);
+    if (adminExists) {
+      if (!isBlank(bootstrapPassword)) {
+        log.warn(
+            "An ADMIN already exists but ADMIN_BOOTSTRAP_PASSWORD is still set;"
+                + " remove it from the environment.");
+      }
+      return;
+    }
+
+    if (isBlank(bootstrapEmail) || isBlank(bootstrapPassword)) {
+      log.warn(
+          "Admin bootstrap skipped: both ADMIN_BOOTSTRAP_EMAIL and"
+              + " ADMIN_BOOTSTRAP_PASSWORD are required.");
+      return;
+    }
+
+    AppUserEntity admin =
+        AppUserEntity.builder()
+            .email(bootstrapEmail)
+            .role(Role.ADMIN)
+            .passwordHash(passwordEncoder.encode(bootstrapPassword))
+            .webauthnUserHandle(UUID.randomUUID())
+            .status(UserStatus.ACTIVE)
+            .build();
+    appUserRepository.insert(admin);
+    log.info("Seeded bootstrap ADMIN user: {}", bootstrapEmail);
+  }
+
+  private static boolean isBlank(String value) {
+    return value == null || value.isBlank();
+  }
+}

--- a/src/main/java/edens/zac/portfolio/backend/services/SessionService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/SessionService.java
@@ -1,0 +1,192 @@
+package edens.zac.portfolio.backend.services;
+
+import edens.zac.portfolio.backend.dao.AppUserRepository;
+import edens.zac.portfolio.backend.dao.UserSessionRepository;
+import edens.zac.portfolio.backend.entity.AppUserEntity;
+import edens.zac.portfolio.backend.entity.UserSessionEntity;
+import edens.zac.portfolio.backend.model.AuthPrincipal;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.HexFormat;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Service;
+
+/**
+ * Owns the opaque, DB-backed session lifecycle. A 256-bit CSPRNG token is sent raw in the {@code
+ * ezac_session} cookie; only its SHA-256 hash is persisted (a DB leak never yields a usable
+ * cookie). Sessions slide a 60-day window and can be revoked instantly. Cookie construction lives
+ * here so controllers stay focused on HTTP wiring.
+ */
+@Service
+@Slf4j
+public class SessionService {
+
+  private static final String COOKIE_NAME = "ezac_session";
+  private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+  private final UserSessionRepository sessionRepository;
+  private final AppUserRepository appUserRepository;
+  private final boolean cookieSecure;
+  private final long ttlDays;
+  private final long refreshThresholdHours;
+
+  /**
+   * Spring constructor: binds config and the repositories.
+   *
+   * @param sessionRepository the repository for {@code user_session} rows
+   * @param appUserRepository the repository for {@code app_user} rows
+   * @param cookieSecure whether the {@code ezac_session} cookie should carry the {@code Secure}
+   *     flag (false in dev)
+   * @param ttlDays sliding session TTL in days; the cookie {@code Max-Age} matches
+   * @param refreshThresholdHours how many hours of inactivity before the sliding window is bumped
+   */
+  public SessionService(
+      UserSessionRepository sessionRepository,
+      AppUserRepository appUserRepository,
+      @Value("${app.auth.cookie-secure:true}") boolean cookieSecure,
+      @Value("${app.auth.session.ttl-days:60}") long ttlDays,
+      @Value("${app.auth.session.refresh-threshold-hours:24}") long refreshThresholdHours) {
+    this.sessionRepository = sessionRepository;
+    this.appUserRepository = appUserRepository;
+    this.cookieSecure = cookieSecure;
+    this.ttlDays = ttlDays;
+    this.refreshThresholdHours = refreshThresholdHours;
+  }
+
+  /**
+   * Mint a new session for {@code user}, persist its hashed token, and write the {@code
+   * ezac_session} cookie onto {@code response}.
+   *
+   * @param user the authenticated principal
+   * @param mfaSatisfied true for a user-verified passkey login, false for break-glass password
+   * @param request used only to record the IP and User-Agent
+   * @param response the Set-Cookie sink
+   */
+  public void create(
+      AppUserEntity user,
+      boolean mfaSatisfied,
+      HttpServletRequest request,
+      HttpServletResponse response) {
+    byte[] tokenBytes = new byte[32];
+    SECURE_RANDOM.nextBytes(tokenBytes);
+    String raw = Base64.getUrlEncoder().withoutPadding().encodeToString(tokenBytes);
+
+    UserSessionEntity session =
+        UserSessionEntity.builder()
+            .userId(user.getId())
+            .tokenHash(sha256Hex(raw))
+            .mfaSatisfied(mfaSatisfied)
+            .ip(request.getHeader("X-Real-IP"))
+            .userAgent(truncate(request.getHeader("User-Agent"), 255))
+            .expiresAt(LocalDateTime.now().plusDays(ttlDays))
+            .build();
+    sessionRepository.insert(session);
+
+    response.addHeader(
+        HttpHeaders.SET_COOKIE,
+        ResponseCookie.from(COOKIE_NAME, raw)
+            .httpOnly(true)
+            .secure(cookieSecure)
+            .sameSite("Strict")
+            .path("/")
+            .maxAge(Duration.ofDays(ttlDays))
+            .build()
+            .toString());
+  }
+
+  /**
+   * Resolve a raw cookie token to a principal. Returns empty if the session is unknown, revoked, or
+   * expired. Applies the sliding refresh: if {@code last_seen_at} is older than the refresh
+   * threshold, bump it and extend expiry by ttl-days from now.
+   *
+   * @param rawToken the raw value read from the {@code ezac_session} cookie
+   * @return the principal, or empty when the session is not currently valid
+   */
+  public Optional<AuthPrincipal> resolve(String rawToken) {
+    if (rawToken == null || rawToken.isBlank()) {
+      return Optional.empty();
+    }
+    Optional<UserSessionEntity> maybeSession =
+        sessionRepository.findByTokenHash(sha256Hex(rawToken));
+    if (maybeSession.isEmpty()) {
+      return Optional.empty();
+    }
+    UserSessionEntity session = maybeSession.get();
+    LocalDateTime now = LocalDateTime.now();
+    if (session.getRevokedAt() != null || session.getExpiresAt().isBefore(now)) {
+      return Optional.empty();
+    }
+
+    if (session.getLastSeenAt().isBefore(now.minusHours(refreshThresholdHours))) {
+      sessionRepository.touch(session.getId(), now, now.plusDays(ttlDays));
+    }
+
+    Optional<AppUserEntity> maybeUser = appUserRepository.findById(session.getUserId());
+    if (maybeUser.isEmpty()) {
+      return Optional.empty();
+    }
+    AppUserEntity user = maybeUser.get();
+    return Optional.of(
+        new AuthPrincipal(user.getId(), user.getEmail(), user.getRole(), session.isMfaSatisfied()));
+  }
+
+  /**
+   * Revoke the session identified by {@code rawToken} and clear the cookie on {@code response}.
+   *
+   * @param rawToken the raw value read from the {@code ezac_session} cookie (may be null)
+   * @param response the Set-Cookie sink for the cleared cookie
+   */
+  public void revoke(String rawToken, HttpServletResponse response) {
+    if (rawToken != null && !rawToken.isBlank()) {
+      sessionRepository.revokeByTokenHash(sha256Hex(rawToken));
+    }
+    response.addHeader(
+        HttpHeaders.SET_COOKIE,
+        ResponseCookie.from(COOKIE_NAME, "")
+            .httpOnly(true)
+            .secure(cookieSecure)
+            .sameSite("Strict")
+            .path("/")
+            .maxAge(0)
+            .build()
+            .toString());
+  }
+
+  /**
+   * Test-only hook exposing the at-rest hash so tests can look a session up by its stored key
+   * without duplicating the hashing algorithm.
+   *
+   * @param rawToken the raw cookie value
+   * @return the SHA-256 hex digest stored in {@code user_session.token_hash}
+   */
+  String sha256HexForTest(String rawToken) {
+    return sha256Hex(rawToken);
+  }
+
+  private static String sha256Hex(String value) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] hashed = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+      return HexFormat.of().formatHex(hashed);
+    } catch (Exception e) {
+      throw new IllegalStateException("SHA-256 unavailable", e);
+    }
+  }
+
+  private static String truncate(String value, int max) {
+    if (value == null) {
+      return null;
+    }
+    return value.length() <= max ? value : value.substring(0, max);
+  }
+}

--- a/src/main/java/edens/zac/portfolio/backend/services/SessionService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/SessionService.java
@@ -39,6 +39,7 @@ public class SessionService {
   private final boolean cookieSecure;
   private final long ttlDays;
   private final long refreshThresholdHours;
+  private final long maxLifetimeDays;
 
   /**
    * Spring constructor: binds config and the repositories.
@@ -47,20 +48,25 @@ public class SessionService {
    * @param appUserRepository the repository for {@code app_user} rows
    * @param cookieSecure whether the {@code ezac_session} cookie should carry the {@code Secure}
    *     flag (false in dev)
-   * @param ttlDays sliding session TTL in days; the cookie {@code Max-Age} matches
+   * @param ttlDays sliding idle TTL in days; the cookie {@code Max-Age} matches and each slide
+   *     extends idle expiry to {@code now + ttlDays}
    * @param refreshThresholdHours how many hours of inactivity before the sliding window is bumped
+   * @param maxLifetimeDays absolute session ceiling in days from creation; a session can never
+   *     slide past {@code createdAt + maxLifetimeDays}, bounding total lifetime per OWASP
    */
   public SessionService(
       UserSessionRepository sessionRepository,
       AppUserRepository appUserRepository,
       @Value("${app.auth.cookie-secure:true}") boolean cookieSecure,
       @Value("${app.auth.session.ttl-days:60}") long ttlDays,
-      @Value("${app.auth.session.refresh-threshold-hours:24}") long refreshThresholdHours) {
+      @Value("${app.auth.session.refresh-threshold-hours:24}") long refreshThresholdHours,
+      @Value("${app.auth.session.max-lifetime-days:90}") long maxLifetimeDays) {
     this.sessionRepository = sessionRepository;
     this.appUserRepository = appUserRepository;
     this.cookieSecure = cookieSecure;
     this.ttlDays = ttlDays;
     this.refreshThresholdHours = refreshThresholdHours;
+    this.maxLifetimeDays = maxLifetimeDays;
   }
 
   /**
@@ -106,8 +112,11 @@ public class SessionService {
 
   /**
    * Resolve a raw cookie token to a principal. Returns empty if the session is unknown, revoked, or
-   * expired. Applies the sliding refresh: if {@code last_seen_at} is older than the refresh
-   * threshold, bump it and extend expiry by ttl-days from now.
+   * expired. Two timeouts bound the session: an <em>idle</em> timeout of {@code ttl-days} of
+   * inactivity (slid forward on each resolve once {@code last_seen_at} is older than the refresh
+   * threshold), and an <em>absolute</em> ceiling of {@code createdAt + max-lifetime-days} that the
+   * slide can never cross. Once the slid expiry reaches the absolute ceiling, the session stops
+   * renewing and lapses, so an actively-used session cannot live forever.
    *
    * @param rawToken the raw value read from the {@code ezac_session} cookie
    * @return the principal, or empty when the session is not currently valid
@@ -128,7 +137,12 @@ public class SessionService {
     }
 
     if (session.getLastSeenAt().isBefore(now.minusHours(refreshThresholdHours))) {
-      sessionRepository.touch(session.getId(), now, now.plusDays(ttlDays));
+      // Slide the idle window to now + ttlDays, but never past the absolute ceiling. The capped
+      // expires_at then enforces the absolute timeout via the expires_at < now rejection above.
+      LocalDateTime absoluteMax = session.getCreatedAt().plusDays(maxLifetimeDays);
+      LocalDateTime slideTo = now.plusDays(ttlDays);
+      LocalDateTime newExpiry = slideTo.isBefore(absoluteMax) ? slideTo : absoluteMax;
+      sessionRepository.touch(session.getId(), now, newExpiry);
     }
 
     Optional<AppUserEntity> maybeUser = appUserRepository.findById(session.getUserId());

--- a/src/main/java/edens/zac/portfolio/backend/services/WebAuthnChallengeStore.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/WebAuthnChallengeStore.java
@@ -4,6 +4,7 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import java.time.Duration;
 import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -21,6 +22,7 @@ public class WebAuthnChallengeStore {
 
   private final Cache<String, Object> cache;
 
+  @Autowired
   public WebAuthnChallengeStore(
       @Value("${app.auth.webauthn.challenge-ttl-minutes:5}") long ttlMinutes) {
     this(Duration.ofMinutes(ttlMinutes));

--- a/src/main/java/edens/zac/portfolio/backend/services/WebAuthnChallengeStore.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/WebAuthnChallengeStore.java
@@ -1,0 +1,54 @@
+package edens.zac.portfolio.backend.services;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.time.Duration;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Short-TTL, single-use store for in-flight WebAuthn ceremony options (the challenge). Because we
+ * use Spring Security's WebAuthn operations programmatically (not the session-backed DSL), the
+ * options minted in {@code /start} must be held server-side until {@code /finish}.
+ *
+ * <p>Keyed by {@code webauthn_user_handle} (registration) or a per-attempt id (login). {@link
+ * #take(String)} removes-and-returns, so each challenge is consumed once (replay defence). Caffeine
+ * bounds memory and expires stragglers after the TTL.
+ */
+@Component
+public class WebAuthnChallengeStore {
+
+  private final Cache<String, Object> cache;
+
+  public WebAuthnChallengeStore(
+      @Value("${app.auth.webauthn.challenge-ttl-minutes:5}") long ttlMinutes) {
+    this(Duration.ofMinutes(ttlMinutes));
+  }
+
+  /** Test-friendly constructor accepting an explicit TTL so expiry can be exercised in millis. */
+  WebAuthnChallengeStore(Duration ttl) {
+    this.cache = Caffeine.newBuilder().expireAfterWrite(ttl).maximumSize(10_000).build();
+  }
+
+  /**
+   * Store ceremony options under a key (user handle or per-attempt id).
+   *
+   * @param key cache key
+   * @param options ceremony options object to store
+   */
+  public void put(String key, Object options) {
+    cache.put(key, options);
+  }
+
+  /**
+   * Remove and return the stored options, or empty if absent/expired. Single-use.
+   *
+   * @param key cache key
+   * @return stored value if present, otherwise empty
+   */
+  public Optional<Object> take(String key) {
+    Object value = cache.asMap().remove(key);
+    return Optional.ofNullable(value);
+  }
+}

--- a/src/main/java/edens/zac/portfolio/backend/services/WebAuthnService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/WebAuthnService.java
@@ -1,0 +1,257 @@
+package edens.zac.portfolio.backend.services;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edens.zac.portfolio.backend.dao.AppUserRepository;
+import edens.zac.portfolio.backend.dao.WebAuthnCredentialRepository;
+import edens.zac.portfolio.backend.entity.AppUserEntity;
+import edens.zac.portfolio.backend.model.AuthPrincipal;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.web.webauthn.api.AuthenticatorAssertionResponse;
+import org.springframework.security.web.webauthn.api.AuthenticatorAttestationResponse;
+import org.springframework.security.web.webauthn.api.PublicKeyCredential;
+import org.springframework.security.web.webauthn.api.PublicKeyCredentialCreationOptions;
+import org.springframework.security.web.webauthn.api.PublicKeyCredentialRequestOptions;
+import org.springframework.security.web.webauthn.api.PublicKeyCredentialUserEntity;
+import org.springframework.security.web.webauthn.jackson.WebauthnJackson2Module;
+import org.springframework.security.web.webauthn.management.ImmutablePublicKeyCredentialCreationOptionsRequest;
+import org.springframework.security.web.webauthn.management.ImmutablePublicKeyCredentialRequestOptionsRequest;
+import org.springframework.security.web.webauthn.management.ImmutableRelyingPartyRegistrationRequest;
+import org.springframework.security.web.webauthn.management.RelyingPartyAuthenticationRequest;
+import org.springframework.security.web.webauthn.management.RelyingPartyPublicKey;
+import org.springframework.security.web.webauthn.management.WebAuthnRelyingPartyOperations;
+import org.springframework.stereotype.Service;
+
+/**
+ * Orchestrates the four WebAuthn ceremonies on top of Spring Security's programmatic operations
+ * engine. Registration is bound to the authenticated principal; login converges on the F1 {@code
+ * SessionService} with {@code mfaSatisfied=true} (passkeys are user-verified).
+ *
+ * <p><strong>Email-scoped login (non-discoverable).</strong> Spring Security 6.4's operations
+ * engine derives the assertion allow-list itself from {@code authentication.getName()} (it resolves
+ * the user entity by that name, then looks up that user's stored credentials). So {@link
+ * #startLogin(String)} passes the email as the operations {@code Authentication} name rather than
+ * handing the engine an explicit descriptor list. Anti-enumeration falls out for free: for an
+ * unknown email the engine mints a fresh challenge with an empty allow-list, so the response shape
+ * and timing never reveal whether the account exists; the mismatch surfaces only at {@link
+ * #finishLogin} (the assertion fails). No 404, no leak.
+ */
+@Service
+@Slf4j
+public class WebAuthnService {
+
+  private final WebAuthnRelyingPartyOperations operations;
+  private final WebAuthnChallengeStore challengeStore;
+  private final AppUserRepository appUserRepository;
+  private final WebAuthnCredentialRepository credentialRepository;
+  private final SessionService sessionService;
+  private final ObjectMapper objectMapper;
+
+  /**
+   * Primary constructor.
+   *
+   * @param operations the WebAuthn relying-party operations engine
+   * @param challengeStore the short-TTL single-use challenge store
+   * @param appUserRepository the app_user repository (principal/handle resolution)
+   * @param credentialRepository the JDBC webauthn_credential repository
+   * @param sessionService the F1 session service (login converges here)
+   * @param webAuthnObjectMapper the WebAuthn-aware mapper that (de)serializes ceremony JSON
+   */
+  public WebAuthnService(
+      WebAuthnRelyingPartyOperations operations,
+      WebAuthnChallengeStore challengeStore,
+      AppUserRepository appUserRepository,
+      WebAuthnCredentialRepository credentialRepository,
+      SessionService sessionService,
+      @Qualifier("webAuthnObjectMapper") ObjectMapper webAuthnObjectMapper) {
+    this.operations = operations;
+    this.challengeStore = challengeStore;
+    this.appUserRepository = appUserRepository;
+    this.credentialRepository = credentialRepository;
+    this.sessionService = sessionService;
+    this.objectMapper = webAuthnObjectMapper;
+  }
+
+  /**
+   * Test-friendly constructor. Builds a WebAuthn-aware {@link ObjectMapper} (the {@code
+   * WebauthnJackson2Module} is required to deserialize the finish-endpoint credential bodies) so
+   * the ceremony JSON path is still exercised under unit tests.
+   *
+   * @param operations the WebAuthn relying-party operations engine
+   * @param challengeStore the short-TTL single-use challenge store
+   * @param appUserRepository the app_user repository
+   * @param credentialRepository the JDBC webauthn_credential repository
+   * @param sessionService the F1 session service
+   */
+  WebAuthnService(
+      WebAuthnRelyingPartyOperations operations,
+      WebAuthnChallengeStore challengeStore,
+      AppUserRepository appUserRepository,
+      WebAuthnCredentialRepository credentialRepository,
+      SessionService sessionService) {
+    this(
+        operations,
+        challengeStore,
+        appUserRepository,
+        credentialRepository,
+        sessionService,
+        defaultWebAuthnObjectMapper());
+  }
+
+  private static ObjectMapper defaultWebAuthnObjectMapper() {
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.registerModule(new WebauthnJackson2Module());
+    return mapper;
+  }
+
+  /**
+   * Registration options for the logged-in admin; the challenge is stored under their user handle.
+   *
+   * @param principal the authenticated principal
+   * @return the W3C creation options to return to the browser
+   */
+  public PublicKeyCredentialCreationOptions startRegistration(AuthPrincipal principal) {
+    AppUserEntity user = requireUser(principal.userId());
+    Authentication auth = toAuthentication(principal);
+    PublicKeyCredentialCreationOptions options =
+        operations.createPublicKeyCredentialCreationOptions(
+            new ImmutablePublicKeyCredentialCreationOptionsRequest(auth));
+    challengeStore.put(user.getWebauthnUserHandle().toString(), options);
+    return options;
+  }
+
+  /**
+   * Verify and store the new credential, scoped to the authenticated principal's stored challenge.
+   *
+   * @param principal the authenticated principal
+   * @param credentialJson the raw W3C attestation credential JSON from {@code register/finish}
+   */
+  public void finishRegistration(AuthPrincipal principal, String credentialJson) {
+    AppUserEntity user = requireUser(principal.userId());
+    PublicKeyCredentialCreationOptions saved =
+        (PublicKeyCredentialCreationOptions)
+            challengeStore
+                .take(user.getWebauthnUserHandle().toString())
+                .orElseThrow(
+                    () ->
+                        new IllegalStateException("No in-flight registration challenge for user"));
+    PublicKeyCredential<AuthenticatorAttestationResponse> credential =
+        deserializeAttestation(credentialJson);
+    operations.registerCredential(
+        new ImmutableRelyingPartyRegistrationRequest(
+            saved, new RelyingPartyPublicKey(credential, user.getEmail())));
+  }
+
+  /**
+   * Assertion request options for a login attempt, scoped to the email's registered credentials
+   * (non-discoverable / allow-list flow, derived by the operations engine from the email). The
+   * challenge is stored under a fresh per-attempt id.
+   *
+   * @param email the email the user typed
+   * @return the per-attempt id + the W3C request options
+   */
+  public LoginStart startLogin(String email) {
+    Authentication auth = usernameAuthentication(email);
+    PublicKeyCredentialRequestOptions options =
+        operations.createCredentialRequestOptions(
+            new ImmutablePublicKeyCredentialRequestOptionsRequest(auth));
+    String attemptId = UUID.randomUUID().toString();
+    challengeStore.put(attemptId, options);
+    return new LoginStart(attemptId, options);
+  }
+
+  /**
+   * Verify the assertion (user-verification + sign_count regression enforced inside the operations
+   * call) and mint an mfa=true session for the resolved user.
+   *
+   * @param attemptId the per-attempt id (carried by the ezac_webauthn_attempt cookie)
+   * @param credentialJson the raw W3C assertion credential JSON from {@code login/finish}
+   * @param request the servlet request (IP / User-Agent for the session row)
+   * @param response the Set-Cookie sink for the session cookie
+   */
+  public void finishLogin(
+      String attemptId,
+      String credentialJson,
+      HttpServletRequest request,
+      HttpServletResponse response) {
+    PublicKeyCredentialRequestOptions saved =
+        (PublicKeyCredentialRequestOptions)
+            challengeStore
+                .take(attemptId)
+                .orElseThrow(() -> new IllegalStateException("No in-flight login challenge"));
+    PublicKeyCredential<AuthenticatorAssertionResponse> credential =
+        deserializeAssertion(credentialJson);
+
+    PublicKeyCredentialUserEntity authenticated =
+        operations.authenticate(new RelyingPartyAuthenticationRequest(saved, credential));
+
+    UUID handle =
+        UUID.fromString(new String(authenticated.getId().getBytes(), StandardCharsets.UTF_8));
+    AppUserEntity user =
+        appUserRepository
+            .findByWebauthnUserHandle(handle)
+            .orElseThrow(
+                () -> new IllegalStateException("Authenticated handle has no app_user: " + handle));
+
+    sessionService.create(user, true, request, response);
+  }
+
+  private AppUserEntity requireUser(Long userId) {
+    return appUserRepository
+        .findById(userId)
+        .orElseThrow(() -> new IllegalStateException("Principal has no app_user: " + userId));
+  }
+
+  private static Authentication toAuthentication(AuthPrincipal principal) {
+    return new UsernamePasswordAuthenticationToken(
+        principal.email(),
+        principal,
+        AuthorityUtils.createAuthorityList("ROLE_" + principal.role().name()));
+  }
+
+  /**
+   * Build a bare {@link Authentication} whose name is the email. The operations engine reads only
+   * {@code getName()} when minting login options, so this carries the email-scoping signal without
+   * implying the user is actually authenticated.
+   */
+  private static Authentication usernameAuthentication(String email) {
+    return new UsernamePasswordAuthenticationToken(email, null, AuthorityUtils.NO_AUTHORITIES);
+  }
+
+  private PublicKeyCredential<AuthenticatorAttestationResponse> deserializeAttestation(
+      String json) {
+    try {
+      return objectMapper.readValue(
+          json, new TypeReference<PublicKeyCredential<AuthenticatorAttestationResponse>>() {});
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Invalid attestation credential JSON", e);
+    }
+  }
+
+  private PublicKeyCredential<AuthenticatorAssertionResponse> deserializeAssertion(String json) {
+    try {
+      return objectMapper.readValue(
+          json, new TypeReference<PublicKeyCredential<AuthenticatorAssertionResponse>>() {});
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Invalid assertion credential JSON", e);
+    }
+  }
+
+  /**
+   * Result of {@link #startLogin(String)}: the per-attempt id (the controller sets it as the {@code
+   * ezac_webauthn_attempt} cookie so the client returns it on {@code /login/finish}) plus the
+   * request options.
+   *
+   * @param attemptId the per-attempt id
+   * @param options the W3C request options
+   */
+  public record LoginStart(String attemptId, PublicKeyCredentialRequestOptions options) {}
+}

--- a/src/main/java/edens/zac/portfolio/backend/services/WebAuthnService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/WebAuthnService.java
@@ -179,8 +179,10 @@ public class WebAuthnService {
    * @param credentialJson the raw W3C assertion credential JSON from {@code login/finish}
    * @param request the servlet request (IP / User-Agent for the session row)
    * @param response the Set-Cookie sink for the session cookie
+   * @return the email address of the successfully authenticated user (used by the controller to
+   *     reset the rate-limiter on success)
    */
-  public void finishLogin(
+  public String finishLogin(
       String attemptId,
       String credentialJson,
       HttpServletRequest request,
@@ -205,6 +207,7 @@ public class WebAuthnService {
                 () -> new IllegalStateException("Authenticated handle has no app_user: " + handle));
 
     sessionService.create(user, true, request, response);
+    return user.getEmail();
   }
 
   private AppUserEntity requireUser(Long userId) {

--- a/src/main/java/edens/zac/portfolio/backend/services/WebAuthnService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/WebAuthnService.java
@@ -11,7 +11,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.AuthorityUtils;
@@ -63,21 +63,24 @@ public class WebAuthnService {
    * @param appUserRepository the app_user repository (principal/handle resolution)
    * @param credentialRepository the JDBC webauthn_credential repository
    * @param sessionService the F1 session service (login converges here)
-   * @param webAuthnObjectMapper the WebAuthn-aware mapper that (de)serializes ceremony JSON
+   * @param objectMapper the primary application mapper (Spring Boot auto-registers the WebAuthn
+   *     Jackson module onto it via the {@link
+   *     edens.zac.portfolio.backend.config.WebAuthnConfig#webauthnJackson2Module()} bean)
    */
+  @Autowired
   public WebAuthnService(
       WebAuthnRelyingPartyOperations operations,
       WebAuthnChallengeStore challengeStore,
       AppUserRepository appUserRepository,
       WebAuthnCredentialRepository credentialRepository,
       SessionService sessionService,
-      @Qualifier("webAuthnObjectMapper") ObjectMapper webAuthnObjectMapper) {
+      ObjectMapper objectMapper) {
     this.operations = operations;
     this.challengeStore = challengeStore;
     this.appUserRepository = appUserRepository;
     this.credentialRepository = credentialRepository;
     this.sessionService = sessionService;
-    this.objectMapper = webAuthnObjectMapper;
+    this.objectMapper = objectMapper;
   }
 
   /**

--- a/src/main/java/edens/zac/portfolio/backend/types/Role.java
+++ b/src/main/java/edens/zac/portfolio/backend/types/Role.java
@@ -1,0 +1,6 @@
+package edens.zac.portfolio.backend.types;
+
+public enum Role {
+  ADMIN,
+  CLIENT
+}

--- a/src/main/java/edens/zac/portfolio/backend/types/UserStatus.java
+++ b/src/main/java/edens/zac/portfolio/backend/types/UserStatus.java
@@ -1,0 +1,7 @@
+package edens.zac.portfolio.backend.types;
+
+public enum UserStatus {
+  INVITED,
+  ACTIVE,
+  DISABLED
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -4,3 +4,6 @@
 # Secure flag (browsers silently drop Secure cookies on insecure origins, which
 # locks the gate after a successful password submit).
 app.gallery-access.cookie-secure=false
+
+# Auth session cookie: disable Secure flag on plain http://localhost.
+app.auth.cookie-secure=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -91,6 +91,7 @@ app.gallery-access.cookie-secure=${GALLERY_COOKIE_SECURE:true}
 app.auth.cookie-secure=${AUTH_COOKIE_SECURE:true}
 app.auth.session.ttl-days=60
 app.auth.session.refresh-threshold-hours=24
+app.auth.session.max-lifetime-days=90
 app.auth.admin.bootstrap-email=${ADMIN_BOOTSTRAP_EMAIL:}
 app.auth.admin.bootstrap-password=${ADMIN_BOOTSTRAP_PASSWORD:}
 app.auth.login.max-attempts=5

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -87,6 +87,19 @@ app.contact.rate-limit-per-email-per-hour=5
 app.gallery-access.cookie-secure=${GALLERY_COOKIE_SECURE:true}
 
 #----------------------------------------#
+# Auth session + cookie
+app.auth.cookie-secure=${AUTH_COOKIE_SECURE:true}
+app.auth.session.ttl-days=60
+app.auth.session.refresh-threshold-hours=24
+app.auth.admin.bootstrap-email=${ADMIN_BOOTSTRAP_EMAIL:}
+app.auth.admin.bootstrap-password=${ADMIN_BOOTSTRAP_PASSWORD:}
+app.auth.login.max-attempts=5
+app.auth.login.window-minutes=15
+app.auth.webauthn.rp-id=${WEBAUTHN_RP_ID:localhost}
+app.auth.webauthn.rp-name=${WEBAUTHN_RP_NAME:Zac Edens Photography}
+app.auth.webauthn.allowed-origins=${WEBAUTHN_ALLOWED_ORIGINS:http://localhost:3000,http://localhost:3001}
+
+#----------------------------------------#
 # Email (AWS SES v2)
 # Disabled by default — flip to true once SES domain + from-address verification land.
 email.enabled=${EMAIL_ENABLED:false}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -99,6 +99,7 @@ app.auth.login.window-minutes=15
 app.auth.webauthn.rp-id=${WEBAUTHN_RP_ID:localhost}
 app.auth.webauthn.rp-name=${WEBAUTHN_RP_NAME:Zac Edens Photography}
 app.auth.webauthn.allowed-origins=${WEBAUTHN_ALLOWED_ORIGINS:http://localhost:3000,http://localhost:3001}
+app.auth.webauthn.challenge-ttl-minutes=5
 
 #----------------------------------------#
 # Email (AWS SES v2)

--- a/src/main/resources/db/migration/V1__initial_schema.sql
+++ b/src/main/resources/db/migration/V1__initial_schema.sql
@@ -1,0 +1,170 @@
+-- V1: Initial portfolio backend schema.
+-- This migration captures the baseline tables that existed before Flyway was introduced.
+-- All subsequent migrations (V2+) alter or extend these tables.
+
+-- Reference lookup tables
+-- Note: location.slug added in V8; V2 creates location with IF NOT EXISTS (pre-Flyway it existed already).
+CREATE TABLE location (
+    id            BIGSERIAL PRIMARY KEY,
+    location_name VARCHAR(255) NOT NULL UNIQUE,
+    created_at    TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_location_name ON location(location_name);
+-- Note: slug columns added to tag, content_people, location in V8.
+CREATE TABLE tag (
+    id         BIGSERIAL PRIMARY KEY,
+    tag_name   VARCHAR(100) NOT NULL UNIQUE,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE content_people (
+    id          BIGSERIAL PRIMARY KEY,
+    person_name VARCHAR(100) NOT NULL UNIQUE,
+    created_at  TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE content_cameras (
+    id          BIGSERIAL PRIMARY KEY,
+    camera_name VARCHAR(200) NOT NULL UNIQUE,
+    created_at  TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE content_lenses (
+    id         BIGSERIAL PRIMARY KEY,
+    lens_name  VARCHAR(200) NOT NULL UNIQUE,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE content_film_types (
+    id             BIGSERIAL PRIMARY KEY,
+    film_type_name VARCHAR(100) NOT NULL UNIQUE,
+    display_name   VARCHAR(200),
+    default_iso    INTEGER NOT NULL DEFAULT 0,
+    created_at     TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- Core collection table
+CREATE TABLE collection (
+    id               BIGSERIAL PRIMARY KEY,
+    type             VARCHAR(50)  NOT NULL,
+    title            VARCHAR(100) NOT NULL,
+    slug             VARCHAR(150) NOT NULL UNIQUE,
+    description      VARCHAR(500),
+    collection_date  DATE,
+    visible          BOOLEAN NOT NULL DEFAULT TRUE,
+    display_mode     VARCHAR(50),
+    cover_image_id   BIGINT,
+    content_per_page INTEGER,
+    total_content    INTEGER,
+    created_at       TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- Base content table (polymorphic parent)
+CREATE TABLE content (
+    id           BIGSERIAL PRIMARY KEY,
+    content_type VARCHAR(50) NOT NULL,
+    created_at   TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at   TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- Image content (child of content)
+-- Note: caption and alt added in V26, rating on gif added in V24.
+CREATE TABLE content_image (
+    id               BIGINT PRIMARY KEY REFERENCES content(id) ON DELETE CASCADE,
+    title            VARCHAR(255),
+    image_width      INTEGER,
+    image_height     INTEGER,
+    iso              INTEGER,
+    author           VARCHAR(100),
+    rating           INTEGER,
+    f_stop           VARCHAR(20),
+    lens_id          BIGINT REFERENCES content_lenses(id),
+    black_and_white  BOOLEAN,
+    is_film          BOOLEAN,
+    film_type_id     BIGINT REFERENCES content_film_types(id),
+    film_format      VARCHAR(20),
+    shutter_speed    VARCHAR(50),
+    camera_id        BIGINT REFERENCES content_cameras(id),
+    focal_length     VARCHAR(50),
+    image_url_web      VARCHAR(1024) NOT NULL,
+    image_url_original VARCHAR(1024),
+    -- image_url_raw added in V10
+    -- capture_date (DATE), last_export_date, original_filename added in V4; create_date, file_identifier dropped in V4
+    file_identifier    VARCHAR(512),
+    create_date        VARCHAR(50)
+);
+
+-- Text content (child of content)
+CREATE TABLE content_text (
+    id           BIGINT PRIMARY KEY REFERENCES content(id) ON DELETE CASCADE,
+    text_content TEXT NOT NULL,
+    format_type  VARCHAR(50)
+);
+
+-- GIF content (child of content)
+CREATE TABLE content_gif (
+    id            BIGINT PRIMARY KEY REFERENCES content(id) ON DELETE CASCADE,
+    title         VARCHAR(255),
+    gif_url       VARCHAR(1024),
+    -- gif_url_web added in V25
+    thumbnail_url VARCHAR(1024),
+    width         INTEGER,
+    height        INTEGER,
+    author        VARCHAR(100),
+    create_date   VARCHAR(50)
+    -- rating added in V24
+);
+
+-- Collection-reference content (child of content)
+CREATE TABLE content_collection (
+    id                     BIGINT PRIMARY KEY REFERENCES content(id) ON DELETE CASCADE,
+    referenced_collection_id BIGINT NOT NULL REFERENCES collection(id) ON DELETE CASCADE
+);
+
+-- Collection content join (ordered)
+CREATE TABLE collection_content (
+    id            BIGSERIAL PRIMARY KEY,
+    collection_id BIGINT NOT NULL REFERENCES collection(id) ON DELETE CASCADE,
+    content_id    BIGINT NOT NULL REFERENCES content(id) ON DELETE CASCADE,
+    order_index   INTEGER NOT NULL DEFAULT 0,
+    visible       BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at    TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- Tag join tables
+CREATE TABLE content_tags (
+    content_id BIGINT NOT NULL REFERENCES content(id) ON DELETE CASCADE,
+    tag_id     BIGINT NOT NULL REFERENCES tag(id) ON DELETE CASCADE,
+    PRIMARY KEY (content_id, tag_id)
+);
+
+CREATE TABLE collection_tags (
+    collection_id BIGINT NOT NULL REFERENCES collection(id) ON DELETE CASCADE,
+    tag_id        BIGINT NOT NULL REFERENCES tag(id) ON DELETE CASCADE,
+    PRIMARY KEY (collection_id, tag_id)
+);
+
+-- People join tables
+-- Note: image_id column is renamed to content_id in V27.
+CREATE TABLE content_image_people (
+    image_id  BIGINT NOT NULL REFERENCES content_image(id) ON DELETE CASCADE,
+    person_id BIGINT NOT NULL REFERENCES content_people(id) ON DELETE CASCADE,
+    PRIMARY KEY (image_id, person_id)
+);
+
+-- collection_people: V9 creates indexes on this table, V22 adds it with IF NOT EXISTS.
+-- Create here so V9 index creation succeeds.
+CREATE TABLE collection_people (
+    collection_id BIGINT NOT NULL REFERENCES collection(id) ON DELETE CASCADE,
+    person_id     BIGINT NOT NULL REFERENCES content_people(id) ON DELETE CASCADE,
+    PRIMARY KEY (collection_id, person_id)
+);
+
+-- Basic indexes
+CREATE INDEX idx_collection_type   ON collection(type);
+CREATE INDEX idx_collection_date   ON collection(collection_date DESC NULLS LAST);
+CREATE INDEX idx_content_type      ON content(content_type);
+CREATE INDEX idx_content_image_url ON content_image(image_url_web);

--- a/src/main/resources/db/migration/V29__create_auth_tables.sql
+++ b/src/main/resources/db/migration/V29__create_auth_tables.sql
@@ -1,0 +1,43 @@
+-- V29: Auth foundation spine (Phase F1).
+-- Three tables: app_user (the principal), user_session (DB-backed opaque sessions),
+-- gallery_access (per-person collection scope — created now, read by no controller until Phase C).
+-- webauthn_credential is V30 (F2), not here.
+
+-- The principal. role distinguishes admin from client.
+CREATE TABLE app_user (
+  id                   BIGSERIAL PRIMARY KEY,
+  email                VARCHAR(255) UNIQUE NOT NULL,
+  role                 VARCHAR(16)  NOT NULL,         -- 'ADMIN' | 'CLIENT'
+  password_hash        VARCHAR(255),                  -- DelegatingPasswordEncoder ({bcrypt}...); null until set
+  webauthn_user_handle UUID UNIQUE NOT NULL,          -- random handle WebAuthn binds to (NOT the email)
+  display_name         VARCHAR(120),
+  status               VARCHAR(16)  NOT NULL,         -- 'INVITED' | 'ACTIVE' | 'DISABLED'
+  created_at           TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  updated_at           TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+CREATE TABLE user_session (
+  id            BIGSERIAL PRIMARY KEY,
+  user_id       BIGINT NOT NULL REFERENCES app_user(id) ON DELETE CASCADE,
+  token_hash    VARCHAR(255) NOT NULL UNIQUE,         -- SHA-256 hex of the raw cookie value
+  mfa_satisfied BOOLEAN NOT NULL DEFAULT FALSE,        -- true=passkey(user-verified), false=break-glass password
+  ip            VARCHAR(64),
+  user_agent    VARCHAR(255),
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_seen_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at    TIMESTAMPTZ NOT NULL,
+  revoked_at    TIMESTAMPTZ
+);
+CREATE INDEX idx_user_session_user_id ON user_session(user_id);
+
+CREATE TABLE gallery_access (
+  id            BIGSERIAL PRIMARY KEY,
+  user_id       BIGINT NOT NULL REFERENCES app_user(id) ON DELETE CASCADE,
+  collection_id BIGINT NOT NULL REFERENCES collection(id) ON DELETE CASCADE,
+  can_download  BOOLEAN NOT NULL DEFAULT TRUE,
+  can_tag       BOOLEAN NOT NULL DEFAULT FALSE,
+  granted_by    BIGINT REFERENCES app_user(id),
+  granted_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at    TIMESTAMPTZ,
+  UNIQUE (user_id, collection_id)
+);

--- a/src/main/resources/db/migration/V30__create_webauthn_credentials.sql
+++ b/src/main/resources/db/migration/V30__create_webauthn_credentials.sql
@@ -1,0 +1,12 @@
+CREATE TABLE webauthn_credential (
+  id            BIGSERIAL PRIMARY KEY,
+  user_id       BIGINT NOT NULL REFERENCES app_user(id) ON DELETE CASCADE,
+  credential_id BYTEA NOT NULL UNIQUE,
+  public_key    BYTEA NOT NULL,
+  sign_count    BIGINT NOT NULL DEFAULT 0,
+  transports    VARCHAR(64),
+  label         VARCHAR(120),
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_used_at  TIMESTAMPTZ
+);
+CREATE INDEX idx_webauthn_credential_user_id ON webauthn_credential(user_id);

--- a/src/test/java/edens/zac/portfolio/backend/AbstractPostgresIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/AbstractPostgresIntegrationTest.java
@@ -1,0 +1,22 @@
+package edens.zac.portfolio.backend;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Base class for DB-touching integration tests. Boots a real Postgres 16 container, wires it to the
+ * Spring DataSource via {@link ServiceConnection}, and lets Flyway build the full V1..V29 schema on
+ * context start — so security-critical SQL actually executes. Requires Docker to be running.
+ */
+@SpringBootTest
+@Testcontainers
+@ActiveProfiles("test")
+public abstract class AbstractPostgresIntegrationTest {
+
+  @Container @ServiceConnection
+  static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+}

--- a/src/test/java/edens/zac/portfolio/backend/AbstractPostgresIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/AbstractPostgresIntegrationTest.java
@@ -1,6 +1,9 @@
 package edens.zac.portfolio.backend;
 
+import org.junit.jupiter.api.AfterEach;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -13,6 +16,10 @@ import org.testcontainers.containers.PostgreSQLContainer;
  * {@link DynamicPropertySource}. Flyway then baselines the non-empty DB at 0 and applies V2..V29 on
  * top — exactly mirroring prod. All subclasses share the same container so the Spring TestContext
  * cache never points at a stopped container. Requires Docker to be running.
+ *
+ * <p>After each test method, auth tables are truncated so every test starts from a clean slate,
+ * eliminating order-dependent failures (e.g. {@code existsByRole} counting rows from a previous
+ * class). Non-auth tables (collections, content, etc.) are intentionally left untouched.
  */
 @SpringBootTest
 @ActiveProfiles("test")
@@ -30,5 +37,19 @@ public abstract class AbstractPostgresIntegrationTest {
     registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
     registry.add("spring.datasource.username", POSTGRES::getUsername);
     registry.add("spring.datasource.password", POSTGRES::getPassword);
+  }
+
+  @Autowired private JdbcTemplate jdbcTemplate;
+
+  /**
+   * Truncate all auth tables after each test so rows from one test (or test class) cannot affect
+   * assertions in another. {@code RESTART IDENTITY} resets sequences; {@code CASCADE} handles FK
+   * children. Only auth tables are touched — pre-existing schema tables are left intact.
+   */
+  @AfterEach
+  void truncateAuthTables() {
+    jdbcTemplate.execute(
+        "TRUNCATE TABLE webauthn_credential, gallery_access, user_session, app_user"
+            + " RESTART IDENTITY CASCADE");
   }
 }

--- a/src/test/java/edens/zac/portfolio/backend/AbstractPostgresIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/AbstractPostgresIntegrationTest.java
@@ -1,26 +1,34 @@
 package edens.zac.portfolio.backend;
 
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 /**
- * Base class for DB-touching integration tests. Boots a real Postgres 16 container, seeds the
- * pre-Flyway base schema via {@code db/test-base-schema.sql} (so the V2..V28 ALTERs have tables to
- * act on), wires the container to the Spring DataSource via {@link ServiceConnection}, and lets
- * Flyway baseline the non-empty DB at 0 and apply V2..V29 on top on context start — so
- * security-critical SQL actually executes. This mirrors prod (already baselined at 0) without
- * adding any migration below the prod max applied version. Requires Docker to be running.
+ * Base class for DB-touching integration tests. Boots a real Postgres 16 container once per JVM run
+ * (singleton pattern — Ryuk reaps it at JVM exit), seeds the pre-Flyway base schema via {@code
+ * db/test-base-schema.sql}, and wires the container URL/credentials into the Spring DataSource via
+ * {@link DynamicPropertySource}. Flyway then baselines the non-empty DB at 0 and applies V2..V29 on
+ * top — exactly mirroring prod. All subclasses share the same container so the Spring TestContext
+ * cache never points at a stopped container. Requires Docker to be running.
  */
 @SpringBootTest
-@Testcontainers
 @ActiveProfiles("test")
 public abstract class AbstractPostgresIntegrationTest {
 
-  @Container @ServiceConnection
-  static PostgreSQLContainer<?> postgres =
+  static final PostgreSQLContainer<?> POSTGRES =
       new PostgreSQLContainer<>("postgres:16-alpine").withInitScript("db/test-base-schema.sql");
+
+  static {
+    POSTGRES.start();
+  }
+
+  @DynamicPropertySource
+  static void datasourceProps(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+    registry.add("spring.datasource.username", POSTGRES::getUsername);
+    registry.add("spring.datasource.password", POSTGRES::getPassword);
+  }
 }

--- a/src/test/java/edens/zac/portfolio/backend/AbstractPostgresIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/AbstractPostgresIntegrationTest.java
@@ -8,9 +8,12 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 /**
- * Base class for DB-touching integration tests. Boots a real Postgres 16 container, wires it to the
- * Spring DataSource via {@link ServiceConnection}, and lets Flyway build the full V1..V29 schema on
- * context start — so security-critical SQL actually executes. Requires Docker to be running.
+ * Base class for DB-touching integration tests. Boots a real Postgres 16 container, seeds the
+ * pre-Flyway base schema via {@code db/test-base-schema.sql} (so the V2..V28 ALTERs have tables to
+ * act on), wires the container to the Spring DataSource via {@link ServiceConnection}, and lets
+ * Flyway baseline the non-empty DB at 0 and apply V2..V29 on top on context start — so
+ * security-critical SQL actually executes. This mirrors prod (already baselined at 0) without
+ * adding any migration below the prod max applied version. Requires Docker to be running.
  */
 @SpringBootTest
 @Testcontainers
@@ -18,5 +21,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 public abstract class AbstractPostgresIntegrationTest {
 
   @Container @ServiceConnection
-  static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+  static PostgreSQLContainer<?> postgres =
+      new PostgreSQLContainer<>("postgres:16-alpine").withInitScript("db/test-base-schema.sql");
 }

--- a/src/test/java/edens/zac/portfolio/backend/AuthWebAuthnMigrationIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/AuthWebAuthnMigrationIntegrationTest.java
@@ -1,0 +1,76 @@
+package edens.zac.portfolio.backend;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Verifies the V30 Flyway migration applied: the webauthn_credential table exists with the expected
+ * columns, the credential_id unique constraint, and the FK to app_user. Extends the F1
+ * Testcontainers base so the full V1..V30 chain runs on context start.
+ */
+class AuthWebAuthnMigrationIntegrationTest extends AbstractPostgresIntegrationTest {
+
+  @Autowired private DataSource dataSource;
+
+  @Test
+  void webauthnCredentialTableExistsWithExpectedColumns() {
+    JdbcTemplate jdbc = new JdbcTemplate(dataSource);
+    Integer tableCount =
+        jdbc.queryForObject(
+            "SELECT COUNT(*) FROM information_schema.tables "
+                + "WHERE table_name = 'webauthn_credential'",
+            Integer.class);
+    assertThat(tableCount).isEqualTo(1);
+
+    Integer columnCount =
+        jdbc.queryForObject(
+            "SELECT COUNT(*) FROM information_schema.columns "
+                + "WHERE table_name = 'webauthn_credential' "
+                + "AND column_name IN "
+                + "('id','user_id','credential_id','public_key','sign_count','transports',"
+                + "'label','created_at','last_used_at')",
+            Integer.class);
+    assertThat(columnCount).isEqualTo(9);
+  }
+
+  @Test
+  void credentialIdHasUniqueConstraint() {
+    JdbcTemplate jdbc = new JdbcTemplate(dataSource);
+    Integer uniqueCount =
+        jdbc.queryForObject(
+            "SELECT COUNT(*) FROM information_schema.table_constraints "
+                + "WHERE table_name = 'webauthn_credential' "
+                + "AND constraint_type = 'UNIQUE'",
+            Integer.class);
+    assertThat(uniqueCount).isGreaterThanOrEqualTo(1);
+  }
+
+  @Test
+  void deletingUserCascadesToCredentials() {
+    JdbcTemplate jdbc = new JdbcTemplate(dataSource);
+    Long userId =
+        jdbc.queryForObject(
+            "INSERT INTO app_user "
+                + "(email, role, webauthn_user_handle, status) "
+                + "VALUES (?, 'ADMIN', gen_random_uuid(), 'ACTIVE') RETURNING id",
+            Long.class,
+            "cascade-webauthn@example.com");
+    jdbc.update(
+        "INSERT INTO webauthn_credential (user_id, credential_id, public_key) "
+            + "VALUES (?, ?, ?)",
+        userId,
+        new byte[] {1, 2, 3},
+        new byte[] {4, 5, 6});
+
+    jdbc.update("DELETE FROM app_user WHERE id = ?", userId);
+
+    Integer remaining =
+        jdbc.queryForObject(
+            "SELECT COUNT(*) FROM webauthn_credential WHERE user_id = ?", Integer.class, userId);
+    assertThat(remaining).isZero();
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/auth/AuthFlowEndToEndTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/auth/AuthFlowEndToEndTest.java
@@ -1,0 +1,145 @@
+package edens.zac.portfolio.backend.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import edens.zac.portfolio.backend.AbstractPostgresIntegrationTest;
+import edens.zac.portfolio.backend.dao.AppUserRepository;
+import edens.zac.portfolio.backend.entity.AppUserEntity;
+import edens.zac.portfolio.backend.model.MeResponse;
+import edens.zac.portfolio.backend.types.Role;
+import edens.zac.portfolio.backend.types.UserStatus;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * End-to-end integration test for the password login flow. Exercises the full stack:
+ * SecurityFilterChain → SessionAuthenticationFilter → SessionService → real Postgres. The {@code
+ * prod}-profile {@link edens.zac.portfolio.backend.config.InternalSecretFilter} is inactive in the
+ * {@code test} profile so no BFF secret header is needed.
+ *
+ * <p>Note: the WebAuthn (passkey) round-trip requires a software authenticator to generate a valid
+ * assertion and is intentionally out of scope for this test.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class AuthFlowEndToEndTest extends AbstractPostgresIntegrationTest {
+
+  private static final String KNOWN_PASSWORD = "correct-horse";
+  private static final String ADMIN_EMAIL = "e2e-admin@example.com";
+
+  @LocalServerPort private int port;
+
+  @Autowired private AppUserRepository appUserRepository;
+  @Autowired private PasswordEncoder passwordEncoder;
+
+  private TestRestTemplate restTemplate;
+
+  @BeforeEach
+  void seedAdminUser() {
+    // AbstractPostgresIntegrationTest.truncateAuthTables() already cleared tables before we seed.
+    restTemplate = new TestRestTemplate();
+    String hash = passwordEncoder.encode(KNOWN_PASSWORD);
+    appUserRepository.insert(
+        AppUserEntity.builder()
+            .email(ADMIN_EMAIL)
+            .role(Role.ADMIN)
+            .passwordHash(hash)
+            .webauthnUserHandle(UUID.randomUUID())
+            .status(UserStatus.ACTIVE)
+            .build());
+  }
+
+  private String baseUrl() {
+    return "http://localhost:" + port;
+  }
+
+  @Test
+  void loginWithCorrectCredentials_returns204WithSessionCookie() {
+    ResponseEntity<Void> response = postLogin(ADMIN_EMAIL, KNOWN_PASSWORD);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    assertThat(response.getHeaders().get("Set-Cookie"))
+        .isNotNull()
+        .anySatisfy(
+            cookie -> {
+              assertThat(cookie).contains("ezac_session=");
+              assertThat(cookie).containsIgnoringCase("HttpOnly");
+            });
+  }
+
+  @Test
+  void meWithSessionCookie_returns200WithAdminPrincipal() {
+    ResponseEntity<Void> loginResponse = postLogin(ADMIN_EMAIL, KNOWN_PASSWORD);
+    assertThat(loginResponse.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+
+    String sessionCookie = extractSessionCookie(loginResponse);
+    assertThat(sessionCookie).isNotBlank();
+
+    ResponseEntity<MeResponse> meResponse = getMe(sessionCookie);
+    assertThat(meResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(meResponse.getBody()).isNotNull();
+    assertThat(meResponse.getBody().email()).isEqualTo(ADMIN_EMAIL);
+    assertThat(meResponse.getBody().role()).isEqualTo(Role.ADMIN);
+    assertThat(meResponse.getBody().mfaSatisfied()).isFalse();
+  }
+
+  @Test
+  void meWithoutCookie_returns401() {
+    ResponseEntity<Void> response =
+        restTemplate.exchange(
+            baseUrl() + "/api/auth/me", HttpMethod.GET, HttpEntity.EMPTY, Void.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+  }
+
+  @Test
+  void loginWithWrongPassword_returns401() {
+    ResponseEntity<Void> response = postLogin(ADMIN_EMAIL, "wrong-password");
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+  }
+
+  // ---- helpers ----
+
+  private ResponseEntity<Void> postLogin(String email, String password) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("Content-Type", "application/json");
+    Map<String, String> body = Map.of("email", email, "password", password);
+    return restTemplate.exchange(
+        baseUrl() + "/api/auth/login",
+        HttpMethod.POST,
+        new HttpEntity<>(body, headers),
+        Void.class);
+  }
+
+  private String extractSessionCookie(ResponseEntity<?> response) {
+    return response.getHeaders().getOrEmpty("Set-Cookie").stream()
+        .filter(c -> c.startsWith("ezac_session="))
+        .findFirst()
+        .map(
+            c -> {
+              String after = c.substring("ezac_session=".length());
+              int semi = after.indexOf(';');
+              return semi >= 0 ? after.substring(0, semi) : after;
+            })
+        .orElse("");
+  }
+
+  private ResponseEntity<MeResponse> getMe(String rawToken) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("Cookie", "ezac_session=" + rawToken);
+    return restTemplate.exchange(
+        baseUrl() + "/api/auth/me", HttpMethod.GET, new HttpEntity<>(headers), MeResponse.class);
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/config/AuthLoginLimiterTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/config/AuthLoginLimiterTest.java
@@ -1,0 +1,56 @@
+package edens.zac.portfolio.backend.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class AuthLoginLimiterTest {
+
+  @Test
+  void fiveFailuresAllowedSixthIsBlocked() {
+    AuthLoginLimiter limiter = new AuthLoginLimiter(5, 15);
+    for (int i = 0; i < 5; i++) {
+      assertThat(limiter.isBlocked("203.0.113.1", "a@example.com")).isFalse();
+      limiter.recordFailure("203.0.113.1", "a@example.com");
+    }
+    assertThat(limiter.isBlocked("203.0.113.1", "a@example.com")).isTrue();
+  }
+
+  @Test
+  void resetClearsTheCounter() {
+    AuthLoginLimiter limiter = new AuthLoginLimiter(2, 15);
+    limiter.recordFailure("203.0.113.1", "b@example.com");
+    limiter.recordFailure("203.0.113.1", "b@example.com");
+    assertThat(limiter.isBlocked("203.0.113.1", "b@example.com")).isTrue();
+
+    limiter.reset("203.0.113.1", "b@example.com");
+    assertThat(limiter.isBlocked("203.0.113.1", "b@example.com")).isFalse();
+  }
+
+  @Test
+  void keyIsCaseInsensitiveOnEmail() {
+    AuthLoginLimiter limiter = new AuthLoginLimiter(2, 15);
+    limiter.recordFailure("203.0.113.1", "Case@Example.com");
+    limiter.recordFailure("203.0.113.1", "case@example.com");
+    // Two failures against the same normalized key -> blocked.
+    assertThat(limiter.isBlocked("203.0.113.1", "CASE@EXAMPLE.COM")).isTrue();
+  }
+
+  @Test
+  void differentIpsAndEmailsHaveIndependentCounters() {
+    AuthLoginLimiter limiter = new AuthLoginLimiter(1, 15);
+    limiter.recordFailure("203.0.113.1", "x@example.com");
+    assertThat(limiter.isBlocked("203.0.113.1", "x@example.com")).isTrue();
+    assertThat(limiter.isBlocked("203.0.113.2", "x@example.com")).isFalse();
+    assertThat(limiter.isBlocked("203.0.113.1", "y@example.com")).isFalse();
+  }
+
+  @Test
+  void nullIpOrEmailNeverBlocks() {
+    AuthLoginLimiter limiter = new AuthLoginLimiter(1, 15);
+    assertThat(limiter.isBlocked(null, "z@example.com")).isFalse();
+    assertThat(limiter.isBlocked("203.0.113.1", null)).isFalse();
+    limiter.recordFailure(null, null);
+    assertThat(limiter.isBlocked(null, null)).isFalse();
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/config/InternalSecretFilterTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/config/InternalSecretFilterTest.java
@@ -1,0 +1,60 @@
+package edens.zac.portfolio.backend.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.annotation.Order;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class InternalSecretFilterTest {
+
+  private final InternalSecretFilter filter = new InternalSecretFilter("the-secret", "");
+
+  @Test
+  void orderIsBelowSpringSecurityChain() {
+    Order order = InternalSecretFilter.class.getAnnotation(Order.class);
+    assertThat(order).isNotNull();
+    // Spring Security's FilterChainProxy registers at -100; the channel gate must run before it.
+    assertThat(order.value()).isEqualTo(-200);
+  }
+
+  @Test
+  void rejectsMissingSecretWith403() throws Exception {
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/read/ping");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain chain = mock(FilterChain.class);
+
+    filter.doFilter(request, response, chain);
+
+    assertThat(response.getStatus()).isEqualTo(403);
+    verify(chain, never()).doFilter(request, response);
+  }
+
+  @Test
+  void passesWithValidSecret() throws Exception {
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/read/ping");
+    request.addHeader("X-Internal-Secret", "the-secret");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain chain = mock(FilterChain.class);
+
+    filter.doFilter(request, response, chain);
+
+    verify(chain).doFilter(request, response);
+  }
+
+  @Test
+  void healthEndpointBypassesGate() throws Exception {
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/actuator/health");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain chain = mock(FilterChain.class);
+
+    filter.doFilter(request, response, chain);
+
+    verify(chain).doFilter(request, response);
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/config/SecurityConfigWebMvcTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/config/SecurityConfigWebMvcTest.java
@@ -1,0 +1,98 @@
+package edens.zac.portfolio.backend.config;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import edens.zac.portfolio.backend.model.AuthPrincipal;
+import edens.zac.portfolio.backend.services.SessionService;
+import edens.zac.portfolio.backend.types.Role;
+import jakarta.servlet.http.Cookie;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@WebMvcTest
+@Import({
+  SecurityConfig.class,
+  SessionAuthenticationFilter.class,
+  SecurityConfigWebMvcTest.StubControllers.class
+})
+class SecurityConfigWebMvcTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockBean private SessionService sessionService;
+
+  @Configuration
+  static class StubControllers {
+    @Bean
+    StubReadController stubReadController() {
+      return new StubReadController();
+    }
+
+    @Bean
+    StubMeController stubMeController() {
+      return new StubMeController();
+    }
+  }
+
+  @RestController
+  static class StubReadController {
+    @GetMapping("/api/read/ping")
+    String ping() {
+      return "pong";
+    }
+  }
+
+  @RestController
+  static class StubMeController {
+    @GetMapping("/api/auth/me")
+    String me() {
+      Object principal =
+          SecurityContextHolder.getContext().getAuthentication() == null
+              ? null
+              : SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+      if (principal instanceof AuthPrincipal p) {
+        return p.email();
+      }
+      // Spring Security's anonymous authentication has a String "anonymousUser" principal.
+      return "anon";
+    }
+  }
+
+  @Test
+  void existingReadEndpointStays200ForAnonymous() throws Exception {
+    mockMvc
+        .perform(get("/api/read/ping"))
+        .andExpect(status().isOk())
+        .andExpect(content().string("pong"));
+  }
+
+  @Test
+  void meReturns401ForAnonymous() throws Exception {
+    mockMvc.perform(get("/api/auth/me")).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void meResolvesPrincipalWhenCookiePresent() throws Exception {
+    when(sessionService.resolve(eq("valid-token")))
+        .thenReturn(Optional.of(new AuthPrincipal(7L, "admin@example.com", Role.ADMIN, false)));
+
+    mockMvc
+        .perform(get("/api/auth/me").cookie(new Cookie("ezac_session", "valid-token")))
+        .andExpect(status().isOk())
+        .andExpect(content().string("admin@example.com"));
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/controller/auth/AuthControllerTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/auth/AuthControllerTest.java
@@ -1,0 +1,184 @@
+package edens.zac.portfolio.backend.controller.auth;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edens.zac.portfolio.backend.config.AuthLoginLimiter;
+import edens.zac.portfolio.backend.dao.AppUserRepository;
+import edens.zac.portfolio.backend.dao.GalleryAccessRepository;
+import edens.zac.portfolio.backend.entity.AppUserEntity;
+import edens.zac.portfolio.backend.model.AuthPrincipal;
+import edens.zac.portfolio.backend.model.LoginRequest;
+import edens.zac.portfolio.backend.services.SessionService;
+import edens.zac.portfolio.backend.types.Role;
+import edens.zac.portfolio.backend.types.UserStatus;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(MockitoExtension.class)
+class AuthControllerTest {
+
+  private MockMvc mockMvc;
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Mock private SessionService sessionService;
+  @Mock private AuthLoginLimiter loginLimiter;
+  @Mock private AppUserRepository appUserRepository;
+  @Mock private GalleryAccessRepository galleryAccessRepository;
+  @Mock private PasswordEncoder passwordEncoder;
+
+  @InjectMocks private AuthController authController;
+
+  @BeforeEach
+  void setUp() {
+    mockMvc = MockMvcBuilders.standaloneSetup(authController).build();
+  }
+
+  @AfterEach
+  void clearContext() {
+    SecurityContextHolder.clearContext();
+  }
+
+  private AppUserEntity admin() {
+    return AppUserEntity.builder()
+        .id(1L)
+        .email("admin@example.com")
+        .role(Role.ADMIN)
+        .passwordHash("{bcrypt}$2a$10$hash")
+        .webauthnUserHandle(UUID.randomUUID())
+        .status(UserStatus.ACTIVE)
+        .build();
+  }
+
+  @Test
+  void loginWithValidCredentialsReturns204AndCreatesSession() throws Exception {
+    when(loginLimiter.isBlocked(anyString(), eq("admin@example.com"))).thenReturn(false);
+    when(appUserRepository.findByEmail("admin@example.com")).thenReturn(Optional.of(admin()));
+    when(passwordEncoder.matches("correct", "{bcrypt}$2a$10$hash")).thenReturn(true);
+
+    mockMvc
+        .perform(
+            post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        new LoginRequest("admin@example.com", "correct"))))
+        .andExpect(status().isNoContent());
+
+    verify(loginLimiter).reset(anyString(), eq("admin@example.com"));
+    verify(sessionService).create(any(AppUserEntity.class), eq(false), any(), any());
+  }
+
+  @Test
+  void loginWithBadPasswordReturns401AndRecordsFailure() throws Exception {
+    when(loginLimiter.isBlocked(anyString(), eq("admin@example.com"))).thenReturn(false);
+    when(appUserRepository.findByEmail("admin@example.com")).thenReturn(Optional.of(admin()));
+    when(passwordEncoder.matches("wrong", "{bcrypt}$2a$10$hash")).thenReturn(false);
+
+    mockMvc
+        .perform(
+            post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        new LoginRequest("admin@example.com", "wrong"))))
+        .andExpect(status().isUnauthorized());
+
+    verify(loginLimiter).recordFailure(anyString(), eq("admin@example.com"));
+    verify(sessionService, never()).create(any(), anyBooleanWrapper(), any(), any());
+  }
+
+  // Helper to keep the never()-verify readable; Mockito's eq for boolean is fine inline too.
+  private static boolean anyBooleanWrapper() {
+    return org.mockito.ArgumentMatchers.anyBoolean();
+  }
+
+  @Test
+  void loginForUnknownEmailReturns401Generic() throws Exception {
+    when(loginLimiter.isBlocked(anyString(), eq("ghost@example.com"))).thenReturn(false);
+    when(appUserRepository.findByEmail("ghost@example.com")).thenReturn(Optional.empty());
+
+    mockMvc
+        .perform(
+            post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(new LoginRequest("ghost@example.com", "x"))))
+        .andExpect(status().isUnauthorized());
+
+    verify(loginLimiter).recordFailure(anyString(), eq("ghost@example.com"));
+  }
+
+  @Test
+  void loginWhenRateLimitedReturns429() throws Exception {
+    when(loginLimiter.isBlocked(anyString(), eq("admin@example.com"))).thenReturn(true);
+
+    mockMvc
+        .perform(
+            post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(new LoginRequest("admin@example.com", "x"))))
+        .andExpect(status().isTooManyRequests());
+
+    verify(appUserRepository, never()).findByEmail(anyString());
+  }
+
+  @Test
+  void logoutReturns204AndRevokes() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/auth/logout").cookie(new jakarta.servlet.http.Cookie("ezac_session", "tok")))
+        .andExpect(status().isNoContent());
+
+    verify(sessionService).revoke(eq("tok"), any());
+  }
+
+  @Test
+  void meReturns200WithPrincipal() throws Exception {
+    AuthPrincipal principal = new AuthPrincipal(1L, "admin@example.com", Role.ADMIN, false);
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new UsernamePasswordAuthenticationToken(
+                principal, null, List.of(new SimpleGrantedAuthority("ROLE_ADMIN"))));
+    when(galleryAccessRepository.findByUserId(1L)).thenReturn(List.of());
+
+    mockMvc
+        .perform(get("/api/auth/me"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.email", org.hamcrest.Matchers.is("admin@example.com")))
+        .andExpect(jsonPath("$.role", org.hamcrest.Matchers.is("ADMIN")))
+        .andExpect(jsonPath("$.mfaSatisfied", org.hamcrest.Matchers.is(false)))
+        .andExpect(jsonPath("$.galleries", org.hamcrest.Matchers.hasSize(0)));
+  }
+
+  @Test
+  void meReturns401WhenAnonymous() throws Exception {
+    // No authentication in the context.
+    mockMvc.perform(get("/api/auth/me")).andExpect(status().isUnauthorized());
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/controller/auth/AuthControllerTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/auth/AuthControllerTest.java
@@ -131,6 +131,47 @@ class AuthControllerTest {
         .andExpect(status().isUnauthorized());
 
     verify(loginLimiter).recordFailure(anyString(), eq("ghost@example.com"));
+    // Dummy BCrypt check must be performed to equalize timing with the wrong-password branch.
+    verify(passwordEncoder).matches(eq("x"), anyString());
+  }
+
+  @Test
+  void unknownEmailAndWrongPasswordBothReturn401WithNoBody() throws Exception {
+    // Unknown email branch
+    when(loginLimiter.isBlocked(anyString(), eq("ghost@example.com"))).thenReturn(false);
+    when(appUserRepository.findByEmail("ghost@example.com")).thenReturn(Optional.empty());
+
+    mockMvc
+        .perform(
+            post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(new LoginRequest("ghost@example.com", "x"))))
+        .andExpect(status().isUnauthorized())
+        .andExpect(
+            result ->
+                org.junit.jupiter.api.Assertions.assertTrue(
+                    result.getResponse().getContentAsString().isEmpty(),
+                    "401 body must be empty for unknown email"));
+
+    // Wrong password branch
+    when(loginLimiter.isBlocked(anyString(), eq("admin@example.com"))).thenReturn(false);
+    when(appUserRepository.findByEmail("admin@example.com")).thenReturn(Optional.of(admin()));
+    when(passwordEncoder.matches("wrong", "{bcrypt}$2a$10$hash")).thenReturn(false);
+
+    mockMvc
+        .perform(
+            post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        new LoginRequest("admin@example.com", "wrong"))))
+        .andExpect(status().isUnauthorized())
+        .andExpect(
+            result ->
+                org.junit.jupiter.api.Assertions.assertTrue(
+                    result.getResponse().getContentAsString().isEmpty(),
+                    "401 body must be empty for wrong password"));
   }
 
   @Test

--- a/src/test/java/edens/zac/portfolio/backend/controller/auth/WebAuthnControllerTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/auth/WebAuthnControllerTest.java
@@ -1,0 +1,165 @@
+package edens.zac.portfolio.backend.controller.auth;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edens.zac.portfolio.backend.model.AuthPrincipal;
+import edens.zac.portfolio.backend.services.WebAuthnService;
+import edens.zac.portfolio.backend.types.Role;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver;
+import org.springframework.security.web.webauthn.api.Bytes;
+import org.springframework.security.web.webauthn.api.ImmutablePublicKeyCredentialUserEntity;
+import org.springframework.security.web.webauthn.api.PublicKeyCredentialCreationOptions;
+import org.springframework.security.web.webauthn.api.PublicKeyCredentialParameters;
+import org.springframework.security.web.webauthn.api.PublicKeyCredentialRequestOptions;
+import org.springframework.security.web.webauthn.api.PublicKeyCredentialRpEntity;
+import org.springframework.security.web.webauthn.jackson.WebauthnJackson2Module;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+/**
+ * Standalone MockMvc tests for {@link WebAuthnController} with a mocked {@link WebAuthnService}
+ * (the ceremony engine itself is unit-tested in WebAuthnServiceTest). Asserts the four endpoints,
+ * the attempt-cookie transport on login, and the 401 when the attempt cookie is absent.
+ */
+class WebAuthnControllerTest {
+
+  private WebAuthnService webAuthnService;
+  private MockMvc mockMvc;
+
+  private final AuthPrincipal admin = new AuthPrincipal(1L, "admin@example.com", Role.ADMIN, false);
+
+  @BeforeEach
+  void setUp() {
+    webAuthnService = mock(WebAuthnService.class);
+    ObjectMapper webAuthnObjectMapper = new ObjectMapper();
+    webAuthnObjectMapper.registerModule(new WebauthnJackson2Module());
+    WebAuthnController controller =
+        new WebAuthnController(webAuthnService, webAuthnObjectMapper, false);
+    mockMvc =
+        MockMvcBuilders.standaloneSetup(controller)
+            .setCustomArgumentResolvers(new AuthenticationPrincipalArgumentResolver())
+            .build();
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  private RequestPostProcessor asAdmin() {
+    return request -> {
+      var auth =
+          new UsernamePasswordAuthenticationToken(
+              admin, null, AuthorityUtils.createAuthorityList("ROLE_ADMIN"));
+      SecurityContextHolder.getContext().setAuthentication(auth);
+      return request;
+    };
+  }
+
+  @Test
+  void registerStartReturns200WithOptions() throws Exception {
+    when(webAuthnService.startRegistration(any())).thenReturn(creationOptions());
+
+    mockMvc
+        .perform(post("/api/auth/webauthn/register/start").with(asAdmin()))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  void registerFinishReturns204AndDelegatesToService() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/auth/webauthn/register/finish")
+                .with(asAdmin())
+                .contentType("application/json")
+                .content("{\"id\":\"abc\"}"))
+        .andExpect(status().isNoContent());
+
+    verify(webAuthnService).finishRegistration(any(), eq("{\"id\":\"abc\"}"));
+  }
+
+  @Test
+  void loginStartReturns200WithOptionsAndSetsAttemptCookie() throws Exception {
+    when(webAuthnService.startLogin(eq("admin@example.com")))
+        .thenReturn(new WebAuthnService.LoginStart("attempt-1", requestOptions()));
+
+    mockMvc
+        .perform(
+            post("/api/auth/webauthn/login/start")
+                .contentType("application/json")
+                .content("{\"email\":\"admin@example.com\"}"))
+        .andExpect(status().isOk())
+        .andExpect(cookie().exists("ezac_webauthn_attempt"))
+        .andExpect(cookie().value("ezac_webauthn_attempt", "attempt-1"))
+        .andExpect(cookie().httpOnly("ezac_webauthn_attempt", true));
+  }
+
+  @Test
+  void loginFinishReadsAttemptCookieDelegatesAndClearsCookie() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/auth/webauthn/login/finish")
+                .cookie(new jakarta.servlet.http.Cookie("ezac_webauthn_attempt", "attempt-1"))
+                .contentType("application/json")
+                .content("{\"id\":\"abc\"}"))
+        .andExpect(status().isNoContent())
+        .andExpect(cookie().maxAge("ezac_webauthn_attempt", 0));
+
+    verify(webAuthnService).finishLogin(eq("attempt-1"), eq("{\"id\":\"abc\"}"), any(), any());
+  }
+
+  @Test
+  void loginFinishWithoutAttemptCookieReturns401() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/auth/webauthn/login/finish")
+                .contentType("application/json")
+                .content("{\"id\":\"abc\"}"))
+        .andExpect(status().isUnauthorized());
+
+    verify(webAuthnService, never()).finishLogin(any(), any(), any(), any());
+  }
+
+  /** A real (minimal) creation-options document the WebAuthn Jackson module can serialize. */
+  private static PublicKeyCredentialCreationOptions creationOptions() {
+    return PublicKeyCredentialCreationOptions.builder()
+        .rp(PublicKeyCredentialRpEntity.builder().id("localhost").name("Test RP").build())
+        .user(
+            ImmutablePublicKeyCredentialUserEntity.builder()
+                .id(Bytes.random())
+                .name("admin@example.com")
+                .displayName("admin@example.com")
+                .build())
+        .challenge(Bytes.random())
+        .pubKeyCredParams(List.of(PublicKeyCredentialParameters.ES256))
+        .timeout(Duration.ofMinutes(5))
+        .build();
+  }
+
+  /** A real (minimal) request-options document the WebAuthn Jackson module can serialize. */
+  private static PublicKeyCredentialRequestOptions requestOptions() {
+    return PublicKeyCredentialRequestOptions.builder()
+        .challenge(Bytes.random())
+        .rpId("localhost")
+        .timeout(Duration.ofMinutes(5))
+        .build();
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/controller/auth/WebAuthnControllerTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/auth/WebAuthnControllerTest.java
@@ -1,6 +1,7 @@
 package edens.zac.portfolio.backend.controller.auth;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -11,6 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edens.zac.portfolio.backend.config.AuthLoginLimiter;
 import edens.zac.portfolio.backend.model.AuthPrincipal;
 import edens.zac.portfolio.backend.services.WebAuthnService;
 import edens.zac.portfolio.backend.types.Role;
@@ -42,6 +44,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 class WebAuthnControllerTest {
 
   private WebAuthnService webAuthnService;
+  private AuthLoginLimiter loginLimiter;
   private MockMvc mockMvc;
 
   private final AuthPrincipal admin = new AuthPrincipal(1L, "admin@example.com", Role.ADMIN, false);
@@ -49,10 +52,11 @@ class WebAuthnControllerTest {
   @BeforeEach
   void setUp() {
     webAuthnService = mock(WebAuthnService.class);
+    loginLimiter = mock(AuthLoginLimiter.class);
     ObjectMapper webAuthnObjectMapper = new ObjectMapper();
     webAuthnObjectMapper.registerModule(new WebauthnJackson2Module());
     WebAuthnController controller =
-        new WebAuthnController(webAuthnService, webAuthnObjectMapper, false);
+        new WebAuthnController(webAuthnService, webAuthnObjectMapper, loginLimiter, false);
     mockMvc =
         MockMvcBuilders.standaloneSetup(controller)
             .setCustomArgumentResolvers(new AuthenticationPrincipalArgumentResolver())
@@ -98,6 +102,7 @@ class WebAuthnControllerTest {
 
   @Test
   void loginStartReturns200WithOptionsAndSetsAttemptCookie() throws Exception {
+    when(loginLimiter.isBlocked(anyString(), eq("admin@example.com"))).thenReturn(false);
     when(webAuthnService.startLogin(eq("admin@example.com")))
         .thenReturn(new WebAuthnService.LoginStart("attempt-1", requestOptions()));
 
@@ -110,10 +115,29 @@ class WebAuthnControllerTest {
         .andExpect(cookie().exists("ezac_webauthn_attempt"))
         .andExpect(cookie().value("ezac_webauthn_attempt", "attempt-1"))
         .andExpect(cookie().httpOnly("ezac_webauthn_attempt", true));
+
+    verify(loginLimiter).recordFailure(anyString(), eq("admin@example.com"));
+  }
+
+  @Test
+  void loginStartReturns429WhenRateLimited() throws Exception {
+    when(loginLimiter.isBlocked(anyString(), eq("admin@example.com"))).thenReturn(true);
+
+    mockMvc
+        .perform(
+            post("/api/auth/webauthn/login/start")
+                .contentType("application/json")
+                .content("{\"email\":\"admin@example.com\"}"))
+        .andExpect(status().isTooManyRequests());
+
+    verify(webAuthnService, never()).startLogin(any());
   }
 
   @Test
   void loginFinishReadsAttemptCookieDelegatesAndClearsCookie() throws Exception {
+    when(webAuthnService.finishLogin(eq("attempt-1"), eq("{\"id\":\"abc\"}"), any(), any()))
+        .thenReturn("admin@example.com");
+
     mockMvc
         .perform(
             post("/api/auth/webauthn/login/finish")
@@ -124,6 +148,44 @@ class WebAuthnControllerTest {
         .andExpect(cookie().maxAge("ezac_webauthn_attempt", 0));
 
     verify(webAuthnService).finishLogin(eq("attempt-1"), eq("{\"id\":\"abc\"}"), any(), any());
+    verify(loginLimiter).reset(anyString(), eq("admin@example.com"));
+  }
+
+  @Test
+  void loginFinishClearsCookieEvenOnServiceException() throws Exception {
+    when(webAuthnService.finishLogin(eq("attempt-1"), any(), any(), any()))
+        .thenThrow(new IllegalStateException("bad assertion"));
+
+    // MockMvc standalone rethrows unhandled controller exceptions. Add a catch-all exception
+    // resolver so the response object is populated (and the Set-Cookie from the finally block is
+    // readable) without the exception blowing up the perform() call.
+    WebAuthnController controller =
+        new WebAuthnController(webAuthnService, new ObjectMapper(), loginLimiter, false);
+    MockMvc exceptionHandlingMvc =
+        MockMvcBuilders.standaloneSetup(controller)
+            .setHandlerExceptionResolvers(
+                (request, response, handler, ex) -> {
+                  response.setStatus(500);
+                  return new org.springframework.web.servlet.ModelAndView();
+                })
+            .build();
+
+    org.springframework.mock.web.MockHttpServletResponse response =
+        exceptionHandlingMvc
+            .perform(
+                post("/api/auth/webauthn/login/finish")
+                    .cookie(new jakarta.servlet.http.Cookie("ezac_webauthn_attempt", "attempt-1"))
+                    .contentType("application/json")
+                    .content("{\"id\":\"abc\"}"))
+            .andReturn()
+            .getResponse();
+
+    boolean clearedCookiePresent =
+        response.getHeaders(org.springframework.http.HttpHeaders.SET_COOKIE).stream()
+            .anyMatch(h -> h.contains("ezac_webauthn_attempt") && h.contains("Max-Age=0"));
+    org.junit.jupiter.api.Assertions.assertTrue(
+        clearedCookiePresent,
+        "attempt cookie must be cleared (Max-Age=0) even when finishLogin throws");
   }
 
   @Test

--- a/src/test/java/edens/zac/portfolio/backend/dao/AppUserRepositoryIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/dao/AppUserRepositoryIntegrationTest.java
@@ -1,0 +1,92 @@
+package edens.zac.portfolio.backend.dao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import edens.zac.portfolio.backend.AbstractPostgresIntegrationTest;
+import edens.zac.portfolio.backend.entity.AppUserEntity;
+import edens.zac.portfolio.backend.types.Role;
+import edens.zac.portfolio.backend.types.UserStatus;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+
+class AppUserRepositoryIntegrationTest extends AbstractPostgresIntegrationTest {
+
+  @Autowired private AppUserRepository repository;
+
+  private AppUserEntity newUser(String email, Role role) {
+    return AppUserEntity.builder()
+        .email(email)
+        .role(role)
+        .webauthnUserHandle(UUID.randomUUID())
+        .status(UserStatus.ACTIVE)
+        .build();
+  }
+
+  @Test
+  void insertThenFindByEmailRoundTrips() {
+    UUID handle = UUID.randomUUID();
+    AppUserEntity user =
+        AppUserEntity.builder()
+            .email("round@example.com")
+            .role(Role.ADMIN)
+            .passwordHash("{bcrypt}$2a$10$abc")
+            .webauthnUserHandle(handle)
+            .displayName("Round Trip")
+            .status(UserStatus.ACTIVE)
+            .build();
+
+    Long id = repository.insert(user);
+    assertThat(id).isNotNull();
+
+    Optional<AppUserEntity> found = repository.findByEmail("round@example.com");
+    assertThat(found).isPresent();
+    assertThat(found.get().getId()).isEqualTo(id);
+    assertThat(found.get().getRole()).isEqualTo(Role.ADMIN);
+    assertThat(found.get().getStatus()).isEqualTo(UserStatus.ACTIVE);
+    assertThat(found.get().getPasswordHash()).isEqualTo("{bcrypt}$2a$10$abc");
+    assertThat(found.get().getWebauthnUserHandle()).isEqualTo(handle);
+    assertThat(found.get().getDisplayName()).isEqualTo("Round Trip");
+    assertThat(found.get().getCreatedAt()).isNotNull();
+  }
+
+  @Test
+  void findByWebauthnUserHandleRoundTrips() {
+    UUID handle = UUID.randomUUID();
+    repository.insert(
+        AppUserEntity.builder()
+            .email("handle@example.com")
+            .role(Role.CLIENT)
+            .webauthnUserHandle(handle)
+            .status(UserStatus.ACTIVE)
+            .build());
+
+    assertThat(repository.findByWebauthnUserHandle(handle)).isPresent();
+    assertThat(repository.findByWebauthnUserHandle(UUID.randomUUID())).isEmpty();
+  }
+
+  @Test
+  void existsByRoleReflectsInsertedAdmin() {
+    assertThat(repository.existsByRole(Role.ADMIN)).isFalse();
+    repository.insert(newUser("admin@example.com", Role.ADMIN));
+    assertThat(repository.existsByRole(Role.ADMIN)).isTrue();
+  }
+
+  @Test
+  void updatePasswordHashPersists() {
+    Long id = repository.insert(newUser("pw@example.com", Role.ADMIN));
+    repository.updatePasswordHash(id, "{bcrypt}$2a$10$newhash");
+    assertThat(repository.findById(id)).isPresent();
+    assertThat(repository.findById(id).get().getPasswordHash()).isEqualTo("{bcrypt}$2a$10$newhash");
+  }
+
+  @Test
+  void duplicateEmailViolatesUniqueConstraint() {
+    repository.insert(newUser("unique@example.com", Role.ADMIN));
+    assertThatThrownBy(() -> repository.insert(newUser("unique@example.com", Role.CLIENT)))
+        .isInstanceOf(DataIntegrityViolationException.class);
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/dao/AuthMigrationIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/dao/AuthMigrationIntegrationTest.java
@@ -1,0 +1,78 @@
+package edens.zac.portfolio.backend.dao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import edens.zac.portfolio.backend.AbstractPostgresIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+class AuthMigrationIntegrationTest extends AbstractPostgresIntegrationTest {
+
+  @Autowired private JdbcTemplate jdbcTemplate;
+
+  private boolean tableExists(String table) {
+    Integer count =
+        jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM information_schema.tables "
+                + "WHERE table_schema = 'public' AND table_name = ?",
+            Integer.class,
+            table);
+    return count != null && count > 0;
+  }
+
+  private boolean columnExists(String table, String column) {
+    Integer count =
+        jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM information_schema.columns "
+                + "WHERE table_schema = 'public' AND table_name = ? AND column_name = ?",
+            Integer.class,
+            table,
+            column);
+    return count != null && count > 0;
+  }
+
+  @Test
+  void v29CreatesThreeAuthTables() {
+    assertThat(tableExists("app_user")).isTrue();
+    assertThat(tableExists("user_session")).isTrue();
+    assertThat(tableExists("gallery_access")).isTrue();
+  }
+
+  @Test
+  void appUserHasWebauthnHandleAndUniqueEmail() {
+    assertThat(columnExists("app_user", "webauthn_user_handle")).isTrue();
+    assertThat(columnExists("app_user", "password_hash")).isTrue();
+
+    // email UNIQUE is enforced: a duplicate insert must throw.
+    jdbcTemplate.update(
+        "INSERT INTO app_user (email, role, webauthn_user_handle, status) "
+            + "VALUES ('dup@example.com', 'ADMIN', gen_random_uuid(), 'ACTIVE')");
+    org.assertj.core.api.Assertions.assertThatThrownBy(
+            () ->
+                jdbcTemplate.update(
+                    "INSERT INTO app_user (email, role, webauthn_user_handle, status) "
+                        + "VALUES ('dup@example.com', 'CLIENT', gen_random_uuid(), 'ACTIVE')"))
+        .isInstanceOf(org.springframework.dao.DataIntegrityViolationException.class);
+  }
+
+  @Test
+  void userSessionForeignKeyCascadesOnUserDelete() {
+    Long userId =
+        jdbcTemplate.queryForObject(
+            "INSERT INTO app_user (email, role, webauthn_user_handle, status) "
+                + "VALUES ('cascade@example.com', 'ADMIN', gen_random_uuid(), 'ACTIVE') RETURNING id",
+            Long.class);
+    jdbcTemplate.update(
+        "INSERT INTO user_session (user_id, token_hash, expires_at) "
+            + "VALUES (?, 'hash-1', now() + interval '1 day')",
+        userId);
+
+    jdbcTemplate.update("DELETE FROM app_user WHERE id = ?", userId);
+
+    Integer remaining =
+        jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM user_session WHERE user_id = ?", Integer.class, userId);
+    assertThat(remaining).isZero();
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/dao/GalleryAccessRepositoryIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/dao/GalleryAccessRepositoryIntegrationTest.java
@@ -1,0 +1,98 @@
+package edens.zac.portfolio.backend.dao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import edens.zac.portfolio.backend.AbstractPostgresIntegrationTest;
+import edens.zac.portfolio.backend.entity.AppUserEntity;
+import edens.zac.portfolio.backend.entity.GalleryAccessEntity;
+import edens.zac.portfolio.backend.types.Role;
+import edens.zac.portfolio.backend.types.UserStatus;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+class GalleryAccessRepositoryIntegrationTest extends AbstractPostgresIntegrationTest {
+
+  @Autowired private GalleryAccessRepository galleryAccessRepository;
+  @Autowired private AppUserRepository userRepository;
+  @Autowired private JdbcTemplate jdbcTemplate;
+
+  private Long seedUser(String email) {
+    return userRepository.insert(
+        AppUserEntity.builder()
+            .email(email)
+            .role(Role.CLIENT)
+            .webauthnUserHandle(UUID.randomUUID())
+            .status(UserStatus.ACTIVE)
+            .build());
+  }
+
+  private Long seedCollection(String slug) {
+    return jdbcTemplate.queryForObject(
+        "INSERT INTO collection (type, title, slug, visibility) "
+            + "VALUES ('CLIENT_GALLERY', ?, ?, 'HIDDEN') RETURNING id",
+        Long.class,
+        "Title " + slug,
+        slug);
+  }
+
+  @Test
+  void insertThenFindByUserIdRoundTrips() {
+    Long userId = seedUser("ga@example.com");
+    Long collectionId = seedCollection("ga-collection-1");
+
+    Long id =
+        galleryAccessRepository.insert(
+            GalleryAccessEntity.builder()
+                .userId(userId)
+                .collectionId(collectionId)
+                .canDownload(true)
+                .canTag(false)
+                .build());
+    assertThat(id).isNotNull();
+
+    List<GalleryAccessEntity> grants = galleryAccessRepository.findByUserId(userId);
+    assertThat(grants).hasSize(1);
+    assertThat(grants.get(0).getCollectionId()).isEqualTo(collectionId);
+    assertThat(grants.get(0).isCanDownload()).isTrue();
+    assertThat(grants.get(0).isCanTag()).isFalse();
+    assertThat(grants.get(0).getGrantedAt()).isNotNull();
+  }
+
+  @Test
+  void findByUserIdReturnsEmptyForUserWithNoGrants() {
+    Long userId = seedUser("empty@example.com");
+    assertThat(galleryAccessRepository.findByUserId(userId)).isEmpty();
+  }
+
+  @Test
+  void duplicateUserCollectionViolatesUniqueConstraint() {
+    Long userId = seedUser("dup-ga@example.com");
+    Long collectionId = seedCollection("ga-collection-2");
+    galleryAccessRepository.insert(
+        GalleryAccessEntity.builder().userId(userId).collectionId(collectionId).build());
+    assertThatThrownBy(
+            () ->
+                galleryAccessRepository.insert(
+                    GalleryAccessEntity.builder()
+                        .userId(userId)
+                        .collectionId(collectionId)
+                        .build()))
+        .isInstanceOf(DataIntegrityViolationException.class);
+  }
+
+  @Test
+  void deletingUserCascadesGrants() {
+    Long userId = seedUser("cascade-ga@example.com");
+    Long collectionId = seedCollection("ga-collection-3");
+    galleryAccessRepository.insert(
+        GalleryAccessEntity.builder().userId(userId).collectionId(collectionId).build());
+
+    jdbcTemplate.update("DELETE FROM app_user WHERE id = ?", userId);
+    assertThat(galleryAccessRepository.findByUserId(userId)).isEmpty();
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/dao/UserSessionRepositoryIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/dao/UserSessionRepositoryIntegrationTest.java
@@ -1,0 +1,110 @@
+package edens.zac.portfolio.backend.dao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import edens.zac.portfolio.backend.AbstractPostgresIntegrationTest;
+import edens.zac.portfolio.backend.entity.AppUserEntity;
+import edens.zac.portfolio.backend.entity.UserSessionEntity;
+import edens.zac.portfolio.backend.types.Role;
+import edens.zac.portfolio.backend.types.UserStatus;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+
+class UserSessionRepositoryIntegrationTest extends AbstractPostgresIntegrationTest {
+
+  @Autowired private UserSessionRepository sessionRepository;
+  @Autowired private AppUserRepository userRepository;
+
+  private Long seedUser(String email) {
+    return userRepository.insert(
+        AppUserEntity.builder()
+            .email(email)
+            .role(Role.ADMIN)
+            .webauthnUserHandle(UUID.randomUUID())
+            .status(UserStatus.ACTIVE)
+            .build());
+  }
+
+  private UserSessionEntity newSession(Long userId, String tokenHash) {
+    return UserSessionEntity.builder()
+        .userId(userId)
+        .tokenHash(tokenHash)
+        .mfaSatisfied(false)
+        .ip("203.0.113.1")
+        .userAgent("JUnit")
+        .expiresAt(LocalDateTime.now().plusDays(60))
+        .build();
+  }
+
+  @Test
+  void insertThenFindByTokenHashRoundTrips() {
+    Long userId = seedUser("sess@example.com");
+    Long id = sessionRepository.insert(newSession(userId, "hash-aaa"));
+    assertThat(id).isNotNull();
+
+    Optional<UserSessionEntity> found = sessionRepository.findByTokenHash("hash-aaa");
+    assertThat(found).isPresent();
+    assertThat(found.get().getUserId()).isEqualTo(userId);
+    assertThat(found.get().isMfaSatisfied()).isFalse();
+    assertThat(found.get().getRevokedAt()).isNull();
+    assertThat(found.get().getExpiresAt()).isNotNull();
+    assertThat(found.get().getLastSeenAt()).isNotNull();
+  }
+
+  @Test
+  void touchUpdatesLastSeenAndExpiry() {
+    Long userId = seedUser("touch@example.com");
+    sessionRepository.insert(newSession(userId, "hash-touch"));
+    UserSessionEntity before = sessionRepository.findByTokenHash("hash-touch").orElseThrow();
+
+    LocalDateTime newSeen = LocalDateTime.now().plusMinutes(5);
+    LocalDateTime newExpiry = before.getExpiresAt().plusDays(1);
+    sessionRepository.touch(before.getId(), newSeen, newExpiry);
+
+    UserSessionEntity after = sessionRepository.findByTokenHash("hash-touch").orElseThrow();
+    assertThat(after.getLastSeenAt()).isAfter(before.getLastSeenAt());
+    assertThat(after.getExpiresAt()).isAfter(before.getExpiresAt());
+  }
+
+  @Test
+  void revokeByTokenHashSetsRevokedAt() {
+    Long userId = seedUser("revoke@example.com");
+    sessionRepository.insert(newSession(userId, "hash-rev"));
+    sessionRepository.revokeByTokenHash("hash-rev");
+
+    UserSessionEntity after = sessionRepository.findByTokenHash("hash-rev").orElseThrow();
+    assertThat(after.getRevokedAt()).isNotNull();
+  }
+
+  @Test
+  void duplicateTokenHashViolatesUniqueConstraint() {
+    Long userId = seedUser("dup-token@example.com");
+    sessionRepository.insert(newSession(userId, "hash-dup"));
+    assertThatThrownBy(() -> sessionRepository.insert(newSession(userId, "hash-dup")))
+        .isInstanceOf(DataIntegrityViolationException.class);
+  }
+
+  @Test
+  void deletingUserCascadesSessions() {
+    Long userId = seedUser("cascade-sess@example.com");
+    sessionRepository.insert(newSession(userId, "hash-cascade"));
+    userRepository.findById(userId).orElseThrow();
+
+    // delete via the user repo path is not exposed; use a direct cascade check through session
+    // lookup
+    // after removing the parent. We rely on the FK ON DELETE CASCADE proven in the migration test;
+    // here we assert the row is gone once the parent is removed.
+    org.springframework.jdbc.core.JdbcTemplate jdbc =
+        (org.springframework.jdbc.core.JdbcTemplate)
+            org.springframework.test.util.ReflectionTestUtils.getField(
+                userRepository, "jdbcTemplate");
+    jdbc.update("DELETE FROM app_user WHERE id = ?", userId);
+
+    assertThat(sessionRepository.findByTokenHash("hash-cascade")).isEmpty();
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/dao/WebAuthnCredentialRepositoryIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/dao/WebAuthnCredentialRepositoryIntegrationTest.java
@@ -1,0 +1,122 @@
+package edens.zac.portfolio.backend.dao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import edens.zac.portfolio.backend.AbstractPostgresIntegrationTest;
+import edens.zac.portfolio.backend.entity.WebAuthnCredentialEntity;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/** Round-trips WebAuthnCredentialRepository against a real Postgres container. */
+class WebAuthnCredentialRepositoryIntegrationTest extends AbstractPostgresIntegrationTest {
+
+  @Autowired private WebAuthnCredentialRepository repository;
+  @Autowired private DataSource dataSource;
+
+  private Long seedUser(String email) {
+    return new JdbcTemplate(dataSource)
+        .queryForObject(
+            "INSERT INTO app_user (email, role, webauthn_user_handle, status) "
+                + "VALUES (?, 'ADMIN', gen_random_uuid(), 'ACTIVE') RETURNING id",
+            Long.class,
+            email);
+  }
+
+  @Test
+  void insertThenFindByUserIdRoundTrips() {
+    Long userId = seedUser("wac-insert@example.com");
+    WebAuthnCredentialEntity cred =
+        WebAuthnCredentialEntity.builder()
+            .userId(userId)
+            .credentialId(new byte[] {10, 20, 30})
+            .publicKey(new byte[] {40, 50, 60})
+            .signCount(0L)
+            .transports("internal")
+            .label("Test Passkey")
+            .build();
+
+    Long id = repository.insert(cred);
+    assertThat(id).isNotNull();
+
+    List<WebAuthnCredentialEntity> found = repository.findByUserId(userId);
+    assertThat(found).hasSize(1);
+    assertThat(found.get(0).getCredentialId()).containsExactly(10, 20, 30);
+    assertThat(found.get(0).getPublicKey()).containsExactly(40, 50, 60);
+    assertThat(found.get(0).getSignCount()).isZero();
+    assertThat(found.get(0).getTransports()).isEqualTo("internal");
+    assertThat(found.get(0).getLabel()).isEqualTo("Test Passkey");
+    assertThat(found.get(0).getCreatedAt()).isNotNull();
+  }
+
+  @Test
+  void findByCredentialIdMatchesExactBytes() {
+    Long userId = seedUser("wac-bycred@example.com");
+    byte[] credId = new byte[] {1, 2, 3, 4, 5};
+    repository.insert(
+        WebAuthnCredentialEntity.builder()
+            .userId(userId)
+            .credentialId(credId)
+            .publicKey(new byte[] {9})
+            .signCount(7L)
+            .build());
+
+    Optional<WebAuthnCredentialEntity> hit = repository.findByCredentialId(credId);
+    assertThat(hit).isPresent();
+    assertThat(hit.get().getSignCount()).isEqualTo(7L);
+
+    Optional<WebAuthnCredentialEntity> miss =
+        repository.findByCredentialId(new byte[] {99, 98, 97});
+    assertThat(miss).isEmpty();
+  }
+
+  @Test
+  void updateSignCountAndLastUsedPersists() {
+    Long userId = seedUser("wac-update@example.com");
+    Long id =
+        repository.insert(
+            WebAuthnCredentialEntity.builder()
+                .userId(userId)
+                .credentialId(new byte[] {7, 7, 7})
+                .publicKey(new byte[] {8})
+                .signCount(0L)
+                .build());
+
+    LocalDateTime now = LocalDateTime.now();
+    repository.updateSignCountAndLastUsed(id, 42L, now);
+
+    WebAuthnCredentialEntity reloaded = repository.findByUserId(userId).get(0);
+    assertThat(reloaded.getSignCount()).isEqualTo(42L);
+    assertThat(reloaded.getLastUsedAt()).isNotNull();
+  }
+
+  @Test
+  void duplicateCredentialIdIsRejected() {
+    Long userId = seedUser("wac-dupe@example.com");
+    byte[] credId = new byte[] {3, 1, 4, 1, 5};
+    repository.insert(
+        WebAuthnCredentialEntity.builder()
+            .userId(userId)
+            .credentialId(credId)
+            .publicKey(new byte[] {1})
+            .signCount(0L)
+            .build());
+
+    assertThatThrownBy(
+            () ->
+                repository.insert(
+                    WebAuthnCredentialEntity.builder()
+                        .userId(userId)
+                        .credentialId(credId)
+                        .publicKey(new byte[] {2})
+                        .signCount(0L)
+                        .build()))
+        .isInstanceOf(DuplicateKeyException.class);
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/dao/WebAuthnCredentialRepositoryIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/dao/WebAuthnCredentialRepositoryIntegrationTest.java
@@ -8,8 +8,6 @@ import edens.zac.portfolio.backend.entity.WebAuthnCredentialEntity;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-import javax.sql.DataSource;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DuplicateKeyException;
@@ -19,25 +17,17 @@ import org.springframework.jdbc.core.JdbcTemplate;
 class WebAuthnCredentialRepositoryIntegrationTest extends AbstractPostgresIntegrationTest {
 
   @Autowired private WebAuthnCredentialRepository repository;
-  @Autowired private DataSource dataSource;
+  @Autowired private JdbcTemplate jdbcTemplate;
 
-  /**
-   * Remove test users inserted by seedUser() so the shared singleton container is clean for other
-   * test classes (e.g. AppUserRepositoryIntegrationTest.existsByRoleReflectsInsertedAdmin).
-   */
-  @AfterEach
-  void cleanUp() {
-    new JdbcTemplate(dataSource)
-        .update("DELETE FROM app_user WHERE email LIKE 'wac-%@example.com'");
-  }
+  // Auth tables are truncated after each test by
+  // AbstractPostgresIntegrationTest.truncateAuthTables.
 
   private Long seedUser(String email) {
-    return new JdbcTemplate(dataSource)
-        .queryForObject(
-            "INSERT INTO app_user (email, role, webauthn_user_handle, status) "
-                + "VALUES (?, 'ADMIN', gen_random_uuid(), 'ACTIVE') RETURNING id",
-            Long.class,
-            email);
+    return jdbcTemplate.queryForObject(
+        "INSERT INTO app_user (email, role, webauthn_user_handle, status) "
+            + "VALUES (?, 'ADMIN', gen_random_uuid(), 'ACTIVE') RETURNING id",
+        Long.class,
+        email);
   }
 
   @Test

--- a/src/test/java/edens/zac/portfolio/backend/dao/WebAuthnCredentialRepositoryIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/dao/WebAuthnCredentialRepositoryIntegrationTest.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DuplicateKeyException;
@@ -19,6 +20,16 @@ class WebAuthnCredentialRepositoryIntegrationTest extends AbstractPostgresIntegr
 
   @Autowired private WebAuthnCredentialRepository repository;
   @Autowired private DataSource dataSource;
+
+  /**
+   * Remove test users inserted by seedUser() so the shared singleton container is clean for other
+   * test classes (e.g. AppUserRepositoryIntegrationTest.existsByRoleReflectsInsertedAdmin).
+   */
+  @AfterEach
+  void cleanUp() {
+    new JdbcTemplate(dataSource)
+        .update("DELETE FROM app_user WHERE email LIKE 'wac-%@example.com'");
+  }
 
   private Long seedUser(String email) {
     return new JdbcTemplate(dataSource)

--- a/src/test/java/edens/zac/portfolio/backend/services/AdminBootstrapTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/AdminBootstrapTest.java
@@ -1,0 +1,65 @@
+package edens.zac.portfolio.backend.services;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import edens.zac.portfolio.backend.dao.AppUserRepository;
+import edens.zac.portfolio.backend.entity.AppUserEntity;
+import edens.zac.portfolio.backend.types.Role;
+import edens.zac.portfolio.backend.types.UserStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class AdminBootstrapTest {
+
+  @Mock private AppUserRepository appUserRepository;
+  @Mock private PasswordEncoder passwordEncoder;
+
+  @Test
+  void createsAdminWhenAbsent() {
+    when(appUserRepository.existsByRole(Role.ADMIN)).thenReturn(false);
+    when(passwordEncoder.encode("s3cret")).thenReturn("{bcrypt}$2a$10$encoded");
+
+    AdminBootstrap bootstrap =
+        new AdminBootstrap(appUserRepository, passwordEncoder, "admin@example.com", "s3cret");
+    bootstrap.init();
+
+    ArgumentCaptor<AppUserEntity> captor = ArgumentCaptor.forClass(AppUserEntity.class);
+    verify(appUserRepository).insert(captor.capture());
+    AppUserEntity inserted = captor.getValue();
+    org.assertj.core.api.Assertions.assertThat(inserted.getEmail()).isEqualTo("admin@example.com");
+    org.assertj.core.api.Assertions.assertThat(inserted.getRole()).isEqualTo(Role.ADMIN);
+    org.assertj.core.api.Assertions.assertThat(inserted.getStatus()).isEqualTo(UserStatus.ACTIVE);
+    org.assertj.core.api.Assertions.assertThat(inserted.getPasswordHash())
+        .isEqualTo("{bcrypt}$2a$10$encoded");
+    org.assertj.core.api.Assertions.assertThat(inserted.getWebauthnUserHandle()).isNotNull();
+  }
+
+  @Test
+  void doesNothingWhenEnvBlank() {
+    AdminBootstrap bootstrap = new AdminBootstrap(appUserRepository, passwordEncoder, "", "");
+    bootstrap.init();
+    verify(appUserRepository, never()).existsByRole(any());
+    verify(appUserRepository, never()).insert(any());
+  }
+
+  @Test
+  void idempotentWhenAdminAlreadyExists() {
+    when(appUserRepository.existsByRole(Role.ADMIN)).thenReturn(true);
+
+    AdminBootstrap bootstrap =
+        new AdminBootstrap(appUserRepository, passwordEncoder, "admin@example.com", "s3cret");
+    bootstrap.init();
+
+    verify(appUserRepository, never()).insert(any());
+    verify(passwordEncoder, never()).encode(eq("s3cret"));
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/services/SessionServiceIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/SessionServiceIntegrationTest.java
@@ -1,0 +1,153 @@
+package edens.zac.portfolio.backend.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import edens.zac.portfolio.backend.AbstractPostgresIntegrationTest;
+import edens.zac.portfolio.backend.dao.AppUserRepository;
+import edens.zac.portfolio.backend.dao.UserSessionRepository;
+import edens.zac.portfolio.backend.entity.AppUserEntity;
+import edens.zac.portfolio.backend.entity.UserSessionEntity;
+import edens.zac.portfolio.backend.model.AuthPrincipal;
+import edens.zac.portfolio.backend.types.Role;
+import edens.zac.portfolio.backend.types.UserStatus;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class SessionServiceIntegrationTest extends AbstractPostgresIntegrationTest {
+
+  @Autowired private SessionService sessionService;
+  @Autowired private AppUserRepository userRepository;
+  @Autowired private UserSessionRepository sessionRepository;
+
+  private AppUserEntity seedAdmin(String email) {
+    Long id =
+        userRepository.insert(
+            AppUserEntity.builder()
+                .email(email)
+                .role(Role.ADMIN)
+                .webauthnUserHandle(UUID.randomUUID())
+                .status(UserStatus.ACTIVE)
+                .build());
+    return userRepository.findById(id).orElseThrow();
+  }
+
+  // Extract the raw ezac_session value from the Set-Cookie header.
+  private String rawTokenFrom(MockHttpServletResponse response) {
+    String setCookie = response.getHeader("Set-Cookie");
+    assertThat(setCookie).isNotNull().contains("ezac_session=");
+    String afterName =
+        setCookie.substring(setCookie.indexOf("ezac_session=") + "ezac_session=".length());
+    int semi = afterName.indexOf(';');
+    return semi >= 0 ? afterName.substring(0, semi) : afterName;
+  }
+
+  @Test
+  void createIssuesCookieAndPersistsHashedToken() {
+    AppUserEntity admin = seedAdmin("create@example.com");
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("User-Agent", "JUnit-UA");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    sessionService.create(admin, false, request, response);
+
+    String setCookie = response.getHeader("Set-Cookie");
+    assertThat(setCookie).contains("ezac_session=");
+    assertThat(setCookie).contains("HttpOnly");
+    assertThat(setCookie).contains("SameSite=Strict");
+    assertThat(setCookie).contains("Path=/");
+
+    String raw = rawTokenFrom(response);
+    // Raw token is NOT stored: looking it up by its own value as the hash must miss.
+    assertThat(sessionRepository.findByTokenHash(raw)).isEmpty();
+    // Resolving with the raw token, however, succeeds.
+    Optional<AuthPrincipal> principal = sessionService.resolve(raw);
+    assertThat(principal).isPresent();
+    assertThat(principal.get().email()).isEqualTo("create@example.com");
+    assertThat(principal.get().role()).isEqualTo(Role.ADMIN);
+    assertThat(principal.get().mfaSatisfied()).isFalse();
+  }
+
+  @Test
+  void resolveRejectsUnknownToken() {
+    assertThat(sessionService.resolve("not-a-real-token")).isEmpty();
+  }
+
+  @Test
+  void resolveRejectsExpiredSession() {
+    AppUserEntity admin = seedAdmin("expired@example.com");
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    sessionService.create(admin, false, request, response);
+    String raw = rawTokenFrom(response);
+
+    // Force expiry into the past.
+    UserSessionEntity session =
+        sessionRepository.findByTokenHash(sessionService.sha256HexForTest(raw)).orElseThrow();
+    sessionRepository.touch(
+        session.getId(), session.getLastSeenAt(), LocalDateTime.now().minusMinutes(1));
+
+    assertThat(sessionService.resolve(raw)).isEmpty();
+  }
+
+  @Test
+  void resolveRejectsRevokedSession() {
+    AppUserEntity admin = seedAdmin("revoked@example.com");
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    sessionService.create(admin, false, request, response);
+    String raw = rawTokenFrom(response);
+
+    sessionService.revoke(raw, new MockHttpServletResponse());
+    assertThat(sessionService.resolve(raw)).isEmpty();
+  }
+
+  @Test
+  void resolveSlidesLastSeenWhenStale() {
+    AppUserEntity admin = seedAdmin("slide@example.com");
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    sessionService.create(admin, false, request, response);
+    String raw = rawTokenFrom(response);
+
+    UserSessionEntity session =
+        sessionRepository.findByTokenHash(sessionService.sha256HexForTest(raw)).orElseThrow();
+    // Make last_seen_at stale (older than the 24h refresh threshold).
+    sessionRepository.touch(
+        session.getId(), LocalDateTime.now().minusDays(2), session.getExpiresAt());
+
+    LocalDateTime before =
+        sessionRepository
+            .findByTokenHash(sessionService.sha256HexForTest(raw))
+            .orElseThrow()
+            .getLastSeenAt();
+
+    assertThat(sessionService.resolve(raw)).isPresent();
+
+    LocalDateTime after =
+        sessionRepository
+            .findByTokenHash(sessionService.sha256HexForTest(raw))
+            .orElseThrow()
+            .getLastSeenAt();
+    assertThat(after).isAfter(before);
+  }
+
+  @Test
+  void revokeClearsCookie() {
+    AppUserEntity admin = seedAdmin("clear@example.com");
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse createResponse = new MockHttpServletResponse();
+    sessionService.create(admin, false, request, createResponse);
+    String raw = rawTokenFrom(createResponse);
+
+    MockHttpServletResponse logoutResponse = new MockHttpServletResponse();
+    sessionService.revoke(raw, logoutResponse);
+    String cleared = logoutResponse.getHeader("Set-Cookie");
+    assertThat(cleared).contains("ezac_session=");
+    assertThat(cleared).contains("Max-Age=0");
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/services/SessionServiceIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/SessionServiceIntegrationTest.java
@@ -1,6 +1,7 @@
 package edens.zac.portfolio.backend.services;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 
 import edens.zac.portfolio.backend.AbstractPostgresIntegrationTest;
 import edens.zac.portfolio.backend.dao.AppUserRepository;
@@ -15,6 +16,7 @@ import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
@@ -23,6 +25,7 @@ class SessionServiceIntegrationTest extends AbstractPostgresIntegrationTest {
   @Autowired private SessionService sessionService;
   @Autowired private AppUserRepository userRepository;
   @Autowired private UserSessionRepository sessionRepository;
+  @Autowired private JdbcTemplate jdbcTemplate;
 
   private AppUserEntity seedAdmin(String email) {
     Long id =
@@ -149,5 +152,50 @@ class SessionServiceIntegrationTest extends AbstractPostgresIntegrationTest {
     String cleared = logoutResponse.getHeader("Set-Cookie");
     assertThat(cleared).contains("ezac_session=");
     assertThat(cleared).contains("Max-Age=0");
+  }
+
+  @Test
+  void resolveCapsSlideAtAbsoluteLifetimeCeiling() {
+    AppUserEntity admin = seedAdmin("absolute@example.com");
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    sessionService.create(admin, false, request, response);
+    String raw = rawTokenFrom(response);
+
+    String tokenHash = sessionService.sha256HexForTest(raw);
+    Long sessionId = sessionRepository.findByTokenHash(tokenHash).orElseThrow().getId();
+
+    // Backdate creation to ~89 days ago and make last_seen_at stale so resolve() slides.
+    // expires_at stays in the future so the session is still valid at resolve time.
+    LocalDateTime createdAt = LocalDateTime.now().minusDays(89);
+    jdbcTemplate.update(
+        "UPDATE user_session SET created_at = ?, last_seen_at = ?, expires_at = ? WHERE id = ?",
+        createdAt,
+        LocalDateTime.now().minusDays(2),
+        LocalDateTime.now().plusDays(1),
+        sessionId);
+
+    assertThat(sessionService.resolve(raw)).isPresent();
+
+    LocalDateTime slidExpiry =
+        sessionRepository.findByTokenHash(tokenHash).orElseThrow().getExpiresAt();
+    // The slide must be capped at createdAt + 90d (~1 day from now), NOT now + 60d.
+    LocalDateTime absoluteMax = createdAt.plusDays(90);
+    assertThat(slidExpiry).isCloseTo(absoluteMax, within(5, java.time.temporal.ChronoUnit.SECONDS));
+    // Sanity: the uncapped slide (now + 60d) is far past the absolute ceiling — confirm we capped.
+    assertThat(slidExpiry).isBefore(LocalDateTime.now().plusDays(2));
+  }
+
+  @Test
+  void resolvePreservesMfaSatisfiedTrue() {
+    AppUserEntity admin = seedAdmin("mfa@example.com");
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    sessionService.create(admin, true, request, response);
+    String raw = rawTokenFrom(response);
+
+    Optional<AuthPrincipal> principal = sessionService.resolve(raw);
+    assertThat(principal).isPresent();
+    assertThat(principal.get().mfaSatisfied()).isTrue();
   }
 }

--- a/src/test/java/edens/zac/portfolio/backend/services/WebAuthnChallengeStoreTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/WebAuthnChallengeStoreTest.java
@@ -1,0 +1,45 @@
+package edens.zac.portfolio.backend.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class WebAuthnChallengeStoreTest {
+
+  @Test
+  void putThenTakeReturnsStoredValue() {
+    WebAuthnChallengeStore store = new WebAuthnChallengeStore(Duration.ofMinutes(5));
+    store.put("key-1", "challenge-options");
+
+    Optional<Object> taken = store.take("key-1");
+
+    assertThat(taken).contains("challenge-options");
+  }
+
+  @Test
+  void takeIsSingleUse() {
+    WebAuthnChallengeStore store = new WebAuthnChallengeStore(Duration.ofMinutes(5));
+    store.put("key-1", "challenge-options");
+
+    assertThat(store.take("key-1")).isPresent();
+    assertThat(store.take("key-1")).isEmpty();
+  }
+
+  @Test
+  void takeMissingKeyIsEmpty() {
+    WebAuthnChallengeStore store = new WebAuthnChallengeStore(Duration.ofMinutes(5));
+    assertThat(store.take("nope")).isEmpty();
+  }
+
+  @Test
+  void entriesExpireAfterTtl() throws InterruptedException {
+    WebAuthnChallengeStore store = new WebAuthnChallengeStore(Duration.ofMillis(50));
+    store.put("key-1", "challenge-options");
+
+    Thread.sleep(120);
+
+    assertThat(store.take("key-1")).isEmpty();
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/services/WebAuthnServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/WebAuthnServiceTest.java
@@ -1,0 +1,250 @@
+package edens.zac.portfolio.backend.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import edens.zac.portfolio.backend.dao.AppUserRepository;
+import edens.zac.portfolio.backend.dao.WebAuthnCredentialRepository;
+import edens.zac.portfolio.backend.entity.AppUserEntity;
+import edens.zac.portfolio.backend.model.AuthPrincipal;
+import edens.zac.portfolio.backend.types.Role;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.web.webauthn.api.Bytes;
+import org.springframework.security.web.webauthn.api.PublicKeyCredentialCreationOptions;
+import org.springframework.security.web.webauthn.api.PublicKeyCredentialRequestOptions;
+import org.springframework.security.web.webauthn.api.PublicKeyCredentialUserEntity;
+import org.springframework.security.web.webauthn.management.PublicKeyCredentialCreationOptionsRequest;
+import org.springframework.security.web.webauthn.management.PublicKeyCredentialRequestOptionsRequest;
+import org.springframework.security.web.webauthn.management.WebAuthnRelyingPartyOperations;
+
+/**
+ * Wiring/contract tests for {@link WebAuthnService}. The {@link WebAuthnRelyingPartyOperations}
+ * engine is mocked (a virtual authenticator is impractical in a unit test), so these assert the
+ * contract: register-start keys the challenge by the principal's user handle; register-finish is
+ * gated on a stored challenge; login-start scopes the assertion to the email (the email is passed
+ * as the operations Authentication name) and still returns options for an unknown email
+ * (anti-enumeration); login-finish resolves the user and creates an mfa=true session; a sign-count
+ * regression surfaced by the ops call propagates and creates no session.
+ */
+@ExtendWith(MockitoExtension.class)
+class WebAuthnServiceTest {
+
+  @Mock private WebAuthnRelyingPartyOperations operations;
+  @Mock private WebAuthnChallengeStore challengeStore;
+  @Mock private AppUserRepository appUserRepository;
+  @Mock private WebAuthnCredentialRepository credentialRepository;
+  @Mock private SessionService sessionService;
+  @Mock private HttpServletRequest request;
+  @Mock private HttpServletResponse response;
+
+  private WebAuthnService service;
+
+  private final UUID handle = UUID.randomUUID();
+  private AppUserEntity admin;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new WebAuthnService(
+            operations, challengeStore, appUserRepository, credentialRepository, sessionService);
+    admin =
+        AppUserEntity.builder()
+            .id(1L)
+            .email("admin@example.com")
+            .role(Role.ADMIN)
+            .webauthnUserHandle(handle)
+            .build();
+  }
+
+  private AuthPrincipal principal() {
+    return new AuthPrincipal(1L, "admin@example.com", Role.ADMIN, false);
+  }
+
+  @Test
+  void startRegistrationStoresOptionsKeyedByUserHandle() {
+    when(appUserRepository.findById(1L)).thenReturn(Optional.of(admin));
+    PublicKeyCredentialCreationOptions opts =
+        org.mockito.Mockito.mock(PublicKeyCredentialCreationOptions.class);
+    when(operations.createPublicKeyCredentialCreationOptions(any())).thenReturn(opts);
+
+    PublicKeyCredentialCreationOptions result = service.startRegistration(principal());
+
+    assertThat(result).isSameAs(opts);
+    verify(challengeStore).put(eq(handle.toString()), eq(opts));
+  }
+
+  @Test
+  void startRegistrationPassesPrincipalEmailAsAuthenticationName() {
+    when(appUserRepository.findById(1L)).thenReturn(Optional.of(admin));
+    when(operations.createPublicKeyCredentialCreationOptions(any()))
+        .thenReturn(org.mockito.Mockito.mock(PublicKeyCredentialCreationOptions.class));
+
+    service.startRegistration(principal());
+
+    // The operations engine scopes registration by authentication.getName(); it must be the email.
+    verify(operations)
+        .createPublicKeyCredentialCreationOptions(
+            argThat(
+                (PublicKeyCredentialCreationOptionsRequest req) ->
+                    "admin@example.com".equals(req.getAuthentication().getName())));
+  }
+
+  @Test
+  void finishRegistrationPersistsCredentialForPrincipal() {
+    when(appUserRepository.findById(1L)).thenReturn(Optional.of(admin));
+    PublicKeyCredentialCreationOptions saved =
+        org.mockito.Mockito.mock(PublicKeyCredentialCreationOptions.class);
+    when(challengeStore.take(handle.toString())).thenReturn(Optional.of(saved));
+
+    service.finishRegistration(principal(), validAttestationJson());
+
+    // registerCredential is invoked (the UserCredentialRepository.save persists); the ops call is
+    // the boundary we assert.
+    verify(operations).registerCredential(any());
+  }
+
+  @Test
+  void finishRegistrationWithoutStoredChallengeIsRejected() {
+    when(appUserRepository.findById(1L)).thenReturn(Optional.of(admin));
+    when(challengeStore.take(handle.toString())).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.finishRegistration(principal(), validAttestationJson()))
+        .isInstanceOf(IllegalStateException.class);
+    verify(operations, never()).registerCredential(any());
+  }
+
+  @Test
+  void startLoginScopesToEmailAndStoresOptions() {
+    PublicKeyCredentialRequestOptions opts =
+        org.mockito.Mockito.mock(PublicKeyCredentialRequestOptions.class);
+    when(operations.createCredentialRequestOptions(any())).thenReturn(opts);
+
+    WebAuthnService.LoginStart start = service.startLogin("admin@example.com");
+
+    assertThat(start.options()).isSameAs(opts);
+    assertThat(start.attemptId()).isNotBlank();
+    verify(challengeStore).put(eq(start.attemptId()), eq(opts));
+    // The email is handed to the operations engine as the Authentication name; the engine itself
+    // builds the email-scoped allow-list from that user's stored credentials.
+    verify(operations)
+        .createCredentialRequestOptions(
+            argThat(
+                (PublicKeyCredentialRequestOptionsRequest req) ->
+                    "admin@example.com".equals(req.getAuthentication().getName())));
+  }
+
+  @Test
+  void startLoginWithUnknownEmailStillReturnsWellFormedOptions() {
+    PublicKeyCredentialRequestOptions opts =
+        org.mockito.Mockito.mock(PublicKeyCredentialRequestOptions.class);
+    when(operations.createCredentialRequestOptions(any())).thenReturn(opts);
+
+    WebAuthnService.LoginStart start = service.startLogin("ghost@example.com");
+
+    // No 404, no leak: an unknown email still yields well-formed options (the operations engine
+    // mints a fresh challenge + empty allow-list for an unknown username).
+    assertThat(start.options()).isSameAs(opts);
+    assertThat(start.attemptId()).isNotBlank();
+    verify(challengeStore).put(eq(start.attemptId()), eq(opts));
+  }
+
+  @Test
+  void finishLoginCreatesMfaTrueSession() {
+    PublicKeyCredentialRequestOptions saved =
+        org.mockito.Mockito.mock(PublicKeyCredentialRequestOptions.class);
+    when(challengeStore.take("attempt-1")).thenReturn(Optional.of(saved));
+
+    PublicKeyCredentialUserEntity authedEntity =
+        org.mockito.Mockito.mock(PublicKeyCredentialUserEntity.class);
+    when(authedEntity.getId())
+        .thenReturn(new Bytes(handle.toString().getBytes(StandardCharsets.UTF_8)));
+    when(operations.authenticate(any())).thenReturn(authedEntity);
+    when(appUserRepository.findByWebauthnUserHandle(handle)).thenReturn(Optional.of(admin));
+
+    service.finishLogin("attempt-1", validAssertionJson(), request, response);
+
+    verify(sessionService).create(eq(admin), eq(true), eq(request), eq(response));
+  }
+
+  @Test
+  void finishLoginPropagatesSignCountRegressionAndCreatesNoSession() {
+    PublicKeyCredentialRequestOptions saved =
+        org.mockito.Mockito.mock(PublicKeyCredentialRequestOptions.class);
+    when(challengeStore.take("attempt-1")).thenReturn(Optional.of(saved));
+    when(operations.authenticate(any()))
+        .thenThrow(new IllegalStateException("Sign count regression detected"));
+
+    assertThatThrownBy(
+            () -> service.finishLogin("attempt-1", validAssertionJson(), request, response))
+        .isInstanceOf(IllegalStateException.class);
+    verify(sessionService, never())
+        .create(any(), org.mockito.ArgumentMatchers.anyBoolean(), any(), any());
+  }
+
+  @Test
+  void finishLoginWithoutStoredChallengeIsRejected() {
+    when(challengeStore.take("attempt-1")).thenReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () -> service.finishLogin("attempt-1", validAssertionJson(), request, response))
+        .isInstanceOf(IllegalStateException.class);
+    verify(operations, never()).authenticate(any());
+  }
+
+  /**
+   * A minimal but structurally valid W3C attestation credential JSON (registration finish body)
+   * that the WebAuthn Jackson module can deserialize into a {@code
+   * PublicKeyCredential<AuthenticatorAttestationResponse>}.
+   */
+  private static String validAttestationJson() {
+    return """
+        {
+          "id": "AQIDBA",
+          "rawId": "AQIDBA",
+          "type": "public-key",
+          "response": {
+            "clientDataJSON": "AQIDBA",
+            "attestationObject": "AQIDBA"
+          },
+          "clientExtensionResults": {}
+        }
+        """;
+  }
+
+  /**
+   * A minimal but structurally valid W3C assertion credential JSON (login finish body) that the
+   * WebAuthn Jackson module can deserialize into a {@code
+   * PublicKeyCredential<AuthenticatorAssertionResponse>}.
+   */
+  private static String validAssertionJson() {
+    return """
+        {
+          "id": "AQIDBA",
+          "rawId": "AQIDBA",
+          "type": "public-key",
+          "response": {
+            "clientDataJSON": "AQIDBA",
+            "authenticatorData": "AQIDBA",
+            "signature": "AQIDBA",
+            "userHandle": "AQIDBA"
+          },
+          "clientExtensionResults": {}
+        }
+        """;
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/services/WebAuthnServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/WebAuthnServiceTest.java
@@ -176,9 +176,10 @@ class WebAuthnServiceTest {
     when(operations.authenticate(any())).thenReturn(authedEntity);
     when(appUserRepository.findByWebauthnUserHandle(handle)).thenReturn(Optional.of(admin));
 
-    service.finishLogin("attempt-1", validAssertionJson(), request, response);
+    String email = service.finishLogin("attempt-1", validAssertionJson(), request, response);
 
     verify(sessionService).create(eq(admin), eq(true), eq(request), eq(response));
+    assertThat(email).isEqualTo("admin@example.com");
   }
 
   @Test

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,17 @@
+# Test profile for Testcontainers integration tests.
+# The shared application.properties pins H2; @ServiceConnection (AbstractPostgresIntegrationTest)
+# supplies a real Postgres DataSource at runtime, so we must clear the H2 driver/JPA dialect that
+# would otherwise win and prevent the container's DataSource from being used.
+spring.datasource.url=
+spring.datasource.driver-class-name=
+spring.jpa.hibernate.ddl-auto=none
+spring.sql.init.mode=never
+
+# Flyway must run so V1..V29 build the schema inside the container.
+spring.flyway.enabled=true
+spring.flyway.locations=classpath:db/migration
+spring.flyway.baseline-on-migrate=true
+spring.flyway.baseline-version=0
+
+# Secrets the context needs to start (mirrors the H2 test props).
+app.access-token.secret=test-secret-for-integration-tests

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -7,7 +7,10 @@ spring.datasource.driver-class-name=
 spring.jpa.hibernate.ddl-auto=none
 spring.sql.init.mode=never
 
-# Flyway must run so V1..V29 build the schema inside the container.
+# Flyway applies V2..V29 on top of the init-script base schema. The container is seeded with
+# db/test-base-schema.sql (via AbstractPostgresIntegrationTest withInitScript) BEFORE Flyway
+# connects, so baseline-on-migrate=true baselines the non-empty DB at 0 and runs V2..V29 — exactly
+# as in prod (already baselined at 0). No V1 is on the prod migration path.
 spring.flyway.enabled=true
 spring.flyway.locations=classpath:db/migration
 spring.flyway.baseline-on-migrate=true
@@ -16,7 +19,8 @@ spring.flyway.baseline-version=0
 # Secrets the context needs to start (mirrors the H2 test props).
 app.access-token.secret=test-secret-for-integration-tests
 
-# AWS stubs required for context load (S3Config, SesConfig inject these).
+# Test-only stub values: present solely so the @SpringBootTest context starts (no real AWS/SES
+# calls are made in these tests). AWS stubs required by S3Config + SesConfig.
 aws.access.key.id=test-key
 aws.secret.access.key=test-secret
 aws.s3.region=us-west-2

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -32,3 +32,9 @@ cloudfront.distribution-id=TEST123
 # Email stubs required for context load (EmailService injects these without defaults).
 email.from-address=no-reply@test.example
 email.frontend-base-url=http://localhost:3000
+
+# WebAuthn stubs required for context load (WebAuthnConfig @Value fields have no defaults in the
+# test application.properties, which shadows the main one that carries env-var-defaulted values).
+app.auth.webauthn.rp-id=localhost
+app.auth.webauthn.rp-name=Test RP
+app.auth.webauthn.allowed-origins=http://localhost:3000

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -15,3 +15,15 @@ spring.flyway.baseline-version=0
 
 # Secrets the context needs to start (mirrors the H2 test props).
 app.access-token.secret=test-secret-for-integration-tests
+
+# AWS stubs required for context load (S3Config, SesConfig inject these).
+aws.access.key.id=test-key
+aws.secret.access.key=test-secret
+aws.s3.region=us-west-2
+aws.portfolio.s3.bucket=test-bucket
+cloudfront.domain=test.cloudfront.net
+cloudfront.distribution-id=TEST123
+
+# Email stubs required for context load (EmailService injects these without defaults).
+email.from-address=no-reply@test.example
+email.frontend-base-url=http://localhost:3000

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,9 +1,10 @@
 # Test profile for Testcontainers integration tests.
-# The shared application.properties pins H2; @ServiceConnection (AbstractPostgresIntegrationTest)
-# supplies a real Postgres DataSource at runtime, so we must clear the H2 driver/JPA dialect that
-# would otherwise win and prevent the container's DataSource from being used.
-spring.datasource.url=
+# DataSource URL/username/password are supplied at runtime by @DynamicPropertySource in
+# AbstractPostgresIntegrationTest (singleton container pattern). Do not hard-code a URL here.
+# Clear the H2 driver/dialect set by the base src/test/resources/application.properties so that
+# Spring Boot auto-detects the PostgreSQL driver from the @DynamicPropertySource-supplied URL.
 spring.datasource.driver-class-name=
+spring.jpa.database-platform=
 spring.jpa.hibernate.ddl-auto=none
 spring.sql.init.mode=never
 

--- a/src/test/resources/db/test-base-schema.sql
+++ b/src/test/resources/db/test-base-schema.sql
@@ -1,6 +1,10 @@
--- V1: Initial portfolio backend schema.
--- This migration captures the baseline tables that existed before Flyway was introduced.
--- All subsequent migrations (V2+) alter or extend these tables.
+-- TEST-ONLY base schema (NOT a Flyway migration).
+-- Reconstructs the tables that pre-dated Flyway in prod, so a fresh Postgres
+-- Testcontainers container has the base schema BEFORE Flyway connects. The container
+-- runs this via withInitScript(); Flyway (baseline-on-migrate=true) then baselines the
+-- non-empty DB at 0 and applies V2..V29 on top — producing the same end schema while
+-- leaving the prod Flyway path (V2..V30, already baselined at 0) completely untouched.
+-- V2's "CREATE TABLE IF NOT EXISTS location" makes this layering safe.
 
 -- Reference lookup tables
 -- Note: location.slug added in V8; V2 creates location with IF NOT EXISTS (pre-Flyway it existed already).


### PR DESCRIPTION
## Summary

Phase F builds the shared **identity + session spine** (admin now, clients later) as an additive vertical slice — **zero behavior change to existing endpoints**.

- **Spring Security 6.4** adopted as the authorization + WebAuthn ceremony engine (used programmatically, **not** the DSL), composed with the existing `@Order` filter perimeter. `InternalSecretFilter` stays the outermost channel gate (`@Order(-200)`).
- **Opaque-token DB sessions** (`user_session`): 256-bit CSPRNG token, SHA-256-at-rest, `ezac_session` HttpOnly/SameSite=Strict cookie, **60-day idle + 90-day absolute** lifetime, instant revoke.
- **Passkeys (WebAuthn)** via webauthn4j + `WebAuthnRelyingPartyOperations` behind our own `/api/auth/webauthn/*` controllers; email-scoped allow-list with anti-enumeration; `sign_count` regression + user-verification enforced; challenge transported via a short-lived HttpOnly cookie.
- **Password** retained as admin bootstrap + break-glass (`AdminBootstrap` `@PostConstruct`, env-driven). `mfa_satisfied` is recorded (passkey=`true` / password=`false`) for Phase A to consume — not enforced yet.
- 4 Flyway tables (V29/V30): `app_user`, `user_session`, `gallery_access`, `webauthn_credential`.
- `AuthLoginLimiter` (5 / 15-min per IP+email, keyed off `X-Real-IP`) on password **and** passkey login-start.

## Not in this PR (deferred)

- **Phase A**: the `proxy.ts` / `app/utils/admin.ts` gating flip, HIDDEN-collection + `/cdn` gating, retire the static `ADMIN_TOKEN`.
- **Phase C**: wiring `gallery_access` into the collection + download controllers, client onboarding / magic-links / SES.

## Test plan

- [x] `./mvnw test` — **758 tests, 0 failures** (Mockito + Testcontainers Postgres + spring-security-test).
- [x] Wired **E2E**: `AdminBootstrap`-seeded admin → `POST /api/auth/login` → `ezac_session` cookie → `GET /api/auth/me` returns principal; `401` without cookie; `401` on wrong password.
- [x] Migration applies cleanly on a fresh Postgres. The reconstructed pre-Flyway base schema is a **test-only** `withInitScript` — the production migration path stays **V2 → V30**, so existing prod/dev Flyway history is untouched.
- [x] Zero-behavior-change verified at the diff level: the only modified pre-existing files are `pom.xml`, `InternalSecretFilter.java` (`@Order`), and `application[-dev].properties`.

Pairs with the frontend client PR in `edens.zac`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
