### PR TITLE
feat(user): random tagged cover + per-user description for /user page

### DIFF
--- a/src/main/java/edens/zac/portfolio/backend/controller/admin/AdminUserController.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/admin/AdminUserController.java
@@ -118,7 +118,10 @@ public class AdminUserController {
   public List<AdminUserSummary> listUsers() {
     return appUserRepository.findAllOrderedByCreatedAt().stream()
         .filter(u -> u.getStatus() != UserStatus.PERSON)
-        .map(u -> new AdminUserSummary(u.getId(), u.getEmail(), u.getName(), u.getStatus()))
+        .map(
+            u ->
+                new AdminUserSummary(
+                    u.getId(), u.getEmail(), u.getName(), u.getStatus(), u.getDescription()))
         .toList();
   }
 
@@ -157,7 +160,8 @@ public class AdminUserController {
         .map(
             u ->
                 ResponseEntity.ok(
-                    new AdminUserSummary(u.getId(), u.getEmail(), u.getName(), u.getStatus())))
+                    new AdminUserSummary(
+                        u.getId(), u.getEmail(), u.getName(), u.getStatus(), u.getDescription())))
         .orElseGet(() -> ResponseEntity.notFound().build());
   }
 
@@ -177,10 +181,15 @@ public class AdminUserController {
     }
     appUserRepository.updateName(id, request.displayName());
     appUserRepository.updateStatus(id, request.status());
+    appUserRepository.updateDescription(id, request.description());
     AppUserEntity updated = appUserRepository.findById(id).orElseThrow();
     return ResponseEntity.ok(
         new AdminUserSummary(
-            updated.getId(), updated.getEmail(), updated.getName(), updated.getStatus()));
+            updated.getId(),
+            updated.getEmail(),
+            updated.getName(),
+            updated.getStatus(),
+            updated.getDescription()));
   }
 
   /**

--- a/src/main/java/edens/zac/portfolio/backend/controller/admin/UserRequests.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/admin/UserRequests.java
@@ -5,6 +5,7 @@ import edens.zac.portfolio.backend.types.UserStatus;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 /** Request and response records for the admin user-management endpoints. */
 public final class UserRequests {
@@ -19,8 +20,10 @@ public final class UserRequests {
    * @param email the account email
    * @param displayName the display name, may be {@code null}
    * @param status the account lifecycle status (INVITED / ACTIVE / DISABLED)
+   * @param description the admin-authored per-user description, may be {@code null}
    */
-  public record AdminUserSummary(Long id, String email, String displayName, UserStatus status) {}
+  public record AdminUserSummary(
+      Long id, String email, String displayName, UserStatus status, String description) {}
 
   /**
    * Body for {@code POST /api/admin/users} — creates a new user account and returns an invite URL.
@@ -40,14 +43,16 @@ public final class UserRequests {
   public record CreateUserResponse(Long userId, String inviteUrl) {}
 
   /**
-   * Body for {@code PATCH /api/admin/users/{id}} — updates the two admin-editable fields. Email is
+   * Body for {@code PATCH /api/admin/users/{id}} — updates the admin-editable fields. Email is
    * deliberately immutable (it is the login identity and invite target). {@code displayName} may be
    * {@code null} to clear it; {@code status} is required.
    *
    * @param displayName the new display name, or {@code null} to clear
    * @param status the new lifecycle status (INVITED / ACTIVE / DISABLED)
+   * @param description the admin-authored per-user description, or {@code null} to clear
    */
-  public record UpdateUserRequest(String displayName, @NotNull UserStatus status) {}
+  public record UpdateUserRequest(
+      String displayName, @NotNull UserStatus status, @Size(max = 500) String description) {}
 
   /**
    * One associated-collection row in the admin user detail. {@code role} is {@code null} when the

--- a/src/main/java/edens/zac/portfolio/backend/dao/AppUserRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/AppUserRepository.java
@@ -22,7 +22,7 @@ public class AppUserRepository extends BaseDao {
 
   private static final String SELECT_APP_USER =
       """
-      SELECT id, email, password_hash, webauthn_user_handle, name, status,
+      SELECT id, email, password_hash, webauthn_user_handle, name, description, status,
              created_at, updated_at
       FROM users
       """;
@@ -36,6 +36,7 @@ public class AppUserRepository extends BaseDao {
             .passwordHash(rs.getString("password_hash"))
             .webauthnUserHandle(handle != null ? (UUID) handle : null)
             .name(rs.getString("name"))
+            .description(rs.getString("description"))
             .status(UserStatus.valueOf(rs.getString("status")))
             .createdAt(getLocalDateTime(rs, "created_at"))
             .updatedAt(getLocalDateTime(rs, "updated_at"))
@@ -110,6 +111,14 @@ public class AppUserRepository extends BaseDao {
     String sql = "UPDATE users SET name = :name, updated_at = now() WHERE id = :id";
     MapSqlParameterSource params =
         createParameterSource().addValue("name", name).addValue("id", id);
+    update(sql, params);
+  }
+
+  @Transactional
+  public void updateDescription(Long id, String description) {
+    String sql = "UPDATE users SET description = :description, updated_at = now() WHERE id = :id";
+    MapSqlParameterSource params =
+        createParameterSource().addValue("description", description).addValue("id", id);
     update(sql, params);
   }
 }

--- a/src/main/java/edens/zac/portfolio/backend/dao/ContentRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/ContentRepository.java
@@ -281,6 +281,30 @@ public class ContentRepository extends BaseDao {
   }
 
   /**
+   * A random image content id the person is tagged on via {@code content_image_people}. Backs the
+   * {@code /user} synthetic-collection cover (random variant, replaces Decision D2's
+   * most-recent-first ordering). Empty when the person tags no image content.
+   */
+  @Transactional(readOnly = true)
+  public Optional<Long> findRandomImageIdByPersonId(Long personId) {
+    if (personId == null) {
+      return Optional.empty();
+    }
+    String sql =
+        """
+        SELECT ci.id
+        FROM content_image ci
+        JOIN content c ON c.id = ci.id
+        JOIN content_image_people cip ON cip.content_id = ci.id
+        WHERE cip.person_id = :personId
+        ORDER BY RANDOM()
+        LIMIT 1
+        """;
+    MapSqlParameterSource params = createParameterSource().addValue("personId", personId);
+    return query(sql, (rs, n) -> rs.getLong("id"), params).stream().findFirst();
+  }
+
+  /**
    * Images a person is tagged on via {@code content_image_people}, newest first (EXIF capture date
    * desc, then row creation desc). Backs the {@code /user} page's standalone tagged-image blocks
    * (spec §7). Empty for null/unknown persons.

--- a/src/main/java/edens/zac/portfolio/backend/entity/AppUserEntity.java
+++ b/src/main/java/edens/zac/portfolio/backend/entity/AppUserEntity.java
@@ -18,6 +18,7 @@ public class AppUserEntity {
   private String passwordHash;
   private UUID webauthnUserHandle;
   private String name;
+  private String description;
   private UserStatus status;
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;

--- a/src/main/java/edens/zac/portfolio/backend/services/UserPageAssembler.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/UserPageAssembler.java
@@ -1,8 +1,10 @@
 package edens.zac.portfolio.backend.services;
 
+import edens.zac.portfolio.backend.dao.AppUserRepository;
 import edens.zac.portfolio.backend.dao.CollectionRepository;
 import edens.zac.portfolio.backend.dao.ContentRepository;
 import edens.zac.portfolio.backend.dao.PersonRepository;
+import edens.zac.portfolio.backend.entity.AppUserEntity;
 import edens.zac.portfolio.backend.entity.CollectionEntity;
 import edens.zac.portfolio.backend.entity.ContentPersonEntity;
 import edens.zac.portfolio.backend.model.CollectionModel;
@@ -42,6 +44,7 @@ public class UserPageAssembler {
 
   private static final String DEFAULT_TITLE = "Your Galleries";
 
+  private final AppUserRepository appUserRepository;
   private final PersonRepository personRepository;
   private final UserCollectionService userCollectionService;
   private final CollectionRepository collectionRepository;
@@ -81,9 +84,14 @@ public class UserPageAssembler {
     ContentModels.Image cover = person.flatMap(p -> resolveCover(p.getId())).orElse(null);
     String title = person.map(ContentPersonEntity::getPersonName).orElse(DEFAULT_TITLE);
 
+    // Description is set unconditionally from the user account row, independent of person tagging.
+    String description =
+        appUserRepository.findById(userId).map(AppUserEntity::getDescription).orElse(null);
+
     return CollectionModel.builder()
         .slug("user")
         .title(title)
+        .description(description)
         .type(CollectionType.PARENT)
         .visibility(CollectionVisibility.UNLISTED)
         .coverImage(cover)
@@ -147,10 +155,10 @@ public class UserPageAssembler {
     };
   }
 
-  /** The most-recent associated content image as a cover model (Decision D2). */
+  /** A random associated content image as a cover model. */
   private Optional<ContentModels.Image> resolveCover(Long personId) {
     return contentRepository
-        .findMostRecentImageIdByPersonId(personId)
+        .findRandomImageIdByPersonId(personId)
         .flatMap(contentRepository::findImageById)
         .map(contentModelConverter::convertImageEntityToModel);
   }

--- a/src/main/resources/db/migration/V38__add_users_description.sql
+++ b/src/main/resources/db/migration/V38__add_users_description.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN description VARCHAR(500);

--- a/src/test/java/edens/zac/portfolio/backend/UserDescriptionMigrationIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/UserDescriptionMigrationIntegrationTest.java
@@ -1,0 +1,74 @@
+package edens.zac.portfolio.backend;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Verifies the V38 Flyway migration applied: the {@code users} table has a nullable {@code
+ * description} column capped at 500 characters. Extends the Testcontainers base so the full V1..V38
+ * chain runs on context start.
+ */
+class UserDescriptionMigrationIntegrationTest extends AbstractPostgresIntegrationTest {
+
+  @Autowired private JdbcTemplate jdbc;
+
+  @Test
+  void usersTableHasDescriptionColumn() {
+    Integer columnCount =
+        jdbc.queryForObject(
+            "SELECT COUNT(*) FROM information_schema.columns "
+                + "WHERE table_name = 'users' AND column_name = 'description'",
+            Integer.class);
+    assertThat(columnCount).isEqualTo(1);
+  }
+
+  @Test
+  void descriptionColumnIsNullableWithCharacterLimit() {
+    // Check data_type and character_maximum_length
+    String dataType =
+        jdbc.queryForObject(
+            "SELECT data_type FROM information_schema.columns "
+                + "WHERE table_name = 'users' AND column_name = 'description'",
+            String.class);
+    assertThat(dataType).isEqualTo("character varying");
+
+    Integer charMaxLength =
+        jdbc.queryForObject(
+            "SELECT character_maximum_length FROM information_schema.columns "
+                + "WHERE table_name = 'users' AND column_name = 'description'",
+            Integer.class);
+    assertThat(charMaxLength).isEqualTo(500);
+
+    // Confirm nullable (is_nullable = 'YES')
+    String isNullable =
+        jdbc.queryForObject(
+            "SELECT is_nullable FROM information_schema.columns "
+                + "WHERE table_name = 'users' AND column_name = 'description'",
+            String.class);
+    assertThat(isNullable).isEqualTo("YES");
+  }
+
+  @Test
+  void descriptionRoundTripsForNewUser() {
+    Long userId =
+        jdbc.queryForObject(
+            "INSERT INTO users (name, email, webauthn_user_handle, status) "
+                + "VALUES (?, ?, gen_random_uuid(), 'ACTIVE') RETURNING id",
+            Long.class,
+            "Desc Migration Test",
+            "desc-migration@example.com");
+
+    // On insert description is NULL by default.
+    String initial =
+        jdbc.queryForObject("SELECT description FROM users WHERE id = ?", String.class, userId);
+    assertThat(initial).isNull();
+
+    jdbc.update("UPDATE users SET description = ? WHERE id = ?", "Hello world.", userId);
+    String updated =
+        jdbc.queryForObject("SELECT description FROM users WHERE id = ?", String.class, userId);
+    assertThat(updated).isEqualTo("Hello world.");
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/controller/admin/AdminUserControllerTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/admin/AdminUserControllerTest.java
@@ -152,6 +152,7 @@ class AdminUserControllerTest {
               .id(1L)
               .email("alice@example.com")
               .name("Alice")
+              .description("A keen landscape photographer.")
               .status(UserStatus.ACTIVE)
               .passwordHash("{bcrypt}$2a$10$secret")
               .webauthnUserHandle(UUID.randomUUID())
@@ -170,6 +171,7 @@ class AdminUserControllerTest {
           .andExpect(jsonPath("$[0].id").value(1))
           .andExpect(jsonPath("$[0].email").value("alice@example.com"))
           .andExpect(jsonPath("$[0].displayName").value("Alice"))
+          .andExpect(jsonPath("$[0].description").value("A keen landscape photographer."))
           .andExpect(jsonPath("$[0].status").value("ACTIVE"))
           // Sensitive fields must never be serialized into the admin list.
           .andExpect(jsonPath("$[0].passwordHash").doesNotExist())
@@ -242,6 +244,7 @@ class AdminUserControllerTest {
               .id(3L)
               .email("carol@example.com")
               .name("Carol")
+              .description("Documentary photographer based in Seattle.")
               .status(UserStatus.ACTIVE)
               .passwordHash("secret-hash")
               .webauthnUserHandle(UUID.randomUUID())
@@ -254,6 +257,7 @@ class AdminUserControllerTest {
           .andExpect(jsonPath("$.id").value(3))
           .andExpect(jsonPath("$.email").value("carol@example.com"))
           .andExpect(jsonPath("$.displayName").value("Carol"))
+          .andExpect(jsonPath("$.description").value("Documentary photographer based in Seattle."))
           .andExpect(jsonPath("$.status").value("ACTIVE"))
           .andExpect(jsonPath("$.passwordHash").doesNotExist())
           .andExpect(jsonPath("$.webauthnUserHandle").doesNotExist());
@@ -303,6 +307,41 @@ class AdminUserControllerTest {
 
       verify(appUserRepository).updateName(8L, "Kenneth");
       verify(appUserRepository).updateStatus(8L, UserStatus.ACTIVE);
+      verify(appUserRepository).updateDescription(8L, null);
+    }
+
+    @Test
+    void updateUserWithDescriptionPersistsAndEchoes() throws Exception {
+      AppUserEntity before =
+          AppUserEntity.builder()
+              .id(9L)
+              .email("diana@example.com")
+              .name("Diana")
+              .status(UserStatus.ACTIVE)
+              .build();
+      AppUserEntity after =
+          AppUserEntity.builder()
+              .id(9L)
+              .email("diana@example.com")
+              .name("Diana")
+              .description("Wildlife and conservation photographer.")
+              .status(UserStatus.ACTIVE)
+              .build();
+      when(appUserRepository.findById(9L))
+          .thenReturn(Optional.of(before))
+          .thenReturn(Optional.of(after));
+
+      mockMvc
+          .perform(
+              patch("/api/admin/users/9")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(
+                      "{\"displayName\":\"Diana\",\"status\":\"ACTIVE\","
+                          + "\"description\":\"Wildlife and conservation photographer.\"}"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.description").value("Wildlife and conservation photographer."));
+
+      verify(appUserRepository).updateDescription(9L, "Wildlife and conservation photographer.");
     }
 
     @Test

--- a/src/test/java/edens/zac/portfolio/backend/dao/AppUserRepositoryIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/dao/AppUserRepositoryIntegrationTest.java
@@ -102,4 +102,23 @@ class AppUserRepositoryIntegrationTest extends AbstractPostgresIntegrationTest {
     assertThat(repository.findById(id)).isPresent();
     assertThat(repository.findById(id).get().getName()).isEqualTo("Alice Smith");
   }
+
+  @Test
+  void updateDescriptionPersists() {
+    Long id = repository.insert(newUser("desc@example.com"));
+    // description is NULL on fresh insert
+    assertThat(repository.findById(id).get().getDescription()).isNull();
+
+    repository.updateDescription(id, "Photographer and traveller.");
+    assertThat(repository.findById(id).get().getDescription())
+        .isEqualTo("Photographer and traveller.");
+  }
+
+  @Test
+  void updateDescriptionCanBeCleared() {
+    Long id = repository.insert(newUser("desc-clear@example.com"));
+    repository.updateDescription(id, "Some description");
+    repository.updateDescription(id, null);
+    assertThat(repository.findById(id).get().getDescription()).isNull();
+  }
 }

--- a/src/test/java/edens/zac/portfolio/backend/services/UserPageAssemblerIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/UserPageAssemblerIntegrationTest.java
@@ -106,6 +106,13 @@ class UserPageAssemblerIntegrationTest extends AbstractPostgresIntegrationTest {
     return contentId;
   }
 
+  /** Seed a user and set a description directly on the row. */
+  private Long seedUserWithDescription(String name, String description) {
+    Long id = seedUserNamed(name);
+    jdbc.update("UPDATE users SET description = ? WHERE id = ?", description, id);
+    return id;
+  }
+
   private static List<ContentModels.Collection> collectionBlocks(CollectionModel model) {
     return model.getContent().stream()
         .filter(ContentModels.Collection.class::isInstance)
@@ -120,7 +127,7 @@ class UserPageAssemblerIntegrationTest extends AbstractPostgresIntegrationTest {
   }
 
   @Test
-  void unionsTaggedAndGrantedCollectionsDeDuplicatedWithMostRecentCover() {
+  void unionsTaggedAndGrantedCollectionsDeDuplicatedWithRandomCover() {
     // The account row IS the person identity: tag and grant against the same id.
     Long userId = seedUserNamed("Jane Doe");
 
@@ -167,9 +174,13 @@ class UserPageAssemblerIntegrationTest extends AbstractPostgresIntegrationTest {
       assertThat(model.getContent().get(i).orderIndex()).isEqualTo(i);
     }
 
-    // Cover is the most-recent tagged image (D2).
+    // Cover is a random tagged image — assert it is one of the seeded images (not a fixed URL).
     assertThat(model.getCoverImage()).isNotNull();
-    assertThat(model.getCoverImage().imageUrl()).isEqualTo("https://cdn/new.webp");
+    assertThat(model.getCoverImage().imageUrl())
+        .isIn("https://cdn/old.webp", "https://cdn/new.webp");
+
+    // No description was set on this user.
+    assertThat(model.getDescription()).isNull();
   }
 
   @Test
@@ -262,5 +273,32 @@ class UserPageAssemblerIntegrationTest extends AbstractPostgresIntegrationTest {
     assertThat(body.get(0).orderIndex()).isZero();
     assertThat(body.get(1).orderIndex()).isEqualTo(1);
     assertThat(body.get(2).orderIndex()).isEqualTo(2);
+  }
+
+  @Test
+  void taggedUserWithDescriptionHasCoverFromTaggedSetAndDescriptionSet() {
+    Long userId = seedUserWithDescription("Described Person", "A portrait photographer.");
+
+    // Tag two images; cover must be one of them.
+    seedTaggedImage(userId, "https://cdn/a.webp", LocalDateTime.now().minusDays(1));
+    seedTaggedImage(userId, "https://cdn/b.webp", LocalDateTime.now().minusDays(2));
+
+    CollectionModel model = assembler.assembleForUser(userId);
+
+    assertThat(model.getDescription()).isEqualTo("A portrait photographer.");
+    assertThat(model.getCoverImage()).isNotNull();
+    assertThat(model.getCoverImage().imageUrl()).isIn("https://cdn/a.webp", "https://cdn/b.webp");
+  }
+
+  @Test
+  void untaggedUserWithDescriptionHasDescriptionSetAndNullCover() {
+    Long userId = seedUserWithDescription("Untagged With Desc", "Grant-only viewer bio.");
+    // This user has no tagged images, no tagged collections, no memberships.
+
+    CollectionModel model = assembler.assembleForUser(userId);
+
+    assertThat(model.getDescription()).isEqualTo("Grant-only viewer bio.");
+    assertThat(model.getCoverImage()).isNull();
+    assertThat(model.getContent()).isEmpty();
   }
 }


### PR DESCRIPTION
Populate the /user synthetic collection (and the admin user-page view) with a random tagged cover image and an admin-authored description. V38 adds users.description (VARCHAR(500), matches CollectionModel @Size); ContentRepository.findRandomImageIdByPersonId (ORDER BY RANDOM()); UserPageAssembler uses the random cover (was most-recent) and sets description unconditionally from the user row; AppUserEntity/AppUserRepository gain the column + updateDescription; AdminUserController PATCH /users/{id} + DTOs carry description.

Stacked on 0189-user-invite-backend (the unmerged branch holding the /user infrastructure).