### PR TITLE
feat(admin): identity merge endpoints (absorb tag-only PERSON into an account)

### DIFF
--- a/src/main/java/edens/zac/portfolio/backend/controller/admin/AdminUserController.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/admin/AdminUserController.java
@@ -4,6 +4,9 @@ import edens.zac.portfolio.backend.controller.admin.UserRequests.AdminUserCollec
 import edens.zac.portfolio.backend.controller.admin.UserRequests.AdminUserSummary;
 import edens.zac.portfolio.backend.controller.admin.UserRequests.CreateUserRequest;
 import edens.zac.portfolio.backend.controller.admin.UserRequests.CreateUserResponse;
+import edens.zac.portfolio.backend.controller.admin.UserRequests.MergePreview;
+import edens.zac.portfolio.backend.controller.admin.UserRequests.MergeRequest;
+import edens.zac.portfolio.backend.controller.admin.UserRequests.MergeResult;
 import edens.zac.portfolio.backend.controller.admin.UserRequests.SetCollectionRoleRequest;
 import edens.zac.portfolio.backend.controller.admin.UserRequests.UpdateUserRequest;
 import edens.zac.portfolio.backend.dao.AppUserRepository;
@@ -11,6 +14,7 @@ import edens.zac.portfolio.backend.dao.UserCollectionRepository;
 import edens.zac.portfolio.backend.entity.AppUserEntity;
 import edens.zac.portfolio.backend.model.CollectionModel;
 import edens.zac.portfolio.backend.services.UserInviteService;
+import edens.zac.portfolio.backend.services.UserMergeService;
 import edens.zac.portfolio.backend.services.UserPageAssembler;
 import edens.zac.portfolio.backend.types.CollectionRole;
 import edens.zac.portfolio.backend.types.UserStatus;
@@ -31,6 +35,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -53,6 +58,7 @@ public class AdminUserController {
   private final UserInviteService userInviteService;
   private final UserCollectionRepository userCollectionRepository;
   private final UserPageAssembler userPageAssembler;
+  private final UserMergeService userMergeService;
   private final String frontendBaseUrl;
 
   public AdminUserController(
@@ -60,11 +66,13 @@ public class AdminUserController {
       UserInviteService userInviteService,
       UserCollectionRepository userCollectionRepository,
       UserPageAssembler userPageAssembler,
+      UserMergeService userMergeService,
       @Value("${email.frontend-base-url}") String frontendBaseUrl) {
     this.appUserRepository = appUserRepository;
     this.userInviteService = userInviteService;
     this.userCollectionRepository = userCollectionRepository;
     this.userPageAssembler = userPageAssembler;
+    this.userMergeService = userMergeService;
     this.frontendBaseUrl = frontendBaseUrl;
   }
 
@@ -109,15 +117,19 @@ public class AdminUserController {
   }
 
   /**
-   * List all user accounts (newest first) for the admin user-management view. Returns identity and
-   * lifecycle state only — never password hashes or WebAuthn handles.
+   * List user accounts (newest first) for the admin user-management view. Returns identity and
+   * lifecycle state only — never password hashes or WebAuthn handles. By default tag-only {@code
+   * PERSON} rows are excluded (accounts only); pass {@code includePeople=true} to surface them for
+   * the identity-merge UI.
    *
+   * @param includePeople when {@code true}, include {@code status='PERSON'} rows in the result
    * @return the user summaries
    */
   @GetMapping
-  public List<AdminUserSummary> listUsers() {
+  public List<AdminUserSummary> listUsers(
+      @RequestParam(name = "includePeople", defaultValue = "false") boolean includePeople) {
     return appUserRepository.findAllOrderedByCreatedAt().stream()
-        .filter(u -> u.getStatus() != UserStatus.PERSON)
+        .filter(u -> includePeople || u.getStatus() != UserStatus.PERSON)
         .map(u -> new AdminUserSummary(u.getId(), u.getEmail(), u.getName(), u.getStatus()))
         .toList();
   }
@@ -245,6 +257,52 @@ public class AdminUserController {
   @GetMapping("/{id}/page")
   public ResponseEntity<CollectionModel> userPage(@PathVariable Long id) {
     return ResponseEntity.ok(userPageAssembler.assembleForUser(id));
+  }
+
+  /**
+   * Preview an identity merge: count what would move from a tag-only PERSON ({@code sourceId}) onto
+   * a surviving identity ({@code targetId}) without mutating anything.
+   *
+   * @param sourceId the tag-only PERSON to absorb
+   * @param targetId the surviving identity
+   * @return {@code 200} with {@link MergePreview}, {@code 404} if either id is missing, or {@code
+   *     409} if the pair is not mergeable (same id, or source is not a PERSON)
+   */
+  @GetMapping("/{sourceId}/merge-preview")
+  public ResponseEntity<MergePreview> mergePreview(
+      @PathVariable Long sourceId, @RequestParam Long targetId) {
+    try {
+      return userMergeService
+          .preview(sourceId, targetId)
+          .map(ResponseEntity::ok)
+          .orElseGet(() -> ResponseEntity.notFound().build());
+    } catch (IllegalStateException e) {
+      return ResponseEntity.status(HttpStatus.CONFLICT).build();
+    }
+  }
+
+  /**
+   * Absorb a tag-only PERSON into the surviving identity in the path: re-point its image/collection
+   * tags + memberships onto the target, collapse duplicates, then hard-delete the source PERSON
+   * row. Irreversible.
+   *
+   * @param targetId the surviving identity (kept)
+   * @param request the source id to absorb
+   * @return {@code 200} with {@link MergeResult}, {@code 404} if either id is missing, or {@code
+   *     409} if the pair is not mergeable (same id, or source is not a PERSON)
+   */
+  @PostMapping("/{targetId}/merge")
+  public ResponseEntity<MergeResult> merge(
+      @PathVariable Long targetId, @Valid @RequestBody MergeRequest request) {
+    if (appUserRepository.findById(request.sourceId()).isEmpty()
+        || appUserRepository.findById(targetId).isEmpty()) {
+      return ResponseEntity.notFound().build();
+    }
+    try {
+      return ResponseEntity.ok(userMergeService.merge(request.sourceId(), targetId));
+    } catch (IllegalStateException e) {
+      return ResponseEntity.status(HttpStatus.CONFLICT).build();
+    }
   }
 
   /** Build the public invite URL, tolerating a {@code frontendBaseUrl} that ends in a slash. */

--- a/src/main/java/edens/zac/portfolio/backend/controller/admin/AdminUserController.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/admin/AdminUserController.java
@@ -20,6 +20,7 @@ import edens.zac.portfolio.backend.types.CollectionRole;
 import edens.zac.portfolio.backend.types.UserStatus;
 import jakarta.validation.Valid;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
@@ -294,12 +295,12 @@ public class AdminUserController {
   @PostMapping("/{targetId}/merge")
   public ResponseEntity<MergeResult> merge(
       @PathVariable Long targetId, @Valid @RequestBody MergeRequest request) {
-    if (appUserRepository.findById(request.sourceId()).isEmpty()
-        || appUserRepository.findById(targetId).isEmpty()) {
-      return ResponseEntity.notFound().build();
-    }
+    // Missing-id 404 and rail 409 are both delegated to the service (mirrors merge-preview), which
+    // re-checks existence inside its own transaction — no redundant controller-level lookups.
     try {
       return ResponseEntity.ok(userMergeService.merge(request.sourceId(), targetId));
+    } catch (NoSuchElementException e) {
+      return ResponseEntity.notFound().build();
     } catch (IllegalStateException e) {
       return ResponseEntity.status(HttpStatus.CONFLICT).build();
     }

--- a/src/main/java/edens/zac/portfolio/backend/controller/admin/UserRequests.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/admin/UserRequests.java
@@ -66,4 +66,44 @@ public final class UserRequests {
    * @param role the new membership role (GENERAL or CLIENT)
    */
   public record SetCollectionRoleRequest(@NotNull CollectionRole role) {}
+
+  /**
+   * Body for {@code POST /api/admin/users/{targetId}/merge} — absorb a tag-only PERSON into the
+   * surviving identity in the path.
+   *
+   * @param sourceId the tag-only PERSON to absorb (it is hard-deleted by the merge)
+   */
+  public record MergeRequest(@NotNull Long sourceId) {}
+
+  /**
+   * Preview of a pending identity merge ({@code GET
+   * /api/admin/users/{sourceId}/merge-preview?targetId=}). Counts what would move from source onto
+   * target without mutating anything.
+   *
+   * @param sourceId the tag-only PERSON to absorb
+   * @param sourceName the source's display name, may be {@code null}
+   * @param targetId the surviving identity
+   * @param targetName the target's display name, may be {@code null}
+   * @param imageTagCount image tags currently on the source
+   * @param collectionCount collection associations currently on the source
+   * @param duplicatesCollapsed source tags that already exist on the target (will be de-duped)
+   */
+  public record MergePreview(
+      Long sourceId,
+      String sourceName,
+      Long targetId,
+      String targetName,
+      int imageTagCount,
+      int collectionCount,
+      int duplicatesCollapsed) {}
+
+  /**
+   * Result of a completed merge ({@code POST /api/admin/users/{targetId}/merge}).
+   *
+   * @param movedImageTags image tags re-pointed onto the target
+   * @param movedCollections collection associations re-pointed onto the target
+   * @param duplicatesCollapsed source tags that collided with an existing target tag and were
+   *     de-duped
+   */
+  public record MergeResult(int movedImageTags, int movedCollections, int duplicatesCollapsed) {}
 }

--- a/src/main/java/edens/zac/portfolio/backend/dao/PersonRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/PersonRepository.java
@@ -201,6 +201,75 @@ public class PersonRepository extends BaseDao {
     update("DELETE FROM collection_people WHERE person_id = :personId", params);
   }
 
+  /** Number of image tags currently on a person. */
+  @Transactional(readOnly = true)
+  public int countImageTags(Long personId) {
+    Integer n =
+        namedParameterJdbcTemplate.queryForObject(
+            "SELECT count(*) FROM content_image_people WHERE person_id = :id",
+            createParameterSource().addValue("id", personId),
+            Integer.class);
+    return n == null ? 0 : n;
+  }
+
+  /** Number of collection associations currently on a person. */
+  @Transactional(readOnly = true)
+  public int countCollectionTags(Long personId) {
+    Integer n =
+        namedParameterJdbcTemplate.queryForObject(
+            "SELECT count(*) FROM collection_people WHERE person_id = :id",
+            createParameterSource().addValue("id", personId),
+            Integer.class);
+    return n == null ? 0 : n;
+  }
+
+  /** Tags on source that would collide with an existing target tag (image + collection). */
+  @Transactional(readOnly = true)
+  public int countCollisions(Long sourceId, Long targetId) {
+    MapSqlParameterSource p =
+        createParameterSource().addValue("src", sourceId).addValue("tgt", targetId);
+    Integer img =
+        namedParameterJdbcTemplate.queryForObject(
+            "SELECT count(*) FROM content_image_people s "
+                + "WHERE s.person_id = :src AND EXISTS (SELECT 1 FROM content_image_people t "
+                + "WHERE t.person_id = :tgt AND t.content_id = s.content_id)",
+            p,
+            Integer.class);
+    Integer col =
+        namedParameterJdbcTemplate.queryForObject(
+            "SELECT count(*) FROM collection_people s "
+                + "WHERE s.person_id = :src AND EXISTS (SELECT 1 FROM collection_people t "
+                + "WHERE t.person_id = :tgt AND t.collection_id = s.collection_id)",
+            p,
+            Integer.class);
+    return (img == null ? 0 : img) + (col == null ? 0 : col);
+  }
+
+  /** Re-point all of source's image + collection tags onto target, de-duplicating first. */
+  @Transactional
+  public void repointTags(Long sourceId, Long targetId) {
+    MapSqlParameterSource p =
+        createParameterSource().addValue("src", sourceId).addValue("tgt", targetId);
+    update(
+        "DELETE FROM content_image_people WHERE person_id = :src "
+            + "AND content_id IN (SELECT content_id FROM content_image_people WHERE person_id = :tgt)",
+        p);
+    update("UPDATE content_image_people SET person_id = :tgt WHERE person_id = :src", p);
+    update(
+        "DELETE FROM collection_people WHERE person_id = :src "
+            + "AND collection_id IN (SELECT collection_id FROM collection_people WHERE person_id = :tgt)",
+        p);
+    update("UPDATE collection_people SET person_id = :tgt WHERE person_id = :src", p);
+  }
+
+  /** Defense-in-depth delete: only removes a tag-only PERSON row. */
+  @Transactional
+  public void deletePersonById(Long id) {
+    update(
+        "DELETE FROM users WHERE id = :id AND status = 'PERSON'",
+        createParameterSource().addValue("id", id));
+  }
+
   @Transactional(readOnly = true)
   public List<ContentPersonEntity> findContentPeople(Long contentId) {
     String sql =

--- a/src/main/java/edens/zac/portfolio/backend/dao/UserCollectionRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/UserCollectionRepository.java
@@ -107,6 +107,20 @@ public class UserCollectionRepository extends BaseDao {
         createParameterSource().addValue("userId", userId).addValue("collectionId", collectionId));
   }
 
+  /**
+   * Re-point a source identity's collection memberships onto target (de-duped). No-op for a PERSON.
+   */
+  @Transactional
+  public void repointMemberships(Long sourceId, Long targetId) {
+    MapSqlParameterSource p =
+        createParameterSource().addValue("src", sourceId).addValue("tgt", targetId);
+    update(
+        "DELETE FROM user_collection WHERE user_id = :src "
+            + "AND collection_id IN (SELECT collection_id FROM user_collection WHERE user_id = :tgt)",
+        p);
+    update("UPDATE user_collection SET user_id = :tgt WHERE user_id = :src", p);
+  }
+
   /** A row for the admin toggle UI: a collection the user is tagged in or a member of, + role. */
   public record AssociatedCollection(Long collectionId, String title, String role) {}
 

--- a/src/main/java/edens/zac/portfolio/backend/services/UserMergeService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/UserMergeService.java
@@ -1,0 +1,98 @@
+package edens.zac.portfolio.backend.services;
+
+import edens.zac.portfolio.backend.controller.admin.UserRequests.MergePreview;
+import edens.zac.portfolio.backend.controller.admin.UserRequests.MergeResult;
+import edens.zac.portfolio.backend.dao.AppUserRepository;
+import edens.zac.portfolio.backend.dao.PersonRepository;
+import edens.zac.portfolio.backend.dao.UserCollectionRepository;
+import edens.zac.portfolio.backend.entity.AppUserEntity;
+import edens.zac.portfolio.backend.types.UserStatus;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Merges a tag-only PERSON (source) into a surviving identity (target). */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UserMergeService {
+
+  private final AppUserRepository appUserRepository;
+  private final PersonRepository personRepository;
+  private final UserCollectionRepository userCollectionRepository;
+
+  /**
+   * Counts what a merge of {@code sourceId} into {@code targetId} would move, without mutating
+   * anything.
+   *
+   * @return empty when either id is missing
+   * @throws IllegalStateException when the pair is not mergeable (same id, or source not a PERSON)
+   */
+  @Transactional(readOnly = true)
+  public Optional<MergePreview> preview(Long sourceId, Long targetId) {
+    Optional<AppUserEntity> source = appUserRepository.findById(sourceId);
+    Optional<AppUserEntity> target = appUserRepository.findById(targetId);
+    if (source.isEmpty() || target.isEmpty()) {
+      return Optional.empty();
+    }
+    requireMergeable(sourceId, targetId, source.get());
+    return Optional.of(
+        new MergePreview(
+            sourceId,
+            source.get().getName(),
+            targetId,
+            target.get().getName(),
+            personRepository.countImageTags(sourceId),
+            personRepository.countCollectionTags(sourceId),
+            personRepository.countCollisions(sourceId, targetId)));
+  }
+
+  /**
+   * Re-points tags + memberships from source onto target, then hard-deletes the source PERSON row.
+   * Runs in a single transaction: re-point happens before delete (the tag FKs are {@code ON DELETE
+   * CASCADE}), and collisions are de-duped before the re-point (the join PKs are composite).
+   *
+   * @throws NoSuchElementException when either id is missing
+   * @throws IllegalStateException when the pair is not mergeable (same id, or source not a PERSON)
+   */
+  @Transactional
+  public MergeResult merge(Long sourceId, Long targetId) {
+    AppUserEntity source =
+        appUserRepository
+            .findById(sourceId)
+            .orElseThrow(() -> new NoSuchElementException("source " + sourceId + " not found"));
+    appUserRepository
+        .findById(targetId)
+        .orElseThrow(() -> new NoSuchElementException("target " + targetId + " not found"));
+    requireMergeable(sourceId, targetId, source);
+
+    final int images = personRepository.countImageTags(sourceId);
+    final int collections = personRepository.countCollectionTags(sourceId);
+    final int collapsed = personRepository.countCollisions(sourceId, targetId);
+
+    personRepository.repointTags(sourceId, targetId);
+    userCollectionRepository.repointMemberships(sourceId, targetId);
+    personRepository.deletePersonById(sourceId);
+
+    log.info(
+        "Merged person {} into {} (images={}, collections={}, collapsed={})",
+        sourceId,
+        targetId,
+        images,
+        collections,
+        collapsed);
+    return new MergeResult(images, collections, collapsed);
+  }
+
+  private void requireMergeable(Long sourceId, Long targetId, AppUserEntity source) {
+    if (sourceId.equals(targetId)) {
+      throw new IllegalStateException("cannot merge an identity into itself");
+    }
+    if (source.getStatus() != UserStatus.PERSON) {
+      throw new IllegalStateException("source must be a tag-only PERSON");
+    }
+  }
+}

--- a/src/main/java/edens/zac/portfolio/backend/services/UserMergeService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/UserMergeService.java
@@ -84,6 +84,9 @@ public class UserMergeService {
         images,
         collections,
         collapsed);
+    // movedImageTags/movedCollections are the GROSS source counts (coherent with the preview's
+    // imageTagCount/collectionCount), not net-of-collisions; duplicatesCollapsed reports the
+    // overlap.
     return new MergeResult(images, collections, collapsed);
   }
 

--- a/src/test/java/edens/zac/portfolio/backend/UserMergeIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/UserMergeIntegrationTest.java
@@ -1,0 +1,112 @@
+package edens.zac.portfolio.backend;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import edens.zac.portfolio.backend.controller.admin.UserRequests.MergePreview;
+import edens.zac.portfolio.backend.controller.admin.UserRequests.MergeResult;
+import edens.zac.portfolio.backend.services.UserMergeService;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Round-trips {@link UserMergeService} against a real Postgres container: seeds two identities with
+ * overlapping tags and asserts the merge re-points tags, collapses duplicates, and hard-deletes the
+ * source — and that a real account can never be the source. Seeding mirrors {@link
+ * IdentityMergeMigrationIntegrationTest} (post-V35 shape: {@code users} + {@code person_id} joins).
+ */
+class UserMergeIntegrationTest extends AbstractPostgresIntegrationTest {
+
+  @Autowired private JdbcTemplate jdbc;
+  @Autowired private UserMergeService userMergeService;
+
+  private Long newPerson(String name) {
+    jdbc.update(
+        "INSERT INTO users (name, webauthn_user_handle, status) VALUES (?, gen_random_uuid(), 'PERSON')",
+        name);
+    return jdbc.queryForObject("SELECT id FROM users WHERE name = ?", Long.class, name);
+  }
+
+  private Long newAccount(String email, String name) {
+    jdbc.update(
+        "INSERT INTO users (email, name, webauthn_user_handle, status) "
+            + "VALUES (?, ?, gen_random_uuid(), 'ACTIVE')",
+        email,
+        name);
+    return jdbc.queryForObject("SELECT id FROM users WHERE email = ?", Long.class, email);
+  }
+
+  private Long newImageTaggedWith(Long personId) {
+    jdbc.update("INSERT INTO content (content_type) VALUES ('IMAGE')");
+    Long contentId = jdbc.queryForObject("SELECT max(id) FROM content", Long.class);
+    jdbc.update(
+        "INSERT INTO content_image (id, title, image_url_web) VALUES (?, 'x', 'http://x')",
+        contentId);
+    jdbc.update(
+        "INSERT INTO content_image_people (content_id, person_id) VALUES (?, ?)",
+        contentId,
+        personId);
+    return contentId;
+  }
+
+  @Test
+  void mergeRepointsTagsCollapsesDuplicatesAndDeletesSource() {
+    Long account = newAccount("danny@danny.com", "Danny");
+    Long person = newPerson("Danny Nieves");
+    Long onlyOnPerson = newImageTaggedWith(person);
+    Long shared = newImageTaggedWith(person);
+    // account is ALSO tagged on `shared` -> that source row must collapse, not duplicate.
+    jdbc.update(
+        "INSERT INTO content_image_people (content_id, person_id) VALUES (?, ?)", shared, account);
+
+    MergeResult result = userMergeService.merge(person, account);
+
+    assertThat(result.duplicatesCollapsed()).isEqualTo(1);
+    // Source had two image tags before the merge; reported `movedImageTags` is the gross source
+    // count (preview-coherent), independent of how many collapsed on landing.
+    assertThat(result.movedImageTags()).isEqualTo(2);
+    // source row gone
+    assertThat(
+            jdbc.queryForObject("SELECT count(*) FROM users WHERE id = ?", Integer.class, person))
+        .isZero();
+    // both images now point at the account, no duplicate on `shared`
+    assertThat(
+            jdbc.queryForObject(
+                "SELECT count(*) FROM content_image_people WHERE person_id = ?",
+                Integer.class,
+                account))
+        .isEqualTo(2);
+    assertThat(
+            jdbc.queryForObject(
+                "SELECT count(*) FROM content_image_people WHERE content_id = ? AND person_id = ?",
+                Integer.class,
+                onlyOnPerson,
+                account))
+        .isEqualTo(1);
+  }
+
+  @Test
+  void previewReportsCountsWithoutMutating() {
+    Long account = newAccount("a@a.com", "Acct");
+    Long person = newPerson("Tag Person");
+    newImageTaggedWith(person);
+
+    Optional<MergePreview> preview = userMergeService.preview(person, account);
+
+    assertThat(preview).isPresent();
+    assertThat(preview.get().imageTagCount()).isEqualTo(1);
+    assertThat(
+            jdbc.queryForObject("SELECT count(*) FROM users WHERE id = ?", Integer.class, person))
+        .isEqualTo(1); // unchanged
+  }
+
+  @Test
+  void refusesToDeleteARealAccount() {
+    Long accountA = newAccount("keep@x.com", "Keep");
+    Long accountB = newAccount("loser@x.com", "Loser");
+    assertThatThrownBy(() -> userMergeService.merge(accountB, accountA))
+        .isInstanceOf(IllegalStateException.class);
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/UserMergeIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/UserMergeIntegrationTest.java
@@ -7,6 +7,7 @@ import edens.zac.portfolio.backend.controller.admin.UserRequests.MergePreview;
 import edens.zac.portfolio.backend.controller.admin.UserRequests.MergeResult;
 import edens.zac.portfolio.backend.services.UserMergeService;
 import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -51,27 +52,62 @@ class UserMergeIntegrationTest extends AbstractPostgresIntegrationTest {
     return contentId;
   }
 
+  /** A real collection row (idiom mirrors UserCollectionRepositoryIntegrationTest). */
+  private Long newCollection() {
+    String slug = "merge-test-" + UUID.randomUUID();
+    return jdbc.queryForObject(
+        "INSERT INTO collection (title, slug, type, visibility) "
+            + "VALUES (?, ?, 'CLIENT_GALLERY', 'UNLISTED') RETURNING id",
+        Long.class,
+        slug,
+        slug);
+  }
+
+  private void tagPersonOnCollection(Long collectionId, Long personId) {
+    jdbc.update(
+        "INSERT INTO collection_people (collection_id, person_id) VALUES (?, ?)",
+        collectionId,
+        personId);
+  }
+
   @Test
   void mergeRepointsTagsCollapsesDuplicatesAndDeletesSource() {
     Long account = newAccount("danny@danny.com", "Danny");
     Long person = newPerson("Danny Nieves");
-    Long onlyOnPerson = newImageTaggedWith(person);
-    Long shared = newImageTaggedWith(person);
-    // account is ALSO tagged on `shared` -> that source row must collapse, not duplicate.
+
+    // --- image tags ---
+    Long onlyOnPersonImage = newImageTaggedWith(person);
+    Long sharedImage = newImageTaggedWith(person);
+    // account is ALSO tagged on `sharedImage` -> that source row must collapse, not duplicate.
     jdbc.update(
-        "INSERT INTO content_image_people (content_id, person_id) VALUES (?, ?)", shared, account);
+        "INSERT INTO content_image_people (content_id, person_id) VALUES (?, ?)",
+        sharedImage,
+        account);
+
+    // --- collection tags (exercises the (collection_id, person_id) PK dedupe branch) ---
+    Long onlyOnPersonCollection = newCollection();
+    tagPersonOnCollection(onlyOnPersonCollection, person);
+    Long sharedCollection = newCollection();
+    tagPersonOnCollection(sharedCollection, person);
+    // account is ALSO tagged on `sharedCollection` -> the source row must collapse on re-point,
+    // otherwise the UPDATE would hit a duplicate-key violation on the composite PK.
+    tagPersonOnCollection(sharedCollection, account);
 
     MergeResult result = userMergeService.merge(person, account);
 
-    assertThat(result.duplicatesCollapsed()).isEqualTo(1);
-    // Source had two image tags before the merge; reported `movedImageTags` is the gross source
-    // count (preview-coherent), independent of how many collapsed on landing.
+    // One image overlap + one collection overlap collapse.
+    assertThat(result.duplicatesCollapsed()).isEqualTo(2);
+    // Source had two image tags + two collection tags before the merge; reported moved counts are
+    // the gross source counts (preview-coherent), independent of how many collapsed on landing.
     assertThat(result.movedImageTags()).isEqualTo(2);
+    assertThat(result.movedCollections()).isEqualTo(2);
+
     // source row gone
     assertThat(
             jdbc.queryForObject("SELECT count(*) FROM users WHERE id = ?", Integer.class, person))
         .isZero();
-    // both images now point at the account, no duplicate on `shared`
+
+    // both images now point at the account, no duplicate on `sharedImage`
     assertThat(
             jdbc.queryForObject(
                 "SELECT count(*) FROM content_image_people WHERE person_id = ?",
@@ -82,9 +118,38 @@ class UserMergeIntegrationTest extends AbstractPostgresIntegrationTest {
             jdbc.queryForObject(
                 "SELECT count(*) FROM content_image_people WHERE content_id = ? AND person_id = ?",
                 Integer.class,
-                onlyOnPerson,
+                onlyOnPersonImage,
                 account))
         .isEqualTo(1);
+
+    // both collections now point at the account, with NO duplicate row on `sharedCollection`
+    assertThat(
+            jdbc.queryForObject(
+                "SELECT count(*) FROM collection_people WHERE person_id = ?",
+                Integer.class,
+                account))
+        .isEqualTo(2);
+    assertThat(
+            jdbc.queryForObject(
+                "SELECT count(*) FROM collection_people WHERE collection_id = ? AND person_id = ?",
+                Integer.class,
+                sharedCollection,
+                account))
+        .isEqualTo(1);
+    assertThat(
+            jdbc.queryForObject(
+                "SELECT count(*) FROM collection_people WHERE collection_id = ? AND person_id = ?",
+                Integer.class,
+                onlyOnPersonCollection,
+                account))
+        .isEqualTo(1);
+    // no orphaned source rows remain in either join
+    assertThat(
+            jdbc.queryForObject(
+                "SELECT count(*) FROM collection_people WHERE person_id = ?",
+                Integer.class,
+                person))
+        .isZero();
   }
 
   @Test

--- a/src/test/java/edens/zac/portfolio/backend/controller/admin/AdminUserControllerTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/admin/AdminUserControllerTest.java
@@ -22,6 +22,7 @@ import edens.zac.portfolio.backend.dao.UserCollectionRepository.AssociatedCollec
 import edens.zac.portfolio.backend.entity.AppUserEntity;
 import edens.zac.portfolio.backend.model.CollectionModel;
 import edens.zac.portfolio.backend.services.UserInviteService;
+import edens.zac.portfolio.backend.services.UserMergeService;
 import edens.zac.portfolio.backend.services.UserPageAssembler;
 import edens.zac.portfolio.backend.types.CollectionRole;
 import edens.zac.portfolio.backend.types.CollectionType;
@@ -49,6 +50,7 @@ class AdminUserControllerTest {
   @Mock private UserInviteService userInviteService;
   @Mock private UserCollectionRepository userCollectionRepository;
   @Mock private UserPageAssembler userPageAssembler;
+  @Mock private UserMergeService userMergeService;
 
   // Trailing slash on purpose: exercises the trailing-slash-safe invite-URL join.
   private static final String FRONTEND_BASE_URL = "https://app.example.com/";
@@ -61,6 +63,7 @@ class AdminUserControllerTest {
             userInviteService,
             userCollectionRepository,
             userPageAssembler,
+            userMergeService,
             FRONTEND_BASE_URL);
     mockMvc =
         MockMvcBuilders.standaloneSetup(controller)


### PR DESCRIPTION
## Identity merge — backend

Admin endpoints to absorb a tag-only `PERSON` into a surviving identity: re-point its `content_image_people` + `collection_people` (+ defensive `user_collection`) onto the target with dedupe, then hard-delete the source PERSON row. **No schema change (no migration).**

### Endpoints
- `GET /api/admin/users/{sourceId}/merge-preview?targetId=` → `MergePreview` (404/409)
- `POST /api/admin/users/{targetId}/merge` `{ sourceId }` → `MergeResult` (404/409)
- `GET /api/admin/users?includePeople=true` surfaces PERSON rows

### Safety
- Rail: source must be `status=PERSON` (a real account is never deleted) → 409 otherwise.
- FKs are `ON DELETE CASCADE`, so the service re-points BEFORE deleting and dedupes (DELETE collisions) BEFORE the UPDATE to avoid PK violations. Whole op is `@Transactional`.

### Testing
`./mvnw clean install` **864 tests, 0 failures**; `UserMergeIntegrationTest` runs against real Postgres (Testcontainers), covering both the image- and collection-tag dedupe branches, the delete, and the rail.

### Notes
- Pairs with the frontend PR — **deploy together**.
- Merged latest `main` (the 0189 identity stack is already on main via #106); resolved `AdminUserController.listUsers` to keep `includePeople` + the new 5-arg `AdminUserSummary` (with `description`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)