### PR TITLE
feat(admin-home): expose cover image dimensions on /admin-home/tiles

### DIFF
--- a/src/main/java/edens/zac/portfolio/backend/model/Records.java
+++ b/src/main/java/edens/zac/portfolio/backend/model/Records.java
@@ -101,8 +101,16 @@ public final class Records {
   public record SiblingRow(
       Long id, String name, String slug, CollectionType type, Long coverImageId) {}
 
-  /** DTO for admin hub tile configuration. coverImageUrl is null when no image is assigned. */
-  public record AdminHomeTileResponse(String tileKey, String coverImageUrl, int displayOrder) {}
+  /**
+   * DTO for admin hub tile configuration. coverImageUrl and dimensions are null when no image is
+   * assigned.
+   */
+  public record AdminHomeTileResponse(
+      String tileKey,
+      String coverImageUrl,
+      Integer coverImageWidth,
+      Integer coverImageHeight,
+      int displayOrder) {}
 
   /**
    * DTO representing the relationship between a child entity (content or collection) and a parent

--- a/src/main/java/edens/zac/portfolio/backend/services/AdminHomeService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/AdminHomeService.java
@@ -58,47 +58,56 @@ public class AdminHomeService {
     List<TileRow> rows = tileRepository.findAllOrderedByDisplay();
     List<Records.AdminHomeTileResponse> out = new ArrayList<>(rows.size());
     for (TileRow row : rows) {
-      String url = resolveCover(row.tileKey());
-      out.add(new Records.AdminHomeTileResponse(row.tileKey(), url, row.displayOrder()));
+      ContentModels.Image cover = resolveCoverImage(row.tileKey());
+      String url = cover != null ? cover.imageUrl() : null;
+      Integer width = cover != null ? cover.imageWidth() : null;
+      Integer height = cover != null ? cover.imageHeight() : null;
+      out.add(
+          new Records.AdminHomeTileResponse(row.tileKey(), url, width, height, row.displayOrder()));
     }
     return List.copyOf(out);
   }
 
-  private String resolveCover(String tileKey) {
+  private ContentModels.Image resolveCoverImage(String tileKey) {
     return switch (tileKey) {
-      case "home" -> randomCoverUrlFromCollections(collectionService.findChildCollectionsForHome());
+      case "home" ->
+          randomCoverImageFromCollections(collectionService.findChildCollectionsForHome());
       case "all-collections" ->
-          randomCoverUrlFromCollections(collectionService.findAllListedWithCovers());
-      case "all-images" -> contentRepository.findRandomImageWebUrl().orElse(null);
+          randomCoverImageFromCollections(collectionService.findAllListedWithCovers());
+      case "all-images" -> {
+        String url = contentRepository.findRandomImageWebUrl().orElse(null);
+        yield url != null ? urlOnlyCoverImage(url) : null;
+      }
       case "blogs" ->
-          randomCoverUrlFromCollections(
+          randomCoverImageFromCollections(
               collectionService.findVisibleByTypeOrderByDate(CollectionType.BLOG));
       case "client-galleries" ->
-          // Client galleries are typically UNLISTED (their listing is private by design), so the
-          // LISTED-only lookup would yield no candidates and the tile would render with no cover.
-          // Admin-context lookup includes UNLISTED.
-          randomCoverUrlFromCollections(
+          randomCoverImageFromCollections(
               collectionService.findByTypeForAdminCovers(CollectionType.CLIENT_GALLERY));
-      // metadata, comments, create, manage, about: no cover (rendered as plain entries elsewhere)
       default -> null;
     };
   }
 
-  private String randomCoverUrlFromCollections(List<CollectionModel> candidates) {
+  private ContentModels.Image randomCoverImageFromCollections(List<CollectionModel> candidates) {
     if (candidates == null || candidates.isEmpty()) {
       return null;
     }
-    List<String> urls =
+    List<ContentModels.Image> images =
         candidates.stream()
             .map(CollectionModel::getCoverImage)
             .filter(Objects::nonNull)
-            .map(ContentModels.Image::imageUrl)
-            .filter(Objects::nonNull)
-            .filter(s -> !s.isBlank())
+            .filter(img -> img.imageUrl() != null && !img.imageUrl().isBlank())
             .toList();
-    if (urls.isEmpty()) {
+    if (images.isEmpty()) {
       return null;
     }
-    return urls.get(ThreadLocalRandom.current().nextInt(urls.size()));
+    return images.get(ThreadLocalRandom.current().nextInt(images.size()));
+  }
+
+  private static ContentModels.Image urlOnlyCoverImage(String url) {
+    return new ContentModels.Image(
+        null, null, null, null, null, null, url, null, null, null, null, null, null, null, null,
+        null, null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+        null);
   }
 }

--- a/src/test/java/edens/zac/portfolio/backend/controller/dev/AdminHomeControllerDevTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/dev/AdminHomeControllerDevTest.java
@@ -42,8 +42,9 @@ class AdminHomeControllerDevTest {
   void getTiles_returnsTileListWith200() throws Exception {
     List<Records.AdminHomeTileResponse> tiles =
         List.of(
-            new Records.AdminHomeTileResponse("home", "https://cdn.example.com/home.jpg", 0),
-            new Records.AdminHomeTileResponse("all-collections", null, 1));
+            new Records.AdminHomeTileResponse(
+                "home", "https://cdn.example.com/home.jpg", 1200, 800, 0),
+            new Records.AdminHomeTileResponse("all-collections", null, null, null, 1));
     when(adminHomeService.getTiles()).thenReturn(tiles);
 
     mockMvc
@@ -52,9 +53,13 @@ class AdminHomeControllerDevTest {
         .andExpect(jsonPath("$", hasSize(2)))
         .andExpect(jsonPath("$[0].tileKey", is("home")))
         .andExpect(jsonPath("$[0].coverImageUrl", is("https://cdn.example.com/home.jpg")))
+        .andExpect(jsonPath("$[0].coverImageWidth", is(1200)))
+        .andExpect(jsonPath("$[0].coverImageHeight", is(800)))
         .andExpect(jsonPath("$[0].displayOrder", is(0)))
         .andExpect(jsonPath("$[1].tileKey", is("all-collections")))
-        .andExpect(jsonPath("$[1].coverImageUrl", nullValue()));
+        .andExpect(jsonPath("$[1].coverImageUrl", nullValue()))
+        .andExpect(jsonPath("$[1].coverImageWidth", nullValue()))
+        .andExpect(jsonPath("$[1].coverImageHeight", nullValue()));
     verify(adminHomeService).getTiles();
   }
 

--- a/src/test/java/edens/zac/portfolio/backend/model/RecordsTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/model/RecordsTest.java
@@ -8,18 +8,24 @@ class RecordsTest {
 
   @Test
   void adminHomeTileResponse_holdsExpectedFields() {
-    var tile = new Records.AdminHomeTileResponse("home", "https://cdn.example.com/home.jpg", 0);
+    var tile =
+        new Records.AdminHomeTileResponse(
+            "home", "https://cdn.example.com/home.jpg", 1600, 1067, 0);
 
     assertThat(tile.tileKey()).isEqualTo("home");
     assertThat(tile.coverImageUrl()).isEqualTo("https://cdn.example.com/home.jpg");
+    assertThat(tile.coverImageWidth()).isEqualTo(1600);
+    assertThat(tile.coverImageHeight()).isEqualTo(1067);
     assertThat(tile.displayOrder()).isEqualTo(0);
   }
 
   @Test
   void adminHomeTileResponse_nullCoverImageUrl_isAllowed() {
-    var tile = new Records.AdminHomeTileResponse("all-collections", null, 1);
+    var tile = new Records.AdminHomeTileResponse("all-collections", null, null, null, 1);
 
     assertThat(tile.coverImageUrl()).isNull();
+    assertThat(tile.coverImageWidth()).isNull();
+    assertThat(tile.coverImageHeight()).isNull();
     assertThat(tile.displayOrder()).isEqualTo(1);
   }
 }

--- a/src/test/java/edens/zac/portfolio/backend/services/AdminHomeServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/AdminHomeServiceTest.java
@@ -36,12 +36,12 @@ class AdminHomeServiceTest {
     service = new AdminHomeService(tileRepository, collectionService, contentRepository);
   }
 
-  /**
-   * Build a CollectionModel whose cover image carries only the supplied imageUrl.
-   * ContentModels.Image is a 28-field record; everything except imageUrl is null because the
-   * service only reads the URL.
-   */
   private static CollectionModel collectionWithCoverUrl(long id, String slug, String url) {
+    return collectionWithCoverImage(id, slug, url, null, null);
+  }
+
+  private static CollectionModel collectionWithCoverImage(
+      long id, String slug, String url, Integer width, Integer height) {
     ContentModels.Image cover =
         new ContentModels.Image(
             null, // id
@@ -56,8 +56,8 @@ class AdminHomeServiceTest {
             null, // visible
             null, // createdAt
             null, // updatedAt
-            null, // imageWidth
-            null, // imageHeight
+            width, // imageWidth
+            height, // imageHeight
             null, // iso
             null, // author
             null, // rating
@@ -97,20 +97,23 @@ class AdminHomeServiceTest {
                   new TileRow("manage", 8),
                   new TileRow("about", 9)));
 
-      var homeChild = collectionWithCoverUrl(11L, "film", "https://cdn/example/home-child.webp");
+      var homeChild =
+          collectionWithCoverImage(11L, "film", "https://cdn/example/home-child.webp", 1600, 1067);
       when(collectionService.findChildCollectionsForHome()).thenReturn(List.of(homeChild));
 
-      var anyVisible = collectionWithCoverUrl(21L, "any", "https://cdn/example/any.webp");
+      var anyVisible =
+          collectionWithCoverImage(21L, "any", "https://cdn/example/any.webp", 1200, 800);
       when(collectionService.findAllListedWithCovers()).thenReturn(List.of(anyVisible));
 
       when(contentRepository.findRandomImageWebUrl())
           .thenReturn(Optional.of("https://cdn/example/random-image.webp"));
 
-      var blog = collectionWithCoverUrl(31L, "trip", "https://cdn/example/blog.webp");
+      var blog = collectionWithCoverImage(31L, "trip", "https://cdn/example/blog.webp", 900, 600);
       when(collectionService.findVisibleByTypeOrderByDate(CollectionType.BLOG))
           .thenReturn(List.of(blog));
 
-      var gallery = collectionWithCoverUrl(41L, "smith", "https://cdn/example/gallery.webp");
+      var gallery =
+          collectionWithCoverImage(41L, "smith", "https://cdn/example/gallery.webp", 1400, 933);
       when(collectionService.findByTypeForAdminCovers(CollectionType.CLIENT_GALLERY))
           .thenReturn(List.of(gallery));
 
@@ -131,15 +134,30 @@ class AdminHomeServiceTest {
               "manage",
               "about");
       assertThat(tiles.get(0).coverImageUrl()).isEqualTo("https://cdn/example/home-child.webp");
+      assertThat(tiles.get(0).coverImageWidth()).isEqualTo(1600);
+      assertThat(tiles.get(0).coverImageHeight()).isEqualTo(1067);
       assertThat(tiles.get(1).coverImageUrl()).isEqualTo("https://cdn/example/any.webp");
+      assertThat(tiles.get(1).coverImageWidth()).isEqualTo(1200);
+      assertThat(tiles.get(1).coverImageHeight()).isEqualTo(800);
       assertThat(tiles.get(2).coverImageUrl()).isEqualTo("https://cdn/example/random-image.webp");
-      assertThat(tiles.get(3).coverImageUrl()).isNull(); // metadata - no source
-      assertThat(tiles.get(4).coverImageUrl()).isNull(); // comments - no source
+      assertThat(tiles.get(2).coverImageWidth()).isNull();
+      assertThat(tiles.get(2).coverImageHeight()).isNull();
+      assertThat(tiles.get(3).coverImageUrl()).isNull();
+      assertThat(tiles.get(3).coverImageWidth()).isNull();
+      assertThat(tiles.get(4).coverImageUrl()).isNull();
+      assertThat(tiles.get(4).coverImageWidth()).isNull();
       assertThat(tiles.get(5).coverImageUrl()).isEqualTo("https://cdn/example/blog.webp");
+      assertThat(tiles.get(5).coverImageWidth()).isEqualTo(900);
+      assertThat(tiles.get(5).coverImageHeight()).isEqualTo(600);
       assertThat(tiles.get(6).coverImageUrl()).isEqualTo("https://cdn/example/gallery.webp");
-      assertThat(tiles.get(7).coverImageUrl()).isNull(); // create - no source
-      assertThat(tiles.get(8).coverImageUrl()).isNull(); // manage - no source
-      assertThat(tiles.get(9).coverImageUrl()).isNull(); // about - no source
+      assertThat(tiles.get(6).coverImageWidth()).isEqualTo(1400);
+      assertThat(tiles.get(6).coverImageHeight()).isEqualTo(933);
+      assertThat(tiles.get(7).coverImageUrl()).isNull();
+      assertThat(tiles.get(7).coverImageWidth()).isNull();
+      assertThat(tiles.get(8).coverImageUrl()).isNull();
+      assertThat(tiles.get(8).coverImageWidth()).isNull();
+      assertThat(tiles.get(9).coverImageUrl()).isNull();
+      assertThat(tiles.get(9).coverImageWidth()).isNull();
       assertThat(tiles.get(0).displayOrder()).isZero();
       assertThat(tiles.get(9).displayOrder()).isEqualTo(9);
     }
@@ -178,6 +196,8 @@ class AdminHomeServiceTest {
 
       assertThat(tiles).hasSize(1);
       assertThat(tiles.get(0).coverImageUrl()).isNull();
+      assertThat(tiles.get(0).coverImageWidth()).isNull();
+      assertThat(tiles.get(0).coverImageHeight()).isNull();
     }
 
     @Test
@@ -190,6 +210,8 @@ class AdminHomeServiceTest {
       assertThat(tiles).hasSize(1);
       assertThat(tiles.get(0).tileKey()).isEqualTo("not-a-known-key");
       assertThat(tiles.get(0).coverImageUrl()).isNull();
+      assertThat(tiles.get(0).coverImageWidth()).isNull();
+      assertThat(tiles.get(0).coverImageHeight()).isNull();
       verifyNoMoreInteractions(collectionService, contentRepository);
     }
   }


### PR DESCRIPTION
AdminHomeTileResponse now carries nullable coverImageWidth/coverImageHeight sourced from the resolved content_image, so the admin hub can render each tile at its cover's natural aspect ratio like a collection card.