### PR TITLE
feat(collection): tag-view read model + unified routing (A1)

### DIFF
--- a/src/main/java/edens/zac/portfolio/backend/dao/TagRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/TagRepository.java
@@ -1,9 +1,15 @@
 package edens.zac.portfolio.backend.dao;
 
+import edens.zac.portfolio.backend.entity.CollectionEntity;
 import edens.zac.portfolio.backend.entity.TagEntity;
 import edens.zac.portfolio.backend.services.SlugUtil;
+import edens.zac.portfolio.backend.types.CollectionType;
+import edens.zac.portfolio.backend.types.CollectionVisibility;
+import edens.zac.portfolio.backend.types.DisplayMode;
+import java.sql.Array;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -35,6 +41,52 @@ public class TagRepository extends BaseDao {
               .slug(rs.getString("slug"))
               .createdAt(getLocalDateTime(rs, "created_at"))
               .build();
+
+  /**
+   * Maps the same collection column set as {@code CollectionRepository.COLLECTION_ROW_MAPPER}. Used
+   * by {@link #findCollectionsByTagId} so tag-view membership rows convert exactly like collections
+   * fetched through the normal read path.
+   */
+  private static final RowMapper<CollectionEntity> COLLECTION_ROW_MAPPER =
+      (rs, rowNum) -> {
+        CollectionEntity entity = new CollectionEntity();
+        entity.setId(rs.getLong("id"));
+        entity.setType(CollectionType.valueOf(rs.getString("type")));
+        entity.setTitle(rs.getString("title"));
+        entity.setSlug(rs.getString("slug"));
+        entity.setDescription(rs.getString("description"));
+        entity.setCollectionDate(getLocalDate(rs, "collection_date"));
+        entity.setVisibility(CollectionVisibility.valueOf(rs.getString("visibility")));
+
+        String displayMode = rs.getString("display_mode");
+        if (displayMode != null) {
+          try {
+            entity.setDisplayMode(DisplayMode.valueOf(displayMode));
+          } catch (IllegalArgumentException e) {
+            log.warn("Invalid display_mode value: {}", displayMode);
+          }
+        }
+
+        Long coverImageId = getLong(rs, "cover_image_id");
+        if (coverImageId != null) {
+          entity.setCoverImageId(coverImageId);
+        }
+
+        entity.setContentPerPage(getInteger(rs, "content_per_page"));
+        entity.setTotalContent(getInteger(rs, "total_content"));
+        entity.setRowsWide(getInteger(rs, "rows_wide"));
+        entity.setGalleryPassword(rs.getString("gallery_password"));
+        Array emailsArray = rs.getArray("recipient_emails");
+        entity.setRecipientEmails(
+            emailsArray != null
+                ? new ArrayList<>(Arrays.asList((String[]) emailsArray.getArray()))
+                : new ArrayList<>());
+        entity.setRating(getInteger(rs, "rating"));
+        entity.setCreatedAt(getLocalDateTime(rs, "created_at"));
+        entity.setUpdatedAt(getLocalDateTime(rs, "updated_at"));
+
+        return entity;
+      };
 
   // ============================================================
   // Tag CRUD Operations
@@ -209,6 +261,75 @@ public class TagRepository extends BaseDao {
         """;
     MapSqlParameterSource params = createParameterSource().addValue("collectionId", collectionId);
     return query(sql, TAG_ROW_MAPPER, params);
+  }
+
+  /**
+   * Collections carrying the given tag, filtered to the supplied visibility set. Walks {@code tag
+   * -> collection_tags -> collection} and applies the same column set + ordering idiom as {@link
+   * edens.zac.portfolio.backend.dao.CollectionRepository#findNonEmptyOrderedByVisibilityIn} (rating
+   * desc, then collection_date desc). Backs the tag-view read model: tagged collections are the
+   * primary members of a synthetic tag PARENT view. Empty when the tag has no visible collections.
+   */
+  @Transactional(readOnly = true)
+  public List<CollectionEntity> findCollectionsByTagId(
+      Long tagId, List<CollectionVisibility> allowed) {
+    if (tagId == null || allowed == null || allowed.isEmpty()) {
+      return List.of();
+    }
+    String sql =
+        """
+        SELECT c.id, c.type, c.title, c.slug, c.description, c.collection_date,
+               c.visibility, c.display_mode, c.cover_image_id, c.content_per_page, c.total_content,
+               c.rows_wide, c.gallery_password, c.recipient_emails, c.rating, c.created_at, c.updated_at
+        FROM collection c
+        JOIN collection_tags ct ON ct.collection_id = c.id
+        WHERE ct.tag_id = :tagId
+          AND c.visibility IN (:visibilities)
+        ORDER BY c.rating DESC NULLS LAST, c.collection_date DESC NULLS LAST
+        """;
+    MapSqlParameterSource params =
+        createParameterSource()
+            .addValue("tagId", tagId)
+            .addValue("visibilities", allowed.stream().map(CollectionVisibility::name).toList());
+    return query(sql, COLLECTION_ROW_MAPPER, params);
+  }
+
+  /**
+   * IDs of IMAGE content carrying the given tag, gated by the owning collection's visibility.
+   *
+   * <p>Content rows have no visibility column of their own, so visibility is derived from the
+   * collection that contains the image: an image is rendered only if it has at least one visible
+   * membership ({@code collection_content.visible = true}) in a collection whose {@code visibility}
+   * is within {@code allowed}. Walks {@code tag -> content_tags -> content (IMAGE) ->
+   * collection_content -> collection}. Returns distinct content ids, most-recently-created first.
+   * Empty when no tagged image is reachable through a visible collection.
+   */
+  @Transactional(readOnly = true)
+  public List<Long> findImageContentByTagId(Long tagId, List<CollectionVisibility> allowed) {
+    if (tagId == null || allowed == null || allowed.isEmpty()) {
+      return List.of();
+    }
+    String sql =
+        """
+        SELECT DISTINCT c.id, c.created_at
+        FROM content c
+        JOIN content_tags ctg ON ctg.content_id = c.id
+        JOIN collection_content cc ON cc.content_id = c.id
+        JOIN collection col ON col.id = cc.collection_id
+        WHERE ctg.tag_id = :tagId
+          AND c.content_type = 'IMAGE'
+          AND cc.visible = true
+          AND col.visibility IN (:visibilities)
+        ORDER BY c.created_at DESC NULLS LAST, c.id DESC
+        """;
+    MapSqlParameterSource params =
+        createParameterSource()
+            .addValue("tagId", tagId)
+            .addValue("visibilities", allowed.stream().map(CollectionVisibility::name).toList());
+    // Custom single-column mapper: the query selects c.created_at as well (Postgres requires
+    // DISTINCT + ORDER BY columns in the select list), so queryForList(..., Long.class) — which
+    // demands a single-column result via SingleColumnRowMapper — would throw at runtime.
+    return query(sql, (rs, rowNum) -> rs.getLong("id"), params);
   }
 
   @Transactional

--- a/src/main/java/edens/zac/portfolio/backend/dao/TagRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/TagRepository.java
@@ -42,11 +42,7 @@ public class TagRepository extends BaseDao {
               .createdAt(getLocalDateTime(rs, "created_at"))
               .build();
 
-  /**
-   * Maps the same collection column set as {@code CollectionRepository.COLLECTION_ROW_MAPPER}. Used
-   * by {@link #findCollectionsByTagId} so tag-view membership rows convert exactly like collections
-   * fetched through the normal read path.
-   */
+  /** Collection row mapper for {@link #findCollectionsByTagId}. */
   private static final RowMapper<CollectionEntity> COLLECTION_ROW_MAPPER =
       (rs, rowNum) -> {
         CollectionEntity entity = new CollectionEntity();
@@ -264,11 +260,8 @@ public class TagRepository extends BaseDao {
   }
 
   /**
-   * Collections carrying the given tag, filtered to the supplied visibility set. Walks {@code tag
-   * -> collection_tags -> collection} and applies the same column set + ordering idiom as {@link
-   * edens.zac.portfolio.backend.dao.CollectionRepository#findNonEmptyOrderedByVisibilityIn} (rating
-   * desc, then collection_date desc). Backs the tag-view read model: tagged collections are the
-   * primary members of a synthetic tag PARENT view. Empty when the tag has no visible collections.
+   * Collections carrying the tag within the allowed visibilities, ordered rating- then date-desc.
+   * The tag-view's primary members; empty when none.
    */
   @Transactional(readOnly = true)
   public List<CollectionEntity> findCollectionsByTagId(
@@ -295,14 +288,9 @@ public class TagRepository extends BaseDao {
   }
 
   /**
-   * IDs of IMAGE content carrying the given tag, gated by the owning collection's visibility.
-   *
-   * <p>Content rows have no visibility column of their own, so visibility is derived from the
-   * collection that contains the image: an image is rendered only if it has at least one visible
-   * membership ({@code collection_content.visible = true}) in a collection whose {@code visibility}
-   * is within {@code allowed}. Walks {@code tag -> content_tags -> content (IMAGE) ->
-   * collection_content -> collection}. Returns distinct content ids, most-recently-created first.
-   * Empty when no tagged image is reachable through a visible collection.
+   * IDs of tagged IMAGE content, newest first. Content has no visibility of its own, so an image
+   * qualifies only via a visible membership ({@code collection_content.visible}) in a collection
+   * within {@code allowed}. Distinct; empty when none qualify.
    */
   @Transactional(readOnly = true)
   public List<Long> findImageContentByTagId(Long tagId, List<CollectionVisibility> allowed) {

--- a/src/main/java/edens/zac/portfolio/backend/dao/TagRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/TagRepository.java
@@ -326,9 +326,6 @@ public class TagRepository extends BaseDao {
         createParameterSource()
             .addValue("tagId", tagId)
             .addValue("visibilities", allowed.stream().map(CollectionVisibility::name).toList());
-    // Custom single-column mapper: the query selects c.created_at as well (Postgres requires
-    // DISTINCT + ORDER BY columns in the select list), so queryForList(..., Long.class) — which
-    // demands a single-column result via SingleColumnRowMapper — would throw at runtime.
     return query(sql, (rs, rowNum) -> rs.getLong("id"), params);
   }
 

--- a/src/main/java/edens/zac/portfolio/backend/services/CollectionService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/CollectionService.java
@@ -73,6 +73,7 @@ public class CollectionService {
   private final MetadataService metadataService;
   private final EmailService emailService;
   private final SyntheticCollectionResolver syntheticResolver;
+  private final TagViewResolver tagViewResolver;
   private final ClientGalleryAuthService clientGalleryAuthService;
   private final UserCollectionService userCollectionService;
   private final Environment springEnv;
@@ -90,12 +91,20 @@ public class CollectionService {
       return syntheticResolver.resolve(slug, isLocalEnvironment());
     }
 
-    // Get collection metadata
-    CollectionEntity collection =
-        collectionRepository
-            .findBySlug(slug)
-            .orElseThrow(
-                () -> new ResourceNotFoundException("Collection not found with slug: " + slug));
+    // Resolution order: synthetic -> real collection -> tag-view -> 404. A real collection is
+    // looked up before the tag-view fallback, so a real collection always wins on slug collision.
+    Optional<CollectionEntity> collectionOpt = collectionRepository.findBySlug(slug);
+    if (collectionOpt.isEmpty()) {
+      // No real collection: try to render the slug as a synthetic tag-view (any tag is browsable
+      // at /{slug}). A tag with zero visible members returns empty and falls through to 404.
+      Optional<CollectionModel> tagView =
+          tagViewResolver.resolveTagView(slug, isLocalEnvironment());
+      if (tagView.isPresent()) {
+        return tagView.get();
+      }
+      throw new ResourceNotFoundException("Collection not found with slug: " + slug);
+    }
+    CollectionEntity collection = collectionOpt.get();
 
     // Enforce visibility: invisible collections are not publicly accessible (except "home")
     enforceVisibility(collection, slug, isLocalEnvironment());

--- a/src/main/java/edens/zac/portfolio/backend/services/TagViewResolver.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/TagViewResolver.java
@@ -24,12 +24,12 @@ import org.springframework.transaction.annotation.Transactional;
  * blocks). No DB schema change: membership is derived live from the {@code collection_tags} and
  * {@code content_tags} join tables.
  *
- * <p>Sibling to {@link SyntheticCollectionResolver}: it follows the same construction pattern
- * (build a PARENT model with {@code visibility=LISTED}) and the same env-aware visibility scope,
- * but is a separate class because its membership comes from a DB tag lookup (returning {@link
- * Optional#empty()} on miss) rather than a static catalog. Depends on repositories + conversion
- * utils directly — NOT on {@link CollectionService} — to avoid a circular bean dependency,
- * mirroring {@link SyntheticCollectionResolver}.
+ * <p>Sibling to {@link SyntheticCollectionResolver}, following the same construction pattern (a
+ * PARENT model with {@code visibility=LISTED}) and env-aware visibility scope. Membership comes
+ * from a DB tag lookup, returning {@link Optional#empty()} when the slug matches no tag.
+ *
+ * <p>Depends on repositories and conversion utils directly (not {@link CollectionService}) to avoid
+ * a circular bean dependency.
  */
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/edens/zac/portfolio/backend/services/TagViewResolver.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/TagViewResolver.java
@@ -1,0 +1,122 @@
+package edens.zac.portfolio.backend.services;
+
+import edens.zac.portfolio.backend.dao.ContentRepository;
+import edens.zac.portfolio.backend.dao.TagRepository;
+import edens.zac.portfolio.backend.entity.CollectionEntity;
+import edens.zac.portfolio.backend.entity.ContentImageEntity;
+import edens.zac.portfolio.backend.entity.TagEntity;
+import edens.zac.portfolio.backend.model.CollectionModel;
+import edens.zac.portfolio.backend.model.ContentModel;
+import edens.zac.portfolio.backend.model.ContentModels;
+import edens.zac.portfolio.backend.types.CollectionType;
+import edens.zac.portfolio.backend.types.CollectionVisibility;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Resolves any non-colliding tag slug into a synthetic, PARENT-shaped {@link CollectionModel} so a
+ * tag becomes browsable as a collection at {@code /{slug}}. Tagged collections render first (as
+ * {@link ContentModels.Collection} blocks), then tagged images (as {@link ContentModels.Image}
+ * blocks). No DB schema change: membership is derived live from the {@code collection_tags} and
+ * {@code content_tags} join tables.
+ *
+ * <p>Sibling to {@link SyntheticCollectionResolver}: it follows the same construction pattern
+ * (build a PARENT model with {@code visibility=LISTED}) and the same env-aware visibility scope,
+ * but is a separate class because its membership comes from a DB tag lookup (returning {@link
+ * Optional#empty()} on miss) rather than a static catalog. Depends on repositories + conversion
+ * utils directly — NOT on {@link CollectionService} — to avoid a circular bean dependency,
+ * mirroring {@link SyntheticCollectionResolver}.
+ */
+@Service
+@RequiredArgsConstructor
+public class TagViewResolver {
+
+  private final TagRepository tagRepository;
+  private final ContentRepository contentRepository;
+  private final CollectionProcessingUtil collectionProcessingUtil;
+  private final ContentModelConverter contentModelConverter;
+
+  /**
+   * Resolve a slug into a tag-view PARENT model. Returns empty when the slug matches no tag, or
+   * when the matching tag has zero visible members (no collections AND no images) — callers fall
+   * through to a 404 rather than render an empty PARENT page.
+   *
+   * @param slug the requested slug (already confirmed not to be a synthetic list slug or a real
+   *     collection by the caller)
+   * @param isLocalEnvironment when true, expands the allowed visibility set to include UNLISTED and
+   *     HIDDEN (dev only); prod sees LISTED only
+   */
+  @Transactional(readOnly = true)
+  public Optional<CollectionModel> resolveTagView(String slug, boolean isLocalEnvironment) {
+    if (slug == null) {
+      return Optional.empty();
+    }
+    Optional<TagEntity> tagOpt = tagRepository.findBySlug(slug);
+    if (tagOpt.isEmpty()) {
+      return Optional.empty();
+    }
+    TagEntity tag = tagOpt.get();
+
+    List<CollectionVisibility> allowed =
+        isLocalEnvironment
+            ? List.of(
+                CollectionVisibility.LISTED,
+                CollectionVisibility.UNLISTED,
+                CollectionVisibility.HIDDEN)
+            : List.of(CollectionVisibility.LISTED);
+
+    // Members: tagged collections first (deliberate collection-level tags), then tagged images.
+    List<CollectionEntity> collectionRows =
+        tagRepository.findCollectionsByTagId(tag.getId(), allowed);
+    List<CollectionModel> memberCollections =
+        collectionProcessingUtil.batchConvertToBasicModels(collectionRows);
+
+    List<Long> imageContentIds = tagRepository.findImageContentByTagId(tag.getId(), allowed);
+    List<ContentImageEntity> imageEntities = contentRepository.findImagesByIds(imageContentIds);
+    List<ContentModels.Image> memberImages =
+        contentModelConverter.batchConvertImageEntitiesToModels(imageEntities);
+
+    // A tag-view with zero members is not a page — fall through to 404.
+    if (memberCollections.isEmpty() && memberImages.isEmpty()) {
+      return Optional.empty();
+    }
+
+    List<ContentModel> content = new ArrayList<>();
+    memberCollections.stream()
+        .map(ContentModels.Collection::fromCollectionModel)
+        .forEach(content::add);
+    content.addAll(memberImages);
+
+    return Optional.of(
+        CollectionModel.builder()
+            .slug(tag.getSlug())
+            .title(tag.getTagName())
+            .type(CollectionType.PARENT)
+            .visibility(CollectionVisibility.LISTED)
+            .coverImage(representativeCover(memberCollections, memberImages))
+            .content(content)
+            .contentCount(content.size())
+            .contentPerPage(content.size())
+            .currentPage(0)
+            .totalPages(1)
+            .build());
+  }
+
+  /**
+   * Pick a representative cover: the first member collection that has a cover image, else the first
+   * tagged image, else none. Member collections arrive rating-desc / date-desc ordered, so "first
+   * with a cover" is the most prominent member.
+   */
+  private ContentModels.Image representativeCover(
+      List<CollectionModel> memberCollections, List<ContentModels.Image> memberImages) {
+    return memberCollections.stream()
+        .map(CollectionModel::getCoverImage)
+        .filter(java.util.Objects::nonNull)
+        .findFirst()
+        .orElseGet(() -> memberImages.isEmpty() ? null : memberImages.get(0));
+  }
+}

--- a/src/main/java/edens/zac/portfolio/backend/services/TagViewResolver.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/TagViewResolver.java
@@ -18,18 +18,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Resolves any non-colliding tag slug into a synthetic, PARENT-shaped {@link CollectionModel} so a
- * tag becomes browsable as a collection at {@code /{slug}}. Tagged collections render first (as
- * {@link ContentModels.Collection} blocks), then tagged images (as {@link ContentModels.Image}
- * blocks). No DB schema change: membership is derived live from the {@code collection_tags} and
- * {@code content_tags} join tables.
+ * Resolves a non-colliding tag slug into a synthetic PARENT {@link CollectionModel} so a tag is
+ * browsable at {@code /{slug}}: tagged collections first, then tagged images. Membership is derived
+ * live from {@code collection_tags}/{@code content_tags} (no schema change).
  *
- * <p>Sibling to {@link SyntheticCollectionResolver}, following the same construction pattern (a
- * PARENT model with {@code visibility=LISTED}) and env-aware visibility scope. Membership comes
- * from a DB tag lookup, returning {@link Optional#empty()} when the slug matches no tag.
- *
- * <p>Depends on repositories and conversion utils directly (not {@link CollectionService}) to avoid
- * a circular bean dependency.
+ * <p>Tag-backed sibling of {@link SyntheticCollectionResolver}; depends on repositories directly
+ * (not {@link CollectionService}) to avoid a circular bean dependency.
  */
 @Service
 @RequiredArgsConstructor
@@ -41,14 +35,11 @@ public class TagViewResolver {
   private final ContentModelConverter contentModelConverter;
 
   /**
-   * Resolve a slug into a tag-view PARENT model. Returns empty when the slug matches no tag, or
-   * when the matching tag has zero visible members (no collections AND no images) — callers fall
-   * through to a 404 rather than render an empty PARENT page.
+   * Resolves a slug into a tag-view PARENT model, or empty when no tag matches or the tag has no
+   * visible members (caller 404s).
    *
-   * @param slug the requested slug (already confirmed not to be a synthetic list slug or a real
-   *     collection by the caller)
-   * @param isLocalEnvironment when true, expands the allowed visibility set to include UNLISTED and
-   *     HIDDEN (dev only); prod sees LISTED only
+   * @param slug requested slug (caller has ruled out synthetic + real-collection slugs)
+   * @param isLocalEnvironment dev expands visibility to UNLISTED/HIDDEN; prod is LISTED only
    */
   @Transactional(readOnly = true)
   public Optional<CollectionModel> resolveTagView(String slug, boolean isLocalEnvironment) {
@@ -106,11 +97,7 @@ public class TagViewResolver {
             .build());
   }
 
-  /**
-   * Pick a representative cover: the first member collection that has a cover image, else the first
-   * tagged image, else none. Member collections arrive rating-desc / date-desc ordered, so "first
-   * with a cover" is the most prominent member.
-   */
+  /** Cover: first member collection with a cover image, else first tagged image, else none. */
   private ContentModels.Image representativeCover(
       List<CollectionModel> memberCollections, List<ContentModels.Image> memberImages) {
     return memberCollections.stream()

--- a/src/test/java/edens/zac/portfolio/backend/services/CollectionServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/CollectionServiceTest.java
@@ -63,6 +63,7 @@ class CollectionServiceTest {
   @Mock private MetadataService metadataService;
   @Mock private edens.zac.portfolio.backend.services.EmailService emailService;
   @Mock private SyntheticCollectionResolver syntheticResolver;
+  @Mock private TagViewResolver tagViewResolver;
   @Mock private ClientGalleryAuthService clientGalleryAuthService;
   @Mock private UserCollectionService userCollectionService;
 
@@ -384,10 +385,57 @@ class CollectionServiceTest {
     void getCollectionWithPagination_slugNotFound_throwsException() {
       String slug = "nonexistent";
       when(collectionRepository.findBySlug(slug)).thenReturn(Optional.empty());
+      when(tagViewResolver.resolveTagView(eq(slug), anyBoolean())).thenReturn(Optional.empty());
 
       assertThatThrownBy(() -> service.getCollectionWithPagination(slug, 0, 10))
           .isInstanceOf(ResourceNotFoundException.class)
           .hasMessageContaining("Collection not found with slug: nonexistent");
+    }
+
+    @Test
+    void getCollectionWithPagination_realCollectionWinsOnSlugCollision() {
+      // A slug that is BOTH a real collection and a plausible tag must resolve to the real
+      // collection — findBySlug is checked before the tag-view fallback, which is never consulted.
+      String slug = "chamonix";
+      CollectionModel model = CollectionModel.builder().id(1L).title("Chamonix").slug(slug).build();
+
+      when(collectionRepository.findBySlug(slug)).thenReturn(Optional.of(testCollection));
+      when(collectionRepository.countContentByCollectionId(1L)).thenReturn(0L);
+      when(collectionRepository.findContentByCollectionId(eq(1L), anyInt(), anyInt()))
+          .thenReturn(Collections.emptyList());
+      when(collectionProcessingUtil.convertToModel(
+              eq(testCollection), any(), anyInt(), anyInt(), anyLong()))
+          .thenReturn(model);
+
+      CollectionModel result = service.getCollectionWithPagination(slug, 0, 10);
+
+      assertThat(result).isSameAs(model);
+      verify(tagViewResolver, never()).resolveTagView(anyString(), anyBoolean());
+    }
+
+    @Test
+    void getCollectionWithPagination_tagFallbackHit_returnsTagView() {
+      String slug = "travel";
+      CollectionModel tagView =
+          CollectionModel.builder().slug(slug).type(CollectionType.PARENT).build();
+
+      when(collectionRepository.findBySlug(slug)).thenReturn(Optional.empty());
+      when(tagViewResolver.resolveTagView(eq(slug), anyBoolean())).thenReturn(Optional.of(tagView));
+
+      CollectionModel result = service.getCollectionWithPagination(slug, 0, 10);
+
+      assertThat(result).isSameAs(tagView);
+    }
+
+    @Test
+    void getCollectionWithPagination_zeroMemberTag_throwsNotFound() {
+      String slug = "orphan";
+      when(collectionRepository.findBySlug(slug)).thenReturn(Optional.empty());
+      when(tagViewResolver.resolveTagView(eq(slug), anyBoolean())).thenReturn(Optional.empty());
+
+      assertThatThrownBy(() -> service.getCollectionWithPagination(slug, 0, 10))
+          .isInstanceOf(ResourceNotFoundException.class)
+          .hasMessageContaining("Collection not found with slug: orphan");
     }
 
     @Test

--- a/src/test/java/edens/zac/portfolio/backend/services/TagViewIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/TagViewIntegrationTest.java
@@ -17,15 +17,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 /**
- * Real-Postgres integration coverage for the A1 tag-view read model. Exercises the new {@link
- * TagRepository} SQL end-to-end against a Flyway-migrated schema so the multi-column {@code
- * DISTINCT} path in {@link TagRepository#findImageContentByTagId} and the visibility/ordering
- * semantics are verified against the real planner rather than a mock.
- *
- * <p>The {@code test} profile is not {@code dev}, so {@link
- * CollectionService#getCollectionWithPagination} resolves with the production visibility scope
- * (LISTED only). Repository methods are additionally exercised directly with explicit visibility
- * sets to cover both the prod and local scopes.
+ * Real-Postgres coverage for the A1 tag-view read model: {@link TagRepository} SQL (incl. the
+ * multi-column {@code DISTINCT} in {@link TagRepository#findImageContentByTagId}), visibility, and
+ * ordering, verified against a Flyway schema rather than mocks. The {@code test} profile resolves
+ * the service path with prod visibility (LISTED); repo methods are also tested directly per scope.
  */
 class TagViewIntegrationTest extends AbstractPostgresIntegrationTest {
 

--- a/src/test/java/edens/zac/portfolio/backend/services/TagViewIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/TagViewIntegrationTest.java
@@ -1,0 +1,259 @@
+package edens.zac.portfolio.backend.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import edens.zac.portfolio.backend.AbstractPostgresIntegrationTest;
+import edens.zac.portfolio.backend.config.ResourceNotFoundException;
+import edens.zac.portfolio.backend.dao.TagRepository;
+import edens.zac.portfolio.backend.entity.CollectionEntity;
+import edens.zac.portfolio.backend.model.CollectionModel;
+import edens.zac.portfolio.backend.model.ContentModels;
+import edens.zac.portfolio.backend.types.CollectionType;
+import edens.zac.portfolio.backend.types.CollectionVisibility;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Real-Postgres integration coverage for the A1 tag-view read model. Exercises the new {@link
+ * TagRepository} SQL end-to-end against a Flyway-migrated schema so the multi-column {@code
+ * DISTINCT} path in {@link TagRepository#findImageContentByTagId} (the column-count regression that
+ * was fixed by hand) cannot recur, and so visibility/ordering semantics are verified against the
+ * real planner rather than a mock.
+ *
+ * <p>The {@code test} profile is not {@code dev}, so {@link
+ * CollectionService#getCollectionWithPagination} resolves with the production visibility scope
+ * (LISTED only). Repository methods are additionally exercised directly with explicit visibility
+ * sets to cover both the prod and local scopes.
+ */
+class TagViewIntegrationTest extends AbstractPostgresIntegrationTest {
+
+  private static final List<CollectionVisibility> PROD_ALLOWED =
+      List.of(CollectionVisibility.LISTED);
+  private static final List<CollectionVisibility> LOCAL_ALLOWED =
+      List.of(
+          CollectionVisibility.LISTED, CollectionVisibility.UNLISTED, CollectionVisibility.HIDDEN);
+
+  @Autowired private TagRepository tagRepository;
+  @Autowired private CollectionService collectionService;
+  @Autowired private JdbcTemplate jdbc;
+
+  // ---- seed helpers -------------------------------------------------------
+
+  private long seedTag(String name, String slug) {
+    jdbc.update("INSERT INTO tag (tag_name, slug) VALUES (?, ?)", name, slug);
+    return jdbc.queryForObject("SELECT id FROM tag WHERE slug = ?", Long.class, slug);
+  }
+
+  private long seedCollection(String slug, CollectionVisibility visibility, Integer rating) {
+    jdbc.update(
+        "INSERT INTO collection (title, slug, type, visibility, rating) VALUES (?, ?, 'BLOG', ?, ?)",
+        slug,
+        slug,
+        visibility.name(),
+        rating);
+    return jdbc.queryForObject("SELECT id FROM collection WHERE slug = ?", Long.class, slug);
+  }
+
+  private void tagCollection(long collectionId, long tagId) {
+    jdbc.update(
+        "INSERT INTO collection_tags (collection_id, tag_id) VALUES (?, ?)", collectionId, tagId);
+  }
+
+  /** Seeds a base content row + its content_image child and returns the shared id. */
+  private long seedImage(String urlWeb) {
+    jdbc.update("INSERT INTO content (content_type) VALUES ('IMAGE')");
+    long id = jdbc.queryForObject("SELECT MAX(id) FROM content", Long.class);
+    jdbc.update(
+        "INSERT INTO content_image (id, title, image_url_web) VALUES (?, ?, ?)",
+        id,
+        "img-" + id,
+        urlWeb);
+    return id;
+  }
+
+  private void tagContent(long contentId, long tagId) {
+    jdbc.update("INSERT INTO content_tags (content_id, tag_id) VALUES (?, ?)", contentId, tagId);
+  }
+
+  private void addMembership(long collectionId, long contentId, boolean visible) {
+    jdbc.update(
+        "INSERT INTO collection_content (collection_id, content_id, visible) VALUES (?, ?, ?)",
+        collectionId,
+        contentId,
+        visible);
+  }
+
+  // ---- findCollectionsByTagId --------------------------------------------
+
+  @Test
+  void findCollectionsByTagId_filtersByVisibilityAndOrders() {
+    long tag = seedTag("Landscape", "landscape-collections");
+    // rating asc on purpose so we can assert the rating-desc ordering reorders them.
+    long listedLow = seedCollection("listed-low", CollectionVisibility.LISTED, 2);
+    long listedHigh = seedCollection("listed-high", CollectionVisibility.LISTED, 4);
+    long unlisted = seedCollection("unlisted-c", CollectionVisibility.UNLISTED, 5);
+    long hidden = seedCollection("hidden-c", CollectionVisibility.HIDDEN, 5);
+    tagCollection(listedLow, tag);
+    tagCollection(listedHigh, tag);
+    tagCollection(unlisted, tag);
+    tagCollection(hidden, tag);
+
+    // Prod scope: only LISTED, ordered rating DESC.
+    List<CollectionEntity> prod = tagRepository.findCollectionsByTagId(tag, PROD_ALLOWED);
+    assertThat(prod).extracting(CollectionEntity::getId).containsExactly(listedHigh, listedLow);
+
+    // Local scope: all three visibilities surface; high-rated first.
+    List<CollectionEntity> local = tagRepository.findCollectionsByTagId(tag, LOCAL_ALLOWED);
+    assertThat(local)
+        .extracting(CollectionEntity::getVisibility)
+        .doesNotContain((CollectionVisibility) null);
+    assertThat(local)
+        .extracting(CollectionEntity::getId)
+        .containsExactlyInAnyOrder(listedLow, listedHigh, unlisted, hidden);
+    // rating DESC NULLS LAST, collection_date DESC NULLS LAST — top two are the rating-5 rows.
+    assertThat(local.subList(0, 2))
+        .extracting(CollectionEntity::getId)
+        .containsExactlyInAnyOrder(unlisted, hidden);
+    assertThat(local.get(local.size() - 1).getId()).isEqualTo(listedLow);
+  }
+
+  @Test
+  void findCollectionsByTagId_tagWithNoCollections_returnsEmpty() {
+    long tag = seedTag("Orphan", "orphan-collections");
+    assertThat(tagRepository.findCollectionsByTagId(tag, LOCAL_ALLOWED)).isEmpty();
+  }
+
+  // ---- findImageContentByTagId -------------------------------------------
+
+  @Test
+  void findImageContentByTagId_gatesOnVisibleMembershipAndCollectionVisibility() {
+    long tag = seedTag("Mountains", "mountains-images");
+    long listed = seedCollection("img-listed", CollectionVisibility.LISTED, 1);
+    long hidden = seedCollection("img-hidden", CollectionVisibility.HIDDEN, 1);
+
+    // Image A: visible membership in a LISTED collection -> surfaces in prod.
+    long imageA = seedImage("https://cdn/a.jpg");
+    tagContent(imageA, tag);
+    addMembership(listed, imageA, true);
+
+    // Image B: tagged, but only a HIDDEN-collection membership -> hidden in prod, visible local.
+    long imageB = seedImage("https://cdn/b.jpg");
+    tagContent(imageB, tag);
+    addMembership(hidden, imageB, true);
+
+    // Image C: tagged, but its only membership is soft-removed (visible=false) -> never surfaces.
+    long imageC = seedImage("https://cdn/c.jpg");
+    tagContent(imageC, tag);
+    addMembership(listed, imageC, false);
+
+    List<Long> prod = tagRepository.findImageContentByTagId(tag, PROD_ALLOWED);
+    assertThat(prod).containsExactly(imageA);
+    assertThat(prod).doesNotContain(imageB, imageC);
+
+    List<Long> local = tagRepository.findImageContentByTagId(tag, LOCAL_ALLOWED);
+    assertThat(local).containsExactlyInAnyOrder(imageA, imageB);
+    assertThat(local).doesNotContain(imageC);
+  }
+
+  /**
+   * Regression guard for the fixed column-count bug: an image that is a visible member of MULTIPLE
+   * LISTED collections must appear exactly once. Against the pre-fix {@code
+   * queryForList(Long.class)} implementation this query (DISTINCT c.id, c.created_at) throws — a
+   * single-column mapper cannot read the two-column result — so this assertion genuinely exercises
+   * the multi-column DISTINCT path.
+   */
+  @Test
+  void findImageContentByTagId_multipleVisibleMemberships_dedupesToOneRow() {
+    long tag = seedTag("Featured", "featured-images");
+    long c1 = seedCollection("multi-1", CollectionVisibility.LISTED, 1);
+    long c2 = seedCollection("multi-2", CollectionVisibility.LISTED, 1);
+
+    long image = seedImage("https://cdn/multi.jpg");
+    tagContent(image, tag);
+    addMembership(c1, image, true);
+    addMembership(c2, image, true);
+
+    List<Long> prod = tagRepository.findImageContentByTagId(tag, PROD_ALLOWED);
+    assertThat(prod).containsExactly(image);
+    assertThat(prod).hasSize(1);
+  }
+
+  @Test
+  void findImageContentByTagId_ordersNewestFirst() {
+    long tag = seedTag("Ordered", "ordered-images");
+    long listed = seedCollection("ord-c", CollectionVisibility.LISTED, 1);
+
+    long older = seedImage("https://cdn/older.jpg");
+    long newer = seedImage("https://cdn/newer.jpg");
+    // Force created_at ordering deterministically.
+    jdbc.update("UPDATE content SET created_at = '2020-01-01 00:00:00' WHERE id = ?", older);
+    jdbc.update("UPDATE content SET created_at = '2024-01-01 00:00:00' WHERE id = ?", newer);
+    tagContent(older, tag);
+    tagContent(newer, tag);
+    addMembership(listed, older, true);
+    addMembership(listed, newer, true);
+
+    assertThat(tagRepository.findImageContentByTagId(tag, PROD_ALLOWED))
+        .containsExactly(newer, older);
+  }
+
+  // ---- resolution path through CollectionService -------------------------
+
+  @Test
+  void getCollectionWithPagination_tagSlug_returnsParentCollectionsFirstThenImages() {
+    long tag = seedTag("Travel", "travel");
+    long memberCollection = seedCollection("travel-trip", CollectionVisibility.LISTED, 5);
+    tagCollection(memberCollection, tag);
+
+    long listed = seedCollection("travel-host", CollectionVisibility.LISTED, 1);
+    long image = seedImage("https://cdn/travel.jpg");
+    tagContent(image, tag);
+    addMembership(listed, image, true);
+
+    CollectionModel model = collectionService.getCollectionWithPagination("travel", 0, 30);
+
+    assertThat(model.getType()).isEqualTo(CollectionType.PARENT);
+    assertThat(model.getSlug()).isEqualTo("travel");
+    assertThat(model.getContent()).hasSize(2);
+    // Collections render before images.
+    assertThat(model.getContent().get(0)).isInstanceOf(ContentModels.Collection.class);
+    assertThat(model.getContent().get(1)).isInstanceOf(ContentModels.Image.class);
+  }
+
+  @Test
+  void getCollectionWithPagination_slugMatchesNothing_throwsNotFound() {
+    assertThatThrownBy(
+            () -> collectionService.getCollectionWithPagination("no-such-thing-anywhere", 0, 30))
+        .isInstanceOf(ResourceNotFoundException.class);
+  }
+
+  @Test
+  void getCollectionWithPagination_tagWithNoVisibleMembers_throwsNotFound() {
+    long tag = seedTag("EmptyTag", "empty-tag");
+    // Member exists but only as a HIDDEN collection -> not visible in prod -> 404.
+    long hidden = seedCollection("empty-hidden", CollectionVisibility.HIDDEN, 1);
+    tagCollection(hidden, tag);
+
+    assertThatThrownBy(() -> collectionService.getCollectionWithPagination("empty-tag", 0, 30))
+        .isInstanceOf(ResourceNotFoundException.class);
+  }
+
+  @Test
+  void getCollectionWithPagination_slugIsBothCollectionAndTag_realCollectionWins() {
+    String slug = "collision-slug";
+    // A real LISTED collection with this slug.
+    seedCollection(slug, CollectionVisibility.LISTED, 1);
+    // A tag that also slugs to the same value, with its own visible member.
+    long tag = seedTag("Collision", slug);
+    long member = seedCollection("collision-member", CollectionVisibility.LISTED, 5);
+    tagCollection(member, tag);
+
+    CollectionModel model = collectionService.getCollectionWithPagination(slug, 0, 30);
+    // Real collection wins: it is type BLOG, not the synthetic PARENT tag-view.
+    assertThat(model.getType()).isEqualTo(CollectionType.BLOG);
+    assertThat(model.getSlug()).isEqualTo(slug);
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/services/TagViewIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/TagViewIntegrationTest.java
@@ -19,9 +19,8 @@ import org.springframework.jdbc.core.JdbcTemplate;
 /**
  * Real-Postgres integration coverage for the A1 tag-view read model. Exercises the new {@link
  * TagRepository} SQL end-to-end against a Flyway-migrated schema so the multi-column {@code
- * DISTINCT} path in {@link TagRepository#findImageContentByTagId} (the column-count regression that
- * was fixed by hand) cannot recur, and so visibility/ordering semantics are verified against the
- * real planner rather than a mock.
+ * DISTINCT} path in {@link TagRepository#findImageContentByTagId} and the visibility/ordering
+ * semantics are verified against the real planner rather than a mock.
  *
  * <p>The {@code test} profile is not {@code dev}, so {@link
  * CollectionService#getCollectionWithPagination} resolves with the production visibility scope
@@ -159,11 +158,8 @@ class TagViewIntegrationTest extends AbstractPostgresIntegrationTest {
   }
 
   /**
-   * Regression guard for the fixed column-count bug: an image that is a visible member of MULTIPLE
-   * LISTED collections must appear exactly once. Against the pre-fix {@code
-   * queryForList(Long.class)} implementation this query (DISTINCT c.id, c.created_at) throws — a
-   * single-column mapper cannot read the two-column result — so this assertion genuinely exercises
-   * the multi-column DISTINCT path.
+   * An image that is a visible member of multiple LISTED collections appears exactly once,
+   * exercising the multi-column {@code DISTINCT c.id, c.created_at} path.
    */
   @Test
   void findImageContentByTagId_multipleVisibleMemberships_dedupesToOneRow() {

--- a/src/test/java/edens/zac/portfolio/backend/services/TagViewResolverTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/TagViewResolverTest.java
@@ -1,0 +1,192 @@
+package edens.zac.portfolio.backend.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import edens.zac.portfolio.backend.dao.ContentRepository;
+import edens.zac.portfolio.backend.dao.TagRepository;
+import edens.zac.portfolio.backend.entity.CollectionEntity;
+import edens.zac.portfolio.backend.entity.ContentImageEntity;
+import edens.zac.portfolio.backend.entity.TagEntity;
+import edens.zac.portfolio.backend.model.CollectionModel;
+import edens.zac.portfolio.backend.model.ContentModel;
+import edens.zac.portfolio.backend.model.ContentModels;
+import edens.zac.portfolio.backend.types.CollectionType;
+import edens.zac.portfolio.backend.types.CollectionVisibility;
+import edens.zac.portfolio.backend.types.ContentType;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TagViewResolverTest {
+
+  @Mock private TagRepository tagRepository;
+  @Mock private ContentRepository contentRepository;
+  @Mock private CollectionProcessingUtil collectionProcessingUtil;
+  @Mock private ContentModelConverter contentModelConverter;
+
+  @InjectMocks private TagViewResolver resolver;
+
+  private static final List<CollectionVisibility> DEV_VISIBILITIES =
+      List.of(
+          CollectionVisibility.LISTED, CollectionVisibility.UNLISTED, CollectionVisibility.HIDDEN);
+  private static final List<CollectionVisibility> PROD_VISIBILITIES =
+      List.of(CollectionVisibility.LISTED);
+
+  private TagEntity tag(long id, String name, String slug) {
+    return TagEntity.builder().id(id).tagName(name).slug(slug).build();
+  }
+
+  private ContentModels.Image imageModel(long id) {
+    return new ContentModels.Image(
+        id,
+        ContentType.IMAGE,
+        null,
+        null,
+        null,
+        null,
+        "https://cdn/" + id + ".webp",
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        List.of(),
+        List.of());
+  }
+
+  @Test
+  void unknownSlug_returnsEmpty() {
+    when(tagRepository.findBySlug("nope")).thenReturn(Optional.empty());
+
+    assertThat(resolver.resolveTagView("nope", true)).isEmpty();
+  }
+
+  @Test
+  void tagWithCollectionsAndImages_returnsParentModelWithCollectionsFirst() {
+    TagEntity travel = tag(7L, "Travel", "travel");
+    when(tagRepository.findBySlug("travel")).thenReturn(Optional.of(travel));
+
+    when(tagRepository.findCollectionsByTagId(eq(7L), eq(PROD_VISIBILITIES)))
+        .thenReturn(List.of(new CollectionEntity(), new CollectionEntity()));
+    CollectionModel coll1 =
+        CollectionModel.builder()
+            .id(1L)
+            .slug("chamonix")
+            .type(CollectionType.BLOG)
+            .coverImage(imageModel(100L))
+            .build();
+    CollectionModel coll2 =
+        CollectionModel.builder().id(2L).slug("iceland").type(CollectionType.PORTFOLIO).build();
+    when(collectionProcessingUtil.batchConvertToBasicModels(any()))
+        .thenReturn(List.of(coll1, coll2));
+
+    when(tagRepository.findImageContentByTagId(eq(7L), eq(PROD_VISIBILITIES)))
+        .thenReturn(List.of(200L, 201L));
+    ContentImageEntity img1 = ContentImageEntity.builder().id(200L).build();
+    ContentImageEntity img2 = ContentImageEntity.builder().id(201L).build();
+    when(contentRepository.findImagesByIds(eq(List.of(200L, 201L))))
+        .thenReturn(List.of(img1, img2));
+    when(contentModelConverter.batchConvertImageEntitiesToModels(eq(List.of(img1, img2))))
+        .thenReturn(List.of(imageModel(200L), imageModel(201L)));
+
+    CollectionModel out = resolver.resolveTagView("travel", false).orElseThrow();
+
+    assertThat(out.getSlug()).isEqualTo("travel");
+    assertThat(out.getTitle()).isEqualTo("Travel");
+    assertThat(out.getType()).isEqualTo(CollectionType.PARENT);
+    assertThat(out.getVisibility()).isEqualTo(CollectionVisibility.LISTED);
+
+    // collections-first ordering: 2 collection blocks then 2 image blocks
+    List<ContentModel> content = out.getContent();
+    assertThat(content).hasSize(4);
+    assertThat(content.get(0)).isInstanceOf(ContentModels.Collection.class);
+    assertThat(content.get(1)).isInstanceOf(ContentModels.Collection.class);
+    assertThat(content.get(2)).isInstanceOf(ContentModels.Image.class);
+    assertThat(content.get(3)).isInstanceOf(ContentModels.Image.class);
+
+    ContentModels.Collection firstColl = (ContentModels.Collection) content.get(0);
+    assertThat(firstColl.contentType()).isEqualTo(ContentType.COLLECTION);
+    assertThat(firstColl.referencedCollectionId()).isEqualTo(1L);
+    assertThat(firstColl.slug()).isEqualTo("chamonix");
+
+    // cover falls back to the first member collection's cover image
+    assertThat(out.getCoverImage()).isNotNull();
+    assertThat(out.getCoverImage().id()).isEqualTo(100L);
+  }
+
+  @Test
+  void tagWithOnlyImages_rendersImageSectionAndCoverFromFirstImage() {
+    TagEntity film = tag(9L, "Film", "film");
+    when(tagRepository.findBySlug("film")).thenReturn(Optional.of(film));
+    when(tagRepository.findCollectionsByTagId(eq(9L), eq(PROD_VISIBILITIES))).thenReturn(List.of());
+    when(collectionProcessingUtil.batchConvertToBasicModels(any())).thenReturn(List.of());
+
+    when(tagRepository.findImageContentByTagId(eq(9L), eq(PROD_VISIBILITIES)))
+        .thenReturn(List.of(300L));
+    ContentImageEntity img = ContentImageEntity.builder().id(300L).build();
+    when(contentRepository.findImagesByIds(eq(List.of(300L)))).thenReturn(List.of(img));
+    when(contentModelConverter.batchConvertImageEntitiesToModels(eq(List.of(img))))
+        .thenReturn(List.of(imageModel(300L)));
+
+    CollectionModel out = resolver.resolveTagView("film", false).orElseThrow();
+
+    assertThat(out.getContent()).hasSize(1);
+    assertThat(out.getContent().get(0)).isInstanceOf(ContentModels.Image.class);
+    assertThat(out.getCoverImage()).isNotNull();
+    assertThat(out.getCoverImage().id()).isEqualTo(300L);
+  }
+
+  @Test
+  void zeroMembers_returnsEmpty() {
+    TagEntity orphan = tag(11L, "Orphan", "orphan");
+    when(tagRepository.findBySlug("orphan")).thenReturn(Optional.of(orphan));
+    when(tagRepository.findCollectionsByTagId(eq(11L), eq(PROD_VISIBILITIES)))
+        .thenReturn(List.of());
+    when(collectionProcessingUtil.batchConvertToBasicModels(any())).thenReturn(List.of());
+    when(tagRepository.findImageContentByTagId(eq(11L), eq(PROD_VISIBILITIES)))
+        .thenReturn(List.of());
+
+    assertThat(resolver.resolveTagView("orphan", false)).isEmpty();
+  }
+
+  @Test
+  void localEnvironment_expandsAllowedVisibilities() {
+    TagEntity travel = tag(7L, "Travel", "travel");
+    when(tagRepository.findBySlug("travel")).thenReturn(Optional.of(travel));
+    when(tagRepository.findCollectionsByTagId(eq(7L), eq(DEV_VISIBILITIES)))
+        .thenReturn(List.of(new CollectionEntity()));
+    when(collectionProcessingUtil.batchConvertToBasicModels(any()))
+        .thenReturn(
+            List.of(CollectionModel.builder().id(1L).slug("c").type(CollectionType.BLOG).build()));
+    when(tagRepository.findImageContentByTagId(eq(7L), eq(DEV_VISIBILITIES))).thenReturn(List.of());
+
+    CollectionModel out = resolver.resolveTagView("travel", true).orElseThrow();
+
+    assertThat(out.getContent()).hasSize(1);
+  }
+}


### PR DESCRIPTION
Any non-colliding tag is browsable as a synthetic PARENT collection at /{slug}. New TagViewResolver builds the model (tagged collections first, then tagged images; cover = first member cover, else first image) and returns empty on a miss/zero-members. Wired into
CollectionService.getCollectionWithPagination as a fallback, so the order is synthetic -> real collection -> tag-view -> 404 (a real collection wins on slug collision). No schema change.

TagRepository gains findCollectionsByTagId and findImageContentByTagId. Image visibility is derived from the owning collection (content rows have no visibility column): an image surfaces only via a collection_content visible membership in a collection within the allowed visibility set.

findImageContentByTagId selects DISTINCT c.id, c.created_at (Postgres requires DISTINCT + ORDER BY columns in the select list) and maps a single column via a custom RowMapper — queryForList(Long.class) would throw at runtime on the two-column result. Covered by TagViewIntegrationTest against real Postgres, including a multi-membership DISTINCT dedup regression guard.