### PR TITLE
Collection IA — A3 Save as Collection + Track C saves/follows (0195)

### DIFF
--- a/scripts/db-tunnel.sh
+++ b/scripts/db-tunnel.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+#
+# db-tunnel.sh — open a local SSH tunnel to the EC2-hosted PostgreSQL so you can
+# browse the database from psql / TablePlus / DBeaver / Postman without opening
+# port 5432 to the internet.
+#
+# This is the database analogue of the shell's `ec2Login`: it first ensures the
+# EC2 security group allows SSH from your CURRENT public IP (the thing that
+# usually blocks you after your IP changes), then forwards localhost:5432 to the
+# database over SSH. Nothing here is hard-coded — all host/credential values come
+# from the environment (this repo is public), so set them in your shell profile
+# or a local, git-ignored `.env` before running.
+#
+# Usage:
+#   ./scripts/db-tunnel.sh up       # ensure SSH access + open the tunnel (idempotent), print connection info
+#   ./scripts/db-tunnel.sh info     # just print connection strings for the running tunnel
+#   ./scripts/db-tunnel.sh status   # is the tunnel up?
+#   ./scripts/db-tunnel.sh down     # close the tunnel (leaves the security-group rule as-is)
+#   ./scripts/db-tunnel.sh psql     # up, then drop into an interactive psql session (needs local psql)
+#
+# Required environment variables:
+#   EC2_PEM_FILE    path to the SSH private key (e.g. ~/keys/portfolio.pem)
+#   EC2_USER        SSH user on the instance    (e.g. ec2-user or ubuntu)
+#   EC2_HOST        instance public IP / DNS
+# Optional (sensible non-secret defaults shown):
+#   SG_ID           security group id to open port 22 on (skips the SG step if unset)
+#   AWS_REGION      default: us-west-2
+#   LOCAL_PORT      default: 5432
+#   REMOTE_PORT     default: 5432
+#   POSTGRES_DB     default: edens_zac
+#   POSTGRES_USER   default: zedens
+#   POSTGRES_PASSWORD  (only used to print a ready-to-paste psql/JDBC line; never logged if unset)
+#
+set -euo pipefail
+
+LOCAL_PORT="${LOCAL_PORT:-5432}"
+REMOTE_PORT="${REMOTE_PORT:-5432}"
+AWS_REGION="${AWS_REGION:-us-west-2}"
+POSTGRES_DB="${POSTGRES_DB:-edens_zac}"
+POSTGRES_USER="${POSTGRES_USER:-zedens}"
+
+err() { printf '\033[31m%s\033[0m\n' "$*" >&2; }
+info() { printf '%s\n' "$*"; }
+
+require_env() {
+  local missing=()
+  [[ -n "${EC2_PEM_FILE:-}" ]] || missing+=("EC2_PEM_FILE")
+  [[ -n "${EC2_USER:-}" ]] || missing+=("EC2_USER")
+  [[ -n "${EC2_HOST:-}" ]] || missing+=("EC2_HOST")
+  if ((${#missing[@]})); then
+    err "Missing required environment variable(s): ${missing[*]}"
+    err "Set them in your shell profile or a local .env, then re-run. See the header of this script."
+    exit 1
+  fi
+  if [[ ! -f "${EC2_PEM_FILE}" ]]; then
+    err "EC2_PEM_FILE points to a file that does not exist: ${EC2_PEM_FILE}"
+    exit 1
+  fi
+}
+
+# Ensure the EC2 security group allows SSH (port 22) from the current public IP.
+# Mirrors the shell's `_ensure_ec2_ssh_access`. No-op if SG_ID is not set.
+ensure_ssh_access() {
+  if [[ -z "${SG_ID:-}" ]]; then
+    info "SG_ID not set — skipping security-group check (assuming port 22 already reachable)."
+    return 0
+  fi
+  if ! command -v aws >/dev/null 2>&1; then
+    err "aws CLI not found but SG_ID is set — install it or unset SG_ID to skip the check."
+    return 1
+  fi
+
+  local my_ip my_cidr current_cidr
+  my_ip="$(curl -s --max-time 5 https://checkip.amazonaws.com | tr -d '[:space:]')"
+  if [[ -z "$my_ip" ]]; then
+    err "Could not determine current public IP; skipping security-group update."
+    return 0
+  fi
+  my_cidr="${my_ip}/32"
+
+  current_cidr="$(aws ec2 describe-security-group-rules \
+    --region "$AWS_REGION" \
+    --filters "Name=group-id,Values=$SG_ID" \
+    --query "SecurityGroupRules[?FromPort==\`22\` && ToPort==\`22\` && !IsEgress].CidrIpv4 | [0]" \
+    --output text 2>/dev/null || true)"
+
+  if [[ "$current_cidr" != "$my_cidr" && -n "$current_cidr" && "$current_cidr" != "None" ]]; then
+    info "Updating SSH security-group rule: $current_cidr -> $my_cidr"
+    aws ec2 revoke-security-group-ingress \
+      --region "$AWS_REGION" --group-id "$SG_ID" \
+      --protocol tcp --port 22 --cidr "$current_cidr" --no-cli-pager
+    aws ec2 authorize-security-group-ingress \
+      --region "$AWS_REGION" --group-id "$SG_ID" \
+      --protocol tcp --port 22 --cidr "$my_cidr" --no-cli-pager
+    info "SSH rule updated to $my_cidr"
+  else
+    info "SSH rule already matches current IP (${my_cidr})"
+  fi
+}
+
+tunnel_pid() {
+  # PID of a process LISTENing on LOCAL_PORT, if any.
+  lsof -ti ":${LOCAL_PORT}" -sTCP:LISTEN 2>/dev/null || true
+}
+
+tunnel_up() {
+  require_env
+  ensure_ssh_access
+  if [[ -n "$(tunnel_pid)" ]]; then
+    info "Tunnel already running on :${LOCAL_PORT}"
+  else
+    ssh -i "$EC2_PEM_FILE" \
+      -L "${LOCAL_PORT}:localhost:${REMOTE_PORT}" \
+      -o ExitOnForwardFailure=yes \
+      "${EC2_USER}@${EC2_HOST}" -N -f
+    info "SSH tunnel established: localhost:${LOCAL_PORT} -> ${EC2_HOST}:${REMOTE_PORT}"
+  fi
+  print_info
+}
+
+tunnel_down() {
+  local pid
+  pid="$(tunnel_pid)"
+  if [[ -n "$pid" ]]; then
+    kill $pid 2>/dev/null || true
+    info "SSH tunnel stopped (PID $pid)"
+  else
+    info "No tunnel running on :${LOCAL_PORT}"
+  fi
+}
+
+tunnel_status() {
+  local pid
+  pid="$(tunnel_pid)"
+  if [[ -n "$pid" ]]; then
+    info "Tunnel UP on :${LOCAL_PORT} (PID $pid)"
+  else
+    info "Tunnel DOWN"
+  fi
+}
+
+print_info() {
+  local pw_display="<POSTGRES_PASSWORD>"
+  [[ -n "${POSTGRES_PASSWORD:-}" ]] && pw_display="${POSTGRES_PASSWORD}"
+  printf '\n'
+  printf 'Connect to the database at:\n'
+  printf '  Host:     localhost\n'
+  printf '  Port:     %s\n' "${LOCAL_PORT}"
+  printf '  Database: %s\n' "${POSTGRES_DB}"
+  printf '  User:     %s\n' "${POSTGRES_USER}"
+  printf '  Password: %s\n\n' "${pw_display}"
+  printf "  psql:  PGPASSWORD='%s' psql -h localhost -p %s -U %s -d %s\n" \
+    "${pw_display}" "${LOCAL_PORT}" "${POSTGRES_USER}" "${POSTGRES_DB}"
+  printf '  JDBC:  jdbc:postgresql://localhost:%s/%s\n' "${LOCAL_PORT}" "${POSTGRES_DB}"
+  printf '  URL:   postgresql://%s@localhost:%s/%s\n\n' "${POSTGRES_USER}" "${LOCAL_PORT}" "${POSTGRES_DB}"
+  printf '  TablePlus / DBeaver / Postman: use the Host/Port/Database/User/Password above.\n'
+  printf '  Close the tunnel when done:  ./scripts/db-tunnel.sh down\n'
+}
+
+open_psql() {
+  tunnel_up
+  if ! command -v psql >/dev/null 2>&1; then
+    err "psql not found locally; the tunnel is up — connect with a GUI client using the info above."
+    return 0
+  fi
+  PGPASSWORD="${POSTGRES_PASSWORD:-}" psql -h localhost -p "${LOCAL_PORT}" -U "${POSTGRES_USER}" -d "${POSTGRES_DB}"
+}
+
+case "${1:-up}" in
+  up) tunnel_up ;;
+  down) tunnel_down ;;
+  info) print_info ;;
+  status) tunnel_status ;;
+  psql) open_psql ;;
+  *)
+    err "Unknown command: ${1:-}"
+    err "Usage: $0 {up|down|info|status|psql}"
+    exit 1
+    ;;
+esac

--- a/src/main/java/edens/zac/portfolio/backend/controller/admin/TagAdminController.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/admin/TagAdminController.java
@@ -1,0 +1,33 @@
+package edens.zac.portfolio.backend.controller.admin;
+
+import edens.zac.portfolio.backend.model.CollectionRequests.UpdateResponse;
+import edens.zac.portfolio.backend.model.SaveAsCollectionRequest;
+import edens.zac.portfolio.backend.services.TagService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Admin endpoints for tag operations.
+ *
+ * <p>Delegates all business logic to {@link TagService}.
+ */
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/admin/tags")
+public class TagAdminController {
+
+  private final TagService tagService;
+
+  @PostMapping("/{id}/save-as-collection")
+  public ResponseEntity<UpdateResponse> saveAsCollection(
+      @PathVariable Long id, @RequestBody(required = false) SaveAsCollectionRequest request) {
+    return ResponseEntity.ok(tagService.convertTagToCollection(id, request));
+  }
+}

--- a/src/main/java/edens/zac/portfolio/backend/controller/dev/AdminController.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/dev/AdminController.java
@@ -89,8 +89,8 @@ class AdminController {
   /**
    * DEV-ONLY: mint an {@code ezac_session} for {@code userId} and set it on the response so the
    * admin can browse the site as that user (e.g. to preview their {@code /user} page). This
-   * controller is {@code @Profile("dev")}, so the endpoint does not exist in prod — impersonation is
-   * never reachable there, which matters while {@code /api/admin/**} has no per-user authz. This
+   * controller is {@code @Profile("dev")}, so the endpoint does not exist in prod — impersonation
+   * is never reachable there, which matters while {@code /api/admin/**} has no per-user authz. This
    * overwrites the caller's current session cookie; log in again to return to the admin account.
    */
   @PostMapping("/impersonate/{userId}")

--- a/src/main/java/edens/zac/portfolio/backend/controller/dev/AdminController.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/dev/AdminController.java
@@ -1,6 +1,9 @@
 package edens.zac.portfolio.backend.controller.dev;
 
 import edens.zac.portfolio.backend.config.GlobalExceptionHandler;
+import edens.zac.portfolio.backend.config.ResourceNotFoundException;
+import edens.zac.portfolio.backend.dao.AppUserRepository;
+import edens.zac.portfolio.backend.entity.AppUserEntity;
 import edens.zac.portfolio.backend.model.CollectionModel;
 import edens.zac.portfolio.backend.model.CollectionRequests;
 import edens.zac.portfolio.backend.model.ContentImageUpdateRequest;
@@ -21,7 +24,10 @@ import edens.zac.portfolio.backend.services.ImageUploadPipelineService;
 import edens.zac.portfolio.backend.services.JobTrackingService;
 import edens.zac.portfolio.backend.services.MetadataService;
 import edens.zac.portfolio.backend.services.PaginationUtil;
+import edens.zac.portfolio.backend.services.SessionService;
 import edens.zac.portfolio.backend.types.CollectionType;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -73,6 +79,31 @@ class AdminController {
   private final ImageUploadPipelineService imageUploadPipelineService;
   private final JobTrackingService jobTrackingService;
   private final MetadataService metadataService;
+  private final SessionService sessionService;
+  private final AppUserRepository appUserRepository;
+
+  // ============================================================================
+  // Dev-only impersonation ("log in as user")
+  // ============================================================================
+
+  /**
+   * DEV-ONLY: mint an {@code ezac_session} for {@code userId} and set it on the response so the
+   * admin can browse the site as that user (e.g. to preview their {@code /user} page). This
+   * controller is {@code @Profile("dev")}, so the endpoint does not exist in prod — impersonation is
+   * never reachable there, which matters while {@code /api/admin/**} has no per-user authz. This
+   * overwrites the caller's current session cookie; log in again to return to the admin account.
+   */
+  @PostMapping("/impersonate/{userId}")
+  ResponseEntity<Void> impersonate(
+      @PathVariable Long userId, HttpServletRequest request, HttpServletResponse response) {
+    AppUserEntity user =
+        appUserRepository
+            .findById(userId)
+            .orElseThrow(() -> new ResourceNotFoundException("User not found with ID: " + userId));
+    sessionService.create(user, false, request, response);
+    log.warn("DEV impersonation: minted a session as user {} ({})", user.getId(), user.getEmail());
+    return ResponseEntity.noContent().build();
+  }
 
   // ============================================================================
   // Admin home tiles

--- a/src/main/java/edens/zac/portfolio/backend/controller/prod/UserFollowsControllerProd.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/prod/UserFollowsControllerProd.java
@@ -2,6 +2,8 @@ package edens.zac.portfolio.backend.controller.prod;
 
 import edens.zac.portfolio.backend.model.AuthPrincipal;
 import edens.zac.portfolio.backend.services.UserFollowsService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -27,12 +29,12 @@ public class UserFollowsControllerProd {
   private final UserFollowsService userFollowsService;
 
   /** Body of {@code POST /api/read/user/follows}. */
-  public record AddFollowRequest(Long collectionId) {}
+  public record AddFollowRequest(@NotNull Long collectionId) {}
 
   /** Add a collection to the caller's follows. 201 on success, 401 when anonymous. */
   @PostMapping
   public ResponseEntity<Void> add(
-      @AuthenticationPrincipal AuthPrincipal principal, @RequestBody AddFollowRequest body) {
+      @AuthenticationPrincipal AuthPrincipal principal, @Valid @RequestBody AddFollowRequest body) {
     if (principal == null) {
       return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
     }

--- a/src/main/java/edens/zac/portfolio/backend/controller/prod/UserFollowsControllerProd.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/prod/UserFollowsControllerProd.java
@@ -1,0 +1,62 @@
+package edens.zac.portfolio.backend.controller.prod;
+
+import edens.zac.portfolio.backend.model.AuthPrincipal;
+import edens.zac.portfolio.backend.services.UserFollowsService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Per-user followed collections. Every endpoint is session-required (401 when anonymous),
+ * self-only.
+ */
+@RestController
+@RequestMapping("/api/read/user/follows")
+@RequiredArgsConstructor
+public class UserFollowsControllerProd {
+
+  private final UserFollowsService userFollowsService;
+
+  /** Body of {@code POST /api/read/user/follows}. */
+  public record AddFollowRequest(Long collectionId) {}
+
+  /** Add a collection to the caller's follows. 201 on success, 401 when anonymous. */
+  @PostMapping
+  public ResponseEntity<Void> add(
+      @AuthenticationPrincipal AuthPrincipal principal, @RequestBody AddFollowRequest body) {
+    if (principal == null) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+    userFollowsService.add(principal.userId(), body.collectionId());
+    return ResponseEntity.status(HttpStatus.CREATED).build();
+  }
+
+  /** Remove a collection from the caller's follows. 204 on success, 401 when anonymous. */
+  @DeleteMapping("/{collectionId}")
+  public ResponseEntity<Void> remove(
+      @AuthenticationPrincipal AuthPrincipal principal, @PathVariable Long collectionId) {
+    if (principal == null) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+    userFollowsService.remove(principal.userId(), collectionId);
+    return ResponseEntity.noContent().build();
+  }
+
+  /** The caller's followed collection ids, newest-followed first. 401 when anonymous. */
+  @GetMapping
+  public ResponseEntity<List<Long>> list(@AuthenticationPrincipal AuthPrincipal principal) {
+    if (principal == null) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+    return ResponseEntity.ok(userFollowsService.listFollowedCollectionIds(principal.userId()));
+  }
+}

--- a/src/main/java/edens/zac/portfolio/backend/controller/prod/UserSavesControllerProd.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/prod/UserSavesControllerProd.java
@@ -3,6 +3,8 @@ package edens.zac.portfolio.backend.controller.prod;
 import edens.zac.portfolio.backend.model.AuthPrincipal;
 import edens.zac.portfolio.backend.model.ContentModels;
 import edens.zac.portfolio.backend.services.UserSavesService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -25,12 +27,12 @@ public class UserSavesControllerProd {
   private final UserSavesService userSavesService;
 
   /** Body of {@code POST /api/read/user/saves}. */
-  public record AddSaveRequest(Long imageId) {}
+  public record AddSaveRequest(@NotNull Long imageId) {}
 
   /** Add an image to the caller's saves. 201 on success, 401 when anonymous. */
   @PostMapping
   public ResponseEntity<Void> add(
-      @AuthenticationPrincipal AuthPrincipal principal, @RequestBody AddSaveRequest body) {
+      @AuthenticationPrincipal AuthPrincipal principal, @Valid @RequestBody AddSaveRequest body) {
     if (principal == null) {
       return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
     }

--- a/src/main/java/edens/zac/portfolio/backend/controller/prod/UserSavesControllerProd.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/prod/UserSavesControllerProd.java
@@ -1,0 +1,59 @@
+package edens.zac.portfolio.backend.controller.prod;
+
+import edens.zac.portfolio.backend.model.AuthPrincipal;
+import edens.zac.portfolio.backend.services.UserSavesService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Per-user saved images. Every endpoint is session-required (401 when anonymous), self-only. */
+@RestController
+@RequestMapping("/api/read/user/saves")
+@RequiredArgsConstructor
+public class UserSavesControllerProd {
+
+  private final UserSavesService userSavesService;
+
+  /** Body of {@code POST /api/read/user/saves}. */
+  public record AddSaveRequest(Long imageId) {}
+
+  /** Add an image to the caller's saves. 201 on success, 401 when anonymous. */
+  @PostMapping
+  public ResponseEntity<Void> add(
+      @AuthenticationPrincipal AuthPrincipal principal, @RequestBody AddSaveRequest body) {
+    if (principal == null) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+    userSavesService.add(principal.userId(), body.imageId());
+    return ResponseEntity.status(HttpStatus.CREATED).build();
+  }
+
+  /** Remove an image from the caller's saves. 204 on success, 401 when anonymous. */
+  @DeleteMapping("/{imageId}")
+  public ResponseEntity<Void> remove(
+      @AuthenticationPrincipal AuthPrincipal principal, @PathVariable Long imageId) {
+    if (principal == null) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+    userSavesService.remove(principal.userId(), imageId);
+    return ResponseEntity.noContent().build();
+  }
+
+  /** The caller's saved image ids, newest-saved first. 401 when anonymous. */
+  @GetMapping
+  public ResponseEntity<List<Long>> list(@AuthenticationPrincipal AuthPrincipal principal) {
+    if (principal == null) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+    return ResponseEntity.ok(userSavesService.listSavedImageIds(principal.userId()));
+  }
+}

--- a/src/main/java/edens/zac/portfolio/backend/controller/prod/UserSavesControllerProd.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/prod/UserSavesControllerProd.java
@@ -1,6 +1,7 @@
 package edens.zac.portfolio.backend.controller.prod;
 
 import edens.zac.portfolio.backend.model.AuthPrincipal;
+import edens.zac.portfolio.backend.model.ContentModels;
 import edens.zac.portfolio.backend.services.UserSavesService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -55,5 +56,15 @@ public class UserSavesControllerProd {
       return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
     }
     return ResponseEntity.ok(userSavesService.listSavedImageIds(principal.userId()));
+  }
+
+  /** The caller's saved images as full models, newest-saved first. 401 when anonymous. */
+  @GetMapping("/images")
+  public ResponseEntity<List<ContentModels.Image>> listImages(
+      @AuthenticationPrincipal AuthPrincipal principal) {
+    if (principal == null) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+    return ResponseEntity.ok(userSavesService.listSavedImages(principal.userId()));
   }
 }

--- a/src/main/java/edens/zac/portfolio/backend/dao/ContentRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/ContentRepository.java
@@ -246,6 +246,39 @@ public class ContentRepository extends BaseDao {
     return queryForObject(sql, CONTENT_IMAGE_ROW_MAPPER, params);
   }
 
+  /**
+   * True iff {@code userId} may SEE {@code imageId}: the image holds at least one visible
+   * membership ({@code collection_content.visible = true}) in a collection that is either LISTED or
+   * one the user holds a {@code user_collection} membership for. Mirrors the public-read predicate
+   * used by {@code CollectionRepository.findReferencedCollectionsByParentId} ({@code cc.visible =
+   * true AND c.visibility = 'LISTED'}) and the membership predicate behind {@code
+   * UserCollectionService.canView}. UNLISTED/HIDDEN-only images are not visible unless the caller
+   * holds an explicit membership. Gates {@code UserSavesService.add} so a viewer cannot save (and
+   * thereby exfiltrate) an image from a gallery they cannot access.
+   */
+  @Transactional(readOnly = true)
+  public boolean isImageVisibleToUser(Long imageId, Long userId) {
+    String sql =
+        """
+        SELECT EXISTS (
+          SELECT 1
+          FROM collection_content cc
+          JOIN collection col ON col.id = cc.collection_id
+          WHERE cc.content_id = :imageId
+            AND cc.visible = true
+            AND (
+              col.visibility = 'LISTED'
+              OR EXISTS (
+                SELECT 1 FROM user_collection uc
+                WHERE uc.collection_id = col.id AND uc.user_id = :userId))
+        )
+        """;
+    MapSqlParameterSource params =
+        createParameterSource().addValue("imageId", imageId).addValue("userId", userId);
+    return Boolean.TRUE.equals(
+        queryForObject(sql, (rs, n) -> rs.getBoolean(1), params).orElse(false));
+  }
+
   @Transactional(readOnly = true)
   public List<ContentImageEntity> findImagesByIds(List<Long> ids) {
     if (ids == null || ids.isEmpty()) {
@@ -256,13 +289,29 @@ public class ContentRepository extends BaseDao {
     return query(sql, CONTENT_IMAGE_ROW_MAPPER, params);
   }
 
-  /** A user's saved images as full entities, newest-saved first. Ignores gallery access. */
+  /**
+   * A user's saved images as full entities, newest-saved first. Applies the same visibility gate as
+   * {@link #isImageVisibleToUser}: an image is returned only while it still holds a visible
+   * membership in a LISTED collection or one the user has explicit access to. Defense-in-depth — a
+   * save made while an image was visible drops out of the list if the owner later hides it, and it
+   * closes the read side even if a row was ever inserted without the write-side check.
+   */
   @Transactional(readOnly = true)
   public List<ContentImageEntity> findSavedImagesByUserId(Long userId) {
     String sql =
         SELECT_CONTENT_IMAGE
             + " JOIN user_saved_image usi ON usi.image_id = c.id"
             + " WHERE usi.user_id = :userId"
+            + "   AND EXISTS ("
+            + "     SELECT 1 FROM collection_content cc"
+            + "     JOIN collection col ON col.id = cc.collection_id"
+            + "     WHERE cc.content_id = c.id"
+            + "       AND cc.visible = true"
+            + "       AND ("
+            + "         col.visibility = 'LISTED'"
+            + "         OR EXISTS ("
+            + "           SELECT 1 FROM user_collection uc"
+            + "           WHERE uc.collection_id = col.id AND uc.user_id = :userId)))"
             + " ORDER BY usi.created_at DESC";
     MapSqlParameterSource params = createParameterSource().addValue("userId", userId);
     return query(sql, CONTENT_IMAGE_ROW_MAPPER, params);

--- a/src/main/java/edens/zac/portfolio/backend/dao/ContentRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/ContentRepository.java
@@ -256,6 +256,18 @@ public class ContentRepository extends BaseDao {
     return query(sql, CONTENT_IMAGE_ROW_MAPPER, params);
   }
 
+  /** A user's saved images as full entities, newest-saved first. Ignores gallery access. */
+  @Transactional(readOnly = true)
+  public List<ContentImageEntity> findSavedImagesByUserId(Long userId) {
+    String sql =
+        SELECT_CONTENT_IMAGE
+            + " JOIN user_saved_image usi ON usi.image_id = c.id"
+            + " WHERE usi.user_id = :userId"
+            + " ORDER BY usi.created_at DESC";
+    MapSqlParameterSource params = createParameterSource().addValue("userId", userId);
+    return query(sql, CONTENT_IMAGE_ROW_MAPPER, params);
+  }
+
   /**
    * The newest image content id a person is tagged on via {@code content_image_people}, ordered by
    * EXIF capture date desc then row creation desc. Backs the {@code /user} synthetic-collection

--- a/src/main/java/edens/zac/portfolio/backend/dao/EquipmentRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/EquipmentRepository.java
@@ -210,6 +210,19 @@ public class EquipmentRepository extends BaseDao {
     }
   }
 
+  /** Update only the film metadata (is_film, default_film_format) for a camera by id. */
+  public void updateCameraFilmMetadata(Long id, Boolean isFilm, FilmFormat defaultFilmFormat) {
+    String sql =
+        "UPDATE content_cameras SET is_film = :isFilm, default_film_format = :defaultFilmFormat WHERE id = :id";
+    MapSqlParameterSource params =
+        createParameterSource()
+            .addValue("isFilm", isFilm != null ? isFilm : Boolean.FALSE)
+            .addValue(
+                "defaultFilmFormat", defaultFilmFormat != null ? defaultFilmFormat.name() : null)
+            .addValue("id", id);
+    update(sql, params);
+  }
+
   @Transactional(readOnly = true)
   public Optional<ContentCameraEntity> findCameraById(Long id) {
     String sql =

--- a/src/main/java/edens/zac/portfolio/backend/dao/TagRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/TagRepository.java
@@ -39,6 +39,7 @@ public class TagRepository extends BaseDao {
               .id(rs.getLong("id"))
               .tagName(rs.getString("tag_name"))
               .slug(rs.getString("slug"))
+              .convertedCollectionId(getLong(rs, "converted_collection_id"))
               .createdAt(getLocalDateTime(rs, "created_at"))
               .build();
 
@@ -90,7 +91,8 @@ public class TagRepository extends BaseDao {
 
   @Transactional(readOnly = true)
   public Optional<TagEntity> findByTagName(String tagName) {
-    String sql = "SELECT id, tag_name, slug, created_at FROM tag WHERE tag_name = :tagName";
+    String sql =
+        "SELECT id, tag_name, slug, converted_collection_id, created_at FROM tag WHERE tag_name = :tagName";
     MapSqlParameterSource params = createParameterSource().addValue("tagName", tagName);
     return queryForObject(sql, TAG_ROW_MAPPER, params);
   }
@@ -98,7 +100,7 @@ public class TagRepository extends BaseDao {
   @Transactional(readOnly = true)
   public Optional<TagEntity> findByTagNameIgnoreCase(String tagName) {
     String sql =
-        "SELECT id, tag_name, slug, created_at FROM tag WHERE LOWER(tag_name) = LOWER(:tagName)";
+        "SELECT id, tag_name, slug, converted_collection_id, created_at FROM tag WHERE LOWER(tag_name) = LOWER(:tagName)";
     MapSqlParameterSource params = createParameterSource().addValue("tagName", tagName);
     return queryForObject(sql, TAG_ROW_MAPPER, params);
   }
@@ -106,7 +108,7 @@ public class TagRepository extends BaseDao {
   @Transactional(readOnly = true)
   public List<TagEntity> findByTagNameContainingIgnoreCase(String searchTerm) {
     String sql =
-        "SELECT id, tag_name, slug, created_at FROM tag WHERE LOWER(tag_name) LIKE LOWER(:searchTerm) ORDER BY tag_name ASC";
+        "SELECT id, tag_name, slug, converted_collection_id, created_at FROM tag WHERE LOWER(tag_name) LIKE LOWER(:searchTerm) ORDER BY tag_name ASC";
     MapSqlParameterSource params =
         createParameterSource().addValue("searchTerm", "%" + searchTerm + "%");
     return query(sql, TAG_ROW_MAPPER, params);
@@ -114,13 +116,15 @@ public class TagRepository extends BaseDao {
 
   @Transactional(readOnly = true)
   public List<TagEntity> findAllByOrderByTagNameAsc() {
-    String sql = "SELECT id, tag_name, slug, created_at FROM tag ORDER BY tag_name ASC";
+    String sql =
+        "SELECT id, tag_name, slug, converted_collection_id, created_at FROM tag ORDER BY tag_name ASC";
     return query(sql, TAG_ROW_MAPPER);
   }
 
   @Transactional(readOnly = true)
   public Optional<TagEntity> findById(Long id) {
-    String sql = "SELECT id, tag_name, slug, created_at FROM tag WHERE id = :id";
+    String sql =
+        "SELECT id, tag_name, slug, converted_collection_id, created_at FROM tag WHERE id = :id";
     MapSqlParameterSource params = createParameterSource().addValue("id", id);
     return queryForObject(sql, TAG_ROW_MAPPER, params);
   }
@@ -143,7 +147,8 @@ public class TagRepository extends BaseDao {
 
   @Transactional(readOnly = true)
   public Optional<TagEntity> findBySlug(String slug) {
-    String sql = "SELECT id, tag_name, slug, created_at FROM tag WHERE slug = :slug";
+    String sql =
+        "SELECT id, tag_name, slug, converted_collection_id, created_at FROM tag WHERE slug = :slug";
     MapSqlParameterSource params = createParameterSource().addValue("slug", slug);
     return queryForObject(sql, TAG_ROW_MAPPER, params);
   }
@@ -177,6 +182,15 @@ public class TagRepository extends BaseDao {
       update(sql, params);
       return entity;
     }
+  }
+
+  /** Stamps the collection a tag was promoted into (or null to clear). */
+  @Transactional
+  public void updateConvertedCollectionId(Long tagId, Long collectionId) {
+    String sql = "UPDATE tag SET converted_collection_id = :collectionId WHERE id = :id";
+    MapSqlParameterSource params =
+        createParameterSource().addValue("id", tagId).addValue("collectionId", collectionId);
+    update(sql, params);
   }
 
   @Transactional
@@ -249,7 +263,7 @@ public class TagRepository extends BaseDao {
   public List<TagEntity> findCollectionTags(Long collectionId) {
     String sql =
         """
-        SELECT t.id, t.tag_name, t.slug, t.created_at
+        SELECT t.id, t.tag_name, t.slug, t.converted_collection_id, t.created_at
         FROM tag t
         JOIN collection_tags ct ON t.id = ct.tag_id
         WHERE ct.collection_id = :collectionId
@@ -397,7 +411,7 @@ public class TagRepository extends BaseDao {
 
     String sql =
         """
-        SELECT ct.content_id, t.id, t.tag_name, t.slug, t.created_at
+        SELECT ct.content_id, t.id, t.tag_name, t.slug, t.converted_collection_id, t.created_at
         FROM content_tags ct
         JOIN tag t ON ct.tag_id = t.id
         WHERE ct.content_id IN (:contentIds)
@@ -416,6 +430,7 @@ public class TagRepository extends BaseDao {
                   .id(rs.getLong("id"))
                   .tagName(rs.getString("tag_name"))
                   .slug(rs.getString("slug"))
+                  .convertedCollectionId(getLong(rs, "converted_collection_id"))
                   .createdAt(getLocalDateTime(rs, "created_at"))
                   .build();
           result.computeIfAbsent(contentId, k -> new ArrayList<>()).add(tag);
@@ -427,7 +442,7 @@ public class TagRepository extends BaseDao {
   public List<TagEntity> findContentTags(Long contentId) {
     String sql =
         """
-        SELECT t.id, t.tag_name, t.slug, t.created_at
+        SELECT t.id, t.tag_name, t.slug, t.converted_collection_id, t.created_at
         FROM tag t
         JOIN content_tags ct ON t.id = ct.tag_id
         WHERE ct.content_id = :contentId

--- a/src/main/java/edens/zac/portfolio/backend/dao/UserFollowedCollectionRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/UserFollowedCollectionRepository.java
@@ -1,0 +1,61 @@
+package edens.zac.portfolio.backend.dao;
+
+import edens.zac.portfolio.backend.entity.UserFollowedCollectionEntity;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/** JDBC access to {@code user_followed_collection}. Mirrors the BaseDao style. */
+@Component
+@Slf4j
+public class UserFollowedCollectionRepository extends BaseDao {
+
+  public UserFollowedCollectionRepository(JdbcTemplate jdbcTemplate) {
+    super(jdbcTemplate);
+  }
+
+  /**
+   * Insert a follow; idempotent via {@code ON CONFLICT DO NOTHING} on the (user, collection) PK.
+   */
+  @Transactional
+  public void insert(UserFollowedCollectionEntity entity) {
+    String sql =
+        """
+        INSERT INTO user_followed_collection (user_id, collection_id)
+        VALUES (:userId, :collectionId)
+        ON CONFLICT (user_id, collection_id) DO NOTHING
+        """;
+    MapSqlParameterSource params =
+        createParameterSource()
+            .addValue("userId", entity.getUserId())
+            .addValue("collectionId", entity.getCollectionId());
+    update(sql, params);
+  }
+
+  /** Remove a follow. Returns the number of rows deleted (0 if it was not followed). */
+  @Transactional
+  public int deleteByUserIdAndCollectionId(Long userId, Long collectionId) {
+    String sql =
+        "DELETE FROM user_followed_collection "
+            + "WHERE user_id = :userId AND collection_id = :collectionId";
+    MapSqlParameterSource params =
+        createParameterSource().addValue("userId", userId).addValue("collectionId", collectionId);
+    return update(sql, params);
+  }
+
+  /** The collection ids a user follows, newest-followed first. */
+  @Transactional(readOnly = true)
+  public List<Long> findCollectionIdsByUserId(Long userId) {
+    String sql =
+        """
+        SELECT collection_id FROM user_followed_collection
+        WHERE user_id = :userId
+        ORDER BY created_at DESC
+        """;
+    MapSqlParameterSource params = createParameterSource().addValue("userId", userId);
+    return query(sql, (rs, n) -> rs.getLong("collection_id"), params);
+  }
+}

--- a/src/main/java/edens/zac/portfolio/backend/dao/UserSavedImageRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/UserSavedImageRepository.java
@@ -1,0 +1,57 @@
+package edens.zac.portfolio.backend.dao;
+
+import edens.zac.portfolio.backend.entity.UserSavedImageEntity;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/** JDBC access to {@code user_saved_image}. Mirrors the BaseDao style. */
+@Component
+@Slf4j
+public class UserSavedImageRepository extends BaseDao {
+
+  public UserSavedImageRepository(JdbcTemplate jdbcTemplate) {
+    super(jdbcTemplate);
+  }
+
+  /** Insert a save; idempotent via {@code ON CONFLICT DO NOTHING} on the (user, image) PK. */
+  @Transactional
+  public void insert(UserSavedImageEntity entity) {
+    String sql =
+        """
+        INSERT INTO user_saved_image (user_id, image_id)
+        VALUES (:userId, :imageId)
+        ON CONFLICT (user_id, image_id) DO NOTHING
+        """;
+    MapSqlParameterSource params =
+        createParameterSource()
+            .addValue("userId", entity.getUserId())
+            .addValue("imageId", entity.getImageId());
+    update(sql, params);
+  }
+
+  /** Remove a save. Returns the number of rows deleted (0 if it was not saved). */
+  @Transactional
+  public int deleteByUserIdAndImageId(Long userId, Long imageId) {
+    String sql = "DELETE FROM user_saved_image WHERE user_id = :userId AND image_id = :imageId";
+    MapSqlParameterSource params =
+        createParameterSource().addValue("userId", userId).addValue("imageId", imageId);
+    return update(sql, params);
+  }
+
+  /** The image ids a user has saved, newest-saved first. */
+  @Transactional(readOnly = true)
+  public List<Long> findImageIdsByUserId(Long userId) {
+    String sql =
+        """
+        SELECT image_id FROM user_saved_image
+        WHERE user_id = :userId
+        ORDER BY created_at DESC
+        """;
+    MapSqlParameterSource params = createParameterSource().addValue("userId", userId);
+    return query(sql, (rs, n) -> rs.getLong("image_id"), params);
+  }
+}

--- a/src/main/java/edens/zac/portfolio/backend/entity/TagEntity.java
+++ b/src/main/java/edens/zac/portfolio/backend/entity/TagEntity.java
@@ -30,6 +30,9 @@ public class TagEntity {
 
   @Size(min = 1, max = 100) private String slug;
 
+  /** Set once the tag is promoted to a real collection; the tag-view then stops rendering. */
+  private Long convertedCollectionId;
+
   private LocalDateTime createdAt;
 
   /**

--- a/src/main/java/edens/zac/portfolio/backend/entity/UserFollowedCollectionEntity.java
+++ b/src/main/java/edens/zac/portfolio/backend/entity/UserFollowedCollectionEntity.java
@@ -1,0 +1,19 @@
+package edens.zac.portfolio.backend.entity;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** One row of {@code user_followed_collection}: a single (user, collection) follow. */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserFollowedCollectionEntity {
+
+  private Long userId;
+  private Long collectionId;
+  private LocalDateTime createdAt;
+}

--- a/src/main/java/edens/zac/portfolio/backend/entity/UserSavedImageEntity.java
+++ b/src/main/java/edens/zac/portfolio/backend/entity/UserSavedImageEntity.java
@@ -1,0 +1,19 @@
+package edens.zac.portfolio.backend.entity;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** One row of {@code user_saved_image}: a single (user, content image) bookmark. */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserSavedImageEntity {
+
+  private Long userId;
+  private Long imageId;
+  private LocalDateTime createdAt;
+}

--- a/src/main/java/edens/zac/portfolio/backend/model/CollectionModel.java
+++ b/src/main/java/edens/zac/portfolio/backend/model/CollectionModel.java
@@ -53,6 +53,9 @@ public class CollectionModel {
 
   private DisplayMode displayMode;
 
+  /** True for a synthetic tag-view model; unset/false for real collections. */
+  private boolean derived;
+
   @Min(1) private Integer rowsWide;
 
   // === Pagination ===

--- a/src/main/java/edens/zac/portfolio/backend/model/SaveAsCollectionRequest.java
+++ b/src/main/java/edens/zac/portfolio/backend/model/SaveAsCollectionRequest.java
@@ -1,0 +1,10 @@
+package edens.zac.portfolio.backend.model;
+
+import edens.zac.portfolio.backend.types.CollectionType;
+import edens.zac.portfolio.backend.types.CollectionVisibility;
+
+/**
+ * Request body for promoting a tag-view into a real collection. Both fields are optional; the
+ * service defaults type to PORTFOLIO and visibility to UNLISTED.
+ */
+public record SaveAsCollectionRequest(CollectionType type, CollectionVisibility visibility) {}

--- a/src/main/java/edens/zac/portfolio/backend/model/SaveAsCollectionRequest.java
+++ b/src/main/java/edens/zac/portfolio/backend/model/SaveAsCollectionRequest.java
@@ -4,7 +4,18 @@ import edens.zac.portfolio.backend.types.CollectionType;
 import edens.zac.portfolio.backend.types.CollectionVisibility;
 
 /**
- * Request body for promoting a tag-view into a real collection. Both fields are optional; the
+ * Request body for promoting a tag-view into a real collection. All fields are optional; the
  * service defaults type to PORTFOLIO and visibility to UNLISTED.
+ *
+ * <p>{@code includeHidden} widens the member snapshot to also copy HIDDEN / password-gated members.
+ * It defaults to false so a promote never silently copies dev-only or password-protected content
+ * into a new collection; an admin must explicitly opt in.
  */
-public record SaveAsCollectionRequest(CollectionType type, CollectionVisibility visibility) {}
+public record SaveAsCollectionRequest(
+    CollectionType type, CollectionVisibility visibility, Boolean includeHidden) {
+
+  /** True only when the caller explicitly opted into copying HIDDEN / password-gated members. */
+  public boolean includeHiddenMembers() {
+    return Boolean.TRUE.equals(includeHidden);
+  }
+}

--- a/src/main/java/edens/zac/portfolio/backend/services/ImageProcessingService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/ImageProcessingService.java
@@ -9,6 +9,7 @@ import edens.zac.portfolio.backend.entity.ContentImageEntity;
 import edens.zac.portfolio.backend.entity.ContentLensEntity;
 import edens.zac.portfolio.backend.services.validator.ContentValidator;
 import edens.zac.portfolio.backend.types.ContentType;
+import edens.zac.portfolio.backend.types.FilmFormat;
 import java.awt.Graphics2D;
 import java.awt.RenderingHints;
 import java.awt.image.BufferedImage;
@@ -457,6 +458,17 @@ public class ImageProcessingService {
 
     String cameraName = metadata.get("camera");
     String bodySerialNumber = metadata.get("bodySerialNumber");
+    // Some film scanners / medium-format backs report a generic capture-software
+    // name in the EXIF Model tag instead of the physical body. Remap to the real
+    // camera and set film defaults before resolving the camera entity.
+    FilmCameraDefaults filmDefaults = resolveFilmCameraDefaults(cameraName, entity);
+    if (filmDefaults != null) {
+      entity.setIsFilm(true);
+      entity.setFilmFormat(filmDefaults.filmFormat());
+      cameraName = filmDefaults.cameraName();
+      // The EXIF serial belongs to the scanner, not the remapped body.
+      bodySerialNumber = filmDefaults.remapped() ? null : bodySerialNumber;
+    }
     if (cameraName != null && !cameraName.trim().isEmpty()) {
       entity.setCamera(createCamera(cameraName, bodySerialNumber, null));
     }
@@ -465,6 +477,53 @@ public class ImageProcessingService {
     if (lensName != null && !lensName.trim().isEmpty()) {
       entity.setLens(createLens(lensName, lensSerialNumber, null));
     }
+  }
+
+  /** Resolved camera name and film format for a recognized film scanner/back. */
+  private record FilmCameraDefaults(String cameraName, FilmFormat filmFormat, boolean remapped) {}
+
+  /**
+   * Hardcoded film-camera detection. Maps generic EXIF Model names reported by film scanners and
+   * medium-format backs to the physical camera and its film format.
+   *
+   * <ul>
+   *   <li>"EZ Controller" (Hasselblad/Flextight scan software) -> 120 film. A square (1:1) frame is
+   *       a Hasselblad 500cm; a wider frame (closer to 645 / 5x7) is a Mamiya 645 Pro.
+   *   <li>"OpticFilm 8300i" (Plustek 35mm scanner) -> 35mm film, camera name unchanged.
+   * </ul>
+   *
+   * @param cameraName the raw EXIF camera name
+   * @param entity the image entity (dimensions already applied) used for aspect-ratio checks
+   * @return the film defaults, or null if the camera is not a recognized film source
+   */
+  private FilmCameraDefaults resolveFilmCameraDefaults(
+      String cameraName, ContentImageEntity entity) {
+    if (cameraName == null) {
+      return null;
+    }
+    String name = cameraName.trim();
+    if ("EZ Controller".equalsIgnoreCase(name)) {
+      String body = isSquareAspectRatio(entity) ? "Hasselblad 500cm" : "Mamiya 645 Pro";
+      return new FilmCameraDefaults(body, FilmFormat.MM_120, true);
+    }
+    if ("OpticFilm 8300i".equalsIgnoreCase(name)) {
+      return new FilmCameraDefaults(name, FilmFormat.MM_35, false);
+    }
+    return null;
+  }
+
+  /**
+   * Whether the image is effectively square (Hasselblad 6x6). A 645 or 5x7 frame has a ratio of
+   * ~1.33-1.4, so a modest tolerance above 1.0 cleanly separates the two.
+   */
+  private boolean isSquareAspectRatio(ContentImageEntity entity) {
+    Integer width = entity.getImageWidth();
+    Integer height = entity.getImageHeight();
+    if (width == null || height == null || width <= 0 || height <= 0) {
+      return false;
+    }
+    double ratio = (double) Math.max(width, height) / Math.min(width, height);
+    return ratio <= 1.15;
   }
 
   /**

--- a/src/main/java/edens/zac/portfolio/backend/services/MetadataService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/MetadataService.java
@@ -190,8 +190,21 @@ public class MetadataService {
       }
     }
 
-    if (equipmentRepository.existsByCameraNameIgnoreCase(cameraName)) {
-      throw new DataIntegrityViolationException("Camera already exists: " + cameraName);
+    // Upsert: if the camera already exists (e.g. auto-created during a film upload),
+    // apply the requested film metadata instead of rejecting the request.
+    Optional<ContentCameraEntity> existingByName =
+        equipmentRepository.findCameraByNameIgnoreCase(cameraName);
+    if (existingByName.isPresent()) {
+      ContentCameraEntity existing = existingByName.get();
+      Boolean newIsFilm = isFilm != null ? isFilm : existing.getIsFilm();
+      FilmFormat newFilmFormat =
+          defaultFilmFormat != null ? defaultFilmFormat : existing.getDefaultFilmFormat();
+      equipmentRepository.updateCameraFilmMetadata(existing.getId(), newIsFilm, newFilmFormat);
+      return Map.of(
+          "id", existing.getId(),
+          "cameraName", existing.getCameraName(),
+          "isFilm", newIsFilm != null ? newIsFilm : Boolean.FALSE,
+          "createdAt", existing.getCreatedAt());
     }
 
     ContentCameraEntity camera =

--- a/src/main/java/edens/zac/portfolio/backend/services/SyntheticCollectionResolver.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/SyntheticCollectionResolver.java
@@ -63,13 +63,7 @@ public class SyntheticCollectionResolver {
       throw new IllegalArgumentException("Not a synthetic slug: " + slug);
     }
 
-    List<CollectionVisibility> allowed =
-        isLocalEnvironment
-            ? List.of(
-                CollectionVisibility.LISTED,
-                CollectionVisibility.UNLISTED,
-                CollectionVisibility.HIDDEN)
-            : List.of(CollectionVisibility.LISTED);
+    List<CollectionVisibility> allowed = CollectionVisibility.visibleScope(isLocalEnvironment);
 
     // "all-client-galleries" includes PARENT collections that have ≥1 CLIENT_GALLERY child
     // (e.g. wedding wrappers with ceremony/reception sub-galleries) so they appear alongside

--- a/src/main/java/edens/zac/portfolio/backend/services/TagService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/TagService.java
@@ -1,0 +1,112 @@
+package edens.zac.portfolio.backend.services;
+
+import edens.zac.portfolio.backend.config.ResourceNotFoundException;
+import edens.zac.portfolio.backend.dao.CollectionRepository;
+import edens.zac.portfolio.backend.dao.TagRepository;
+import edens.zac.portfolio.backend.entity.CollectionContentEntity;
+import edens.zac.portfolio.backend.entity.CollectionEntity;
+import edens.zac.portfolio.backend.entity.TagEntity;
+import edens.zac.portfolio.backend.model.CollectionRequests;
+import edens.zac.portfolio.backend.model.SaveAsCollectionRequest;
+import edens.zac.portfolio.backend.types.CollectionType;
+import edens.zac.portfolio.backend.types.CollectionVisibility;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Tag admin operations: promoting a tag-view into a real, editable collection. */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TagService {
+
+  private static final List<CollectionVisibility> ALL_VISIBILITIES =
+      List.of(
+          CollectionVisibility.LISTED, CollectionVisibility.UNLISTED, CollectionVisibility.HIDDEN);
+
+  private final TagRepository tagRepository;
+  private final CollectionRepository collectionRepository;
+  private final CollectionService collectionService;
+
+  /**
+   * Promotes a tag into a real collection at {@code tag.slug}: creates the collection, snapshots
+   * the tag's current members into it, and flags the tag converted so its tag-view stops rendering.
+   *
+   * @param tagId tag to convert
+   * @param request optional type/visibility (default PORTFOLIO / UNLISTED)
+   * @return the new collection in the same shape {@code createChildCollection} returns
+   */
+  @Transactional
+  public CollectionRequests.UpdateResponse convertTagToCollection(
+      Long tagId, SaveAsCollectionRequest request) {
+    TagEntity tag =
+        tagRepository
+            .findById(tagId)
+            .orElseThrow(() -> new ResourceNotFoundException("Tag not found with ID: " + tagId));
+
+    if (tag.getConvertedCollectionId() != null) {
+      throw new IllegalStateException("Tag " + tagId + " is already converted to a collection");
+    }
+    if (collectionRepository.findBySlug(tag.getSlug()).isPresent()) {
+      throw new IllegalStateException("A collection already owns slug '" + tag.getSlug() + "'");
+    }
+
+    CollectionType type =
+        request != null && request.type() != null ? request.type() : CollectionType.PORTFOLIO;
+    CollectionVisibility visibility =
+        request != null && request.visibility() != null
+            ? request.visibility()
+            : CollectionVisibility.UNLISTED;
+
+    // Create the collection, then take over the tag's slug and requested visibility.
+    CollectionRequests.UpdateResponse created =
+        collectionService.createCollection(new CollectionRequests.Create(type, tag.getTagName()));
+    Long newCollectionId = created.collection().getId();
+
+    CollectionEntity newCollection =
+        collectionRepository
+            .findById(newCollectionId)
+            .orElseThrow(
+                () ->
+                    new ResourceNotFoundException(
+                        "Created collection not found with ID: " + newCollectionId));
+    newCollection.setSlug(tag.getSlug());
+    newCollection.setVisibility(visibility);
+    collectionRepository.save(newCollection);
+
+    snapshotMembers(tagId, newCollectionId);
+
+    tagRepository.updateConvertedCollectionId(tagId, newCollectionId);
+    log.info(
+        "Converted tag {} into collection {} at slug '{}'", tagId, newCollectionId, tag.getSlug());
+
+    return collectionService.getUpdateCollectionData(tag.getSlug());
+  }
+
+  /** Snapshots tagged member collections (first) then tagged images into collection_content. */
+  private void snapshotMembers(Long tagId, Long collectionId) {
+    List<CollectionEntity> memberCollections =
+        tagRepository.findCollectionsByTagId(tagId, ALL_VISIBILITIES);
+    for (CollectionEntity member : memberCollections) {
+      collectionService.linkCollectionToParent(collectionId, member.getId());
+    }
+
+    List<Long> imageContentIds = tagRepository.findImageContentByTagId(tagId, ALL_VISIBILITIES);
+    Integer maxOrderIndex = collectionRepository.getMaxOrderIndexForCollection(collectionId);
+    int orderIndex = maxOrderIndex != null ? maxOrderIndex + 1 : 0;
+    for (Long imageContentId : imageContentIds) {
+      collectionRepository.saveContent(
+          CollectionContentEntity.builder()
+              .collectionId(collectionId)
+              .contentId(imageContentId)
+              .orderIndex(orderIndex++)
+              .visible(true)
+              .createdAt(LocalDateTime.now())
+              .updatedAt(LocalDateTime.now())
+              .build());
+    }
+  }
+}

--- a/src/main/java/edens/zac/portfolio/backend/services/TagService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/TagService.java
@@ -23,9 +23,13 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class TagService {
 
-  private static final List<CollectionVisibility> ALL_VISIBILITIES =
-      List.of(
-          CollectionVisibility.LISTED, CollectionVisibility.UNLISTED, CollectionVisibility.HIDDEN);
+  /**
+   * Default snapshot scope for a promote: prod-visible members only (LISTED + UNLISTED), EXCLUDING
+   * HIDDEN. HIDDEN is dev-only, so copying it into a new collection would leak dev-gated content;
+   * an admin must explicitly opt in via {@code includeHidden} to capture it.
+   */
+  private static final List<CollectionVisibility> DEFAULT_SNAPSHOT_SCOPE =
+      List.of(CollectionVisibility.LISTED, CollectionVisibility.UNLISTED);
 
   private final TagRepository tagRepository;
   private final CollectionRepository collectionRepository;
@@ -77,7 +81,7 @@ public class TagService {
     newCollection.setVisibility(visibility);
     collectionRepository.save(newCollection);
 
-    snapshotMembers(tagId, newCollectionId);
+    snapshotMembers(tagId, newCollectionId, request);
 
     tagRepository.updateConvertedCollectionId(tagId, newCollectionId);
     log.info(
@@ -86,15 +90,31 @@ public class TagService {
     return collectionService.getUpdateCollectionData(tag.getSlug());
   }
 
-  /** Snapshots tagged member collections (first) then tagged images into collection_content. */
-  private void snapshotMembers(Long tagId, Long collectionId) {
-    List<CollectionEntity> memberCollections =
-        tagRepository.findCollectionsByTagId(tagId, ALL_VISIBILITIES);
+  /**
+   * Snapshots tagged member collections (first) then tagged images into collection_content.
+   *
+   * <p>Scope defaults to {@link #DEFAULT_SNAPSHOT_SCOPE} (LISTED + UNLISTED). A HIDDEN member — or
+   * a password-gated collection — is only captured when the request explicitly opts in via {@code
+   * includeHidden}, so a promote never silently copies dev-only or password-protected content into
+   * the new collection. Image ids are derived from a visible membership in an in-scope collection
+   * (see {@code TagRepository.findImageContentByTagId}), so HIDDEN-only images are already excluded
+   * by the same scope.
+   */
+  private void snapshotMembers(Long tagId, Long collectionId, SaveAsCollectionRequest request) {
+    boolean includeHidden = request != null && request.includeHiddenMembers();
+    List<CollectionVisibility> scope =
+        includeHidden ? CollectionVisibility.visibleScope(true) : DEFAULT_SNAPSHOT_SCOPE;
+
+    List<CollectionEntity> memberCollections = tagRepository.findCollectionsByTagId(tagId, scope);
     for (CollectionEntity member : memberCollections) {
+      // Skip password-gated member collections unless explicitly opted in.
+      if (!includeHidden && member.getGalleryPassword() != null) {
+        continue;
+      }
       collectionService.linkCollectionToParent(collectionId, member.getId());
     }
 
-    List<Long> imageContentIds = tagRepository.findImageContentByTagId(tagId, ALL_VISIBILITIES);
+    List<Long> imageContentIds = tagRepository.findImageContentByTagId(tagId, scope);
     Integer maxOrderIndex = collectionRepository.getMaxOrderIndexForCollection(collectionId);
     int orderIndex = maxOrderIndex != null ? maxOrderIndex + 1 : 0;
     for (Long imageContentId : imageContentIds) {

--- a/src/main/java/edens/zac/portfolio/backend/services/TagViewResolver.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/TagViewResolver.java
@@ -52,6 +52,12 @@ public class TagViewResolver {
     }
     TagEntity tag = tagOpt.get();
 
+    // A converted tag has handed its slug to a real collection; that collection now renders
+    // instead.
+    if (tag.getConvertedCollectionId() != null) {
+      return Optional.empty();
+    }
+
     List<CollectionVisibility> allowed =
         isLocalEnvironment
             ? List.of(
@@ -87,6 +93,7 @@ public class TagViewResolver {
             .slug(tag.getSlug())
             .title(tag.getTagName())
             .type(CollectionType.PARENT)
+            .derived(true)
             .visibility(CollectionVisibility.LISTED)
             .coverImage(representativeCover(memberCollections, memberImages))
             .content(content)

--- a/src/main/java/edens/zac/portfolio/backend/services/TagViewResolver.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/TagViewResolver.java
@@ -12,7 +12,10 @@ import edens.zac.portfolio.backend.types.CollectionType;
 import edens.zac.portfolio.backend.types.CollectionVisibility;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -58,13 +61,7 @@ public class TagViewResolver {
       return Optional.empty();
     }
 
-    List<CollectionVisibility> allowed =
-        isLocalEnvironment
-            ? List.of(
-                CollectionVisibility.LISTED,
-                CollectionVisibility.UNLISTED,
-                CollectionVisibility.HIDDEN)
-            : List.of(CollectionVisibility.LISTED);
+    List<CollectionVisibility> allowed = CollectionVisibility.visibleScope(isLocalEnvironment);
 
     // Members: tagged collections first (deliberate collection-level tags), then tagged images.
     List<CollectionEntity> collectionRows =
@@ -72,8 +69,16 @@ public class TagViewResolver {
     List<CollectionModel> memberCollections =
         collectionProcessingUtil.batchConvertToBasicModels(collectionRows);
 
+    // findImageContentByTagId returns ids in the intended order, but findImagesByIds uses an
+    // unordered "WHERE c.id IN (:ids)" (shared by 4 other callers, so it stays unordered).
+    // Re-key the fetched entities by id and re-stream over the ordered id list to restore order,
+    // dropping any id that resolved to no entity.
     List<Long> imageContentIds = tagRepository.findImageContentByTagId(tag.getId(), allowed);
-    List<ContentImageEntity> imageEntities = contentRepository.findImagesByIds(imageContentIds);
+    Map<Long, ContentImageEntity> imagesById =
+        contentRepository.findImagesByIds(imageContentIds).stream()
+            .collect(Collectors.toMap(ContentImageEntity::getId, image -> image));
+    List<ContentImageEntity> imageEntities =
+        imageContentIds.stream().map(imagesById::get).filter(Objects::nonNull).toList();
     List<ContentModels.Image> memberImages =
         contentModelConverter.batchConvertImageEntitiesToModels(imageEntities);
 

--- a/src/main/java/edens/zac/portfolio/backend/services/UserFollowsService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/UserFollowsService.java
@@ -1,0 +1,40 @@
+package edens.zac.portfolio.backend.services;
+
+import edens.zac.portfolio.backend.dao.UserFollowedCollectionRepository;
+import edens.zac.portfolio.backend.entity.UserFollowedCollectionEntity;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Per-user followed collections ("Your Space"). Any logged-in user may follow any collection: there
+ * is no per-collection access check. Auth is enforced at the controller (principal null-check).
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UserFollowsService {
+
+  private final UserFollowedCollectionRepository userFollowedCollectionRepository;
+
+  /** Add a collection to the user's follows. Idempotent. */
+  @Transactional
+  public void add(Long userId, Long collectionId) {
+    userFollowedCollectionRepository.insert(
+        UserFollowedCollectionEntity.builder().userId(userId).collectionId(collectionId).build());
+  }
+
+  /** Remove a collection from the user's own follows. No-op if it was not followed. */
+  @Transactional
+  public void remove(Long userId, Long collectionId) {
+    userFollowedCollectionRepository.deleteByUserIdAndCollectionId(userId, collectionId);
+  }
+
+  /** The collection ids the user follows, newest-followed first. */
+  @Transactional(readOnly = true)
+  public List<Long> listFollowedCollectionIds(Long userId) {
+    return userFollowedCollectionRepository.findCollectionIdsByUserId(userId);
+  }
+}

--- a/src/main/java/edens/zac/portfolio/backend/services/UserFollowsService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/UserFollowsService.java
@@ -1,5 +1,7 @@
 package edens.zac.portfolio.backend.services;
 
+import edens.zac.portfolio.backend.config.ResourceNotFoundException;
+import edens.zac.portfolio.backend.dao.CollectionRepository;
 import edens.zac.portfolio.backend.dao.UserFollowedCollectionRepository;
 import edens.zac.portfolio.backend.entity.UserFollowedCollectionEntity;
 import java.util.List;
@@ -18,10 +20,18 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserFollowsService {
 
   private final UserFollowedCollectionRepository userFollowedCollectionRepository;
+  private final CollectionRepository collectionRepository;
 
-  /** Add a collection to the user's follows. Idempotent. */
+  /**
+   * Add a collection to the user's follows. Idempotent. Rejects a nonexistent collection with a 404
+   * (via {@link ResourceNotFoundException}) rather than letting the missing-row FK surface as a
+   * 409.
+   */
   @Transactional
   public void add(Long userId, Long collectionId) {
+    if (collectionRepository.findById(collectionId).isEmpty()) {
+      throw new ResourceNotFoundException("Collection not found with ID: " + collectionId);
+    }
     userFollowedCollectionRepository.insert(
         UserFollowedCollectionEntity.builder().userId(userId).collectionId(collectionId).build());
   }

--- a/src/main/java/edens/zac/portfolio/backend/services/UserSavesService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/UserSavesService.java
@@ -1,0 +1,40 @@
+package edens.zac.portfolio.backend.services;
+
+import edens.zac.portfolio.backend.dao.UserSavedImageRepository;
+import edens.zac.portfolio.backend.entity.UserSavedImageEntity;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Per-user saved images ("Your Space" bookmarks). Any logged-in user may save any image: there is
+ * no per-collection access check. Auth is enforced at the controller (principal null-check).
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UserSavesService {
+
+  private final UserSavedImageRepository userSavedImageRepository;
+
+  /** Add an image to the user's saves. Idempotent. */
+  @Transactional
+  public void add(Long userId, Long imageId) {
+    userSavedImageRepository.insert(
+        UserSavedImageEntity.builder().userId(userId).imageId(imageId).build());
+  }
+
+  /** Remove an image from the user's own saves. No-op if it was not saved. */
+  @Transactional
+  public void remove(Long userId, Long imageId) {
+    userSavedImageRepository.deleteByUserIdAndImageId(userId, imageId);
+  }
+
+  /** The image ids the user has saved, newest-saved first. */
+  @Transactional(readOnly = true)
+  public List<Long> listSavedImageIds(Long userId) {
+    return userSavedImageRepository.findImageIdsByUserId(userId);
+  }
+}

--- a/src/main/java/edens/zac/portfolio/backend/services/UserSavesService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/UserSavesService.java
@@ -13,8 +13,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Per-user saved images ("Your Space" bookmarks). Any logged-in user may save any image: there is
- * no per-collection access check. Auth is enforced at the controller (principal null-check).
+ * Per-user saved images ("Your Space" bookmarks). A logged-in user may save an image only if they
+ * may SEE it — i.e. it holds a visible membership in a LISTED collection or one the caller has an
+ * explicit {@code user_collection} membership for (see {@link
+ * ContentRepository#isImageVisibleToUser}). This prevents a client-gallery user from POSTing an
+ * arbitrary image id to exfiltrate images from HIDDEN/UNLISTED collections or another client's
+ * gated gallery via the saved-images read. Auth (identity) is enforced at the controller (principal
+ * null-check); this service enforces per-image visibility.
  */
 @Service
 @RequiredArgsConstructor
@@ -26,12 +31,15 @@ public class UserSavesService {
   private final ContentModelConverter contentModelConverter;
 
   /**
-   * Add an image to the user's saves. Idempotent. Rejects a nonexistent image with a 404 (via
-   * {@link ResourceNotFoundException}) rather than letting the missing-row FK surface as a 409.
+   * Add an image to the user's saves. Idempotent. Rejects an image the caller may not see with a
+   * 404 (via {@link ResourceNotFoundException}) — deliberately 404 not 403, so a sequential id scan
+   * cannot distinguish "missing" from "exists but hidden" (no enumeration oracle). The visibility
+   * check subsumes the old existence guard: an id with no visible LISTED/accessible membership
+   * (including a nonexistent id) is treated as not found.
    */
   @Transactional
   public void add(Long userId, Long imageId) {
-    if (contentRepository.findImageById(imageId).isEmpty()) {
+    if (!contentRepository.isImageVisibleToUser(imageId, userId)) {
       throw new ResourceNotFoundException("Image not found with ID: " + imageId);
     }
     userSavedImageRepository.insert(

--- a/src/main/java/edens/zac/portfolio/backend/services/UserSavesService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/UserSavesService.java
@@ -1,5 +1,6 @@
 package edens.zac.portfolio.backend.services;
 
+import edens.zac.portfolio.backend.config.ResourceNotFoundException;
 import edens.zac.portfolio.backend.dao.ContentRepository;
 import edens.zac.portfolio.backend.dao.UserSavedImageRepository;
 import edens.zac.portfolio.backend.entity.ContentImageEntity;
@@ -24,9 +25,15 @@ public class UserSavesService {
   private final ContentRepository contentRepository;
   private final ContentModelConverter contentModelConverter;
 
-  /** Add an image to the user's saves. Idempotent. */
+  /**
+   * Add an image to the user's saves. Idempotent. Rejects a nonexistent image with a 404 (via
+   * {@link ResourceNotFoundException}) rather than letting the missing-row FK surface as a 409.
+   */
   @Transactional
   public void add(Long userId, Long imageId) {
+    if (contentRepository.findImageById(imageId).isEmpty()) {
+      throw new ResourceNotFoundException("Image not found with ID: " + imageId);
+    }
     userSavedImageRepository.insert(
         UserSavedImageEntity.builder().userId(userId).imageId(imageId).build());
   }

--- a/src/main/java/edens/zac/portfolio/backend/services/UserSavesService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/UserSavesService.java
@@ -1,7 +1,10 @@
 package edens.zac.portfolio.backend.services;
 
+import edens.zac.portfolio.backend.dao.ContentRepository;
 import edens.zac.portfolio.backend.dao.UserSavedImageRepository;
+import edens.zac.portfolio.backend.entity.ContentImageEntity;
 import edens.zac.portfolio.backend.entity.UserSavedImageEntity;
+import edens.zac.portfolio.backend.model.ContentModels;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserSavesService {
 
   private final UserSavedImageRepository userSavedImageRepository;
+  private final ContentRepository contentRepository;
+  private final ContentModelConverter contentModelConverter;
 
   /** Add an image to the user's saves. Idempotent. */
   @Transactional
@@ -36,5 +41,12 @@ public class UserSavesService {
   @Transactional(readOnly = true)
   public List<Long> listSavedImageIds(Long userId) {
     return userSavedImageRepository.findImageIdsByUserId(userId);
+  }
+
+  /** The user's saved images as full models, newest-saved first. */
+  @Transactional(readOnly = true)
+  public List<ContentModels.Image> listSavedImages(Long userId) {
+    List<ContentImageEntity> entities = contentRepository.findSavedImagesByUserId(userId);
+    return contentModelConverter.batchConvertImageEntitiesToModels(entities);
   }
 }

--- a/src/main/java/edens/zac/portfolio/backend/types/CollectionVisibility.java
+++ b/src/main/java/edens/zac/portfolio/backend/types/CollectionVisibility.java
@@ -2,6 +2,7 @@ package edens.zac.portfolio.backend.types;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.List;
 
 /**
  * 3-state visibility for collections. Replaces the legacy {@code visible} boolean as of V20.
@@ -16,6 +17,18 @@ public enum CollectionVisibility {
   LISTED,
   UNLISTED,
   HIDDEN;
+
+  private static final List<CollectionVisibility> PROD_SCOPE = List.of(LISTED);
+  private static final List<CollectionVisibility> LOCAL_SCOPE = List.of(LISTED, UNLISTED, HIDDEN);
+
+  /**
+   * The visibility scope a viewer may browse: prod sees LISTED only; a local/dev environment
+   * additionally sees UNLISTED and HIDDEN. Single source of truth for the {@code
+   * isLocalEnvironment} ternary previously duplicated across the resolvers and {@code TagService}.
+   */
+  public static List<CollectionVisibility> visibleScope(boolean isLocalEnvironment) {
+    return isLocalEnvironment ? LOCAL_SCOPE : PROD_SCOPE;
+  }
 
   public boolean appearsInLists() {
     return this == LISTED;

--- a/src/main/resources/db/migration/V39__add_tag_converted_collection_id.sql
+++ b/src/main/resources/db/migration/V39__add_tag_converted_collection_id.sql
@@ -1,0 +1,2 @@
+-- Links a tag to the collection it was promoted into; nulled if that collection is deleted.
+ALTER TABLE tag ADD COLUMN converted_collection_id BIGINT REFERENCES collection(id) ON DELETE SET NULL;

--- a/src/main/resources/db/migration/V40__create_user_saves_and_follows.sql
+++ b/src/main/resources/db/migration/V40__create_user_saves_and_follows.sql
@@ -1,0 +1,28 @@
+-- V40: "Your Space" — per-user saved images and followed collections.
+-- Two user-scoped join tables mirroring V33 user_selects, but with no per-collection access
+-- gate: any logged-in user may bookmark any image or follow any collection. FKs point at
+-- `users` (V35 renamed app_user -> users; V36 user_collection is the current precedent).
+
+BEGIN;
+
+CREATE TABLE user_saved_image (
+  user_id    BIGINT      NOT NULL REFERENCES users(id)         ON DELETE CASCADE,
+  image_id   BIGINT      NOT NULL REFERENCES content_image(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, image_id)
+);
+
+-- Backs the "Saved" list: a user's saves newest-first.
+CREATE INDEX idx_user_saved_image_user ON user_saved_image (user_id, created_at DESC);
+
+CREATE TABLE user_followed_collection (
+  user_id       BIGINT      NOT NULL REFERENCES users(id)      ON DELETE CASCADE,
+  collection_id BIGINT      NOT NULL REFERENCES collection(id) ON DELETE CASCADE,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, collection_id)
+);
+
+-- Backs the "Following" list: a user's follows newest-first.
+CREATE INDEX idx_user_followed_collection_user ON user_followed_collection (user_id, created_at DESC);
+
+COMMIT;

--- a/src/main/resources/db/migration/V41__unique_collection_slug.sql
+++ b/src/main/resources/db/migration/V41__unique_collection_slug.sql
@@ -1,0 +1,14 @@
+-- V41: Enforce uniqueness on collection.slug.
+--
+-- Slug is the resolution key for /{slug}: CollectionRepository.findBySlug uses queryForObject and
+-- throws if it ever matches more than one row. Two concurrent tag->collection converts (TagService)
+-- can both pass the app-level findBySlug check and insert the same slug, after which findBySlug 500s
+-- permanently for that slug. Existing slug indexes are NON-unique (V6 idx_collection_slug, V9's
+-- partial idx_collection_slug_visible); this adds the missing UNIQUE guarantee — matching V8's
+-- UNIQUE slug indexes on location/tag/content_people.
+--
+-- Safe to add without a data cleanup: duplicate slugs would ALREADY break findBySlug (queryForObject)
+-- today, so the live DB provably contains none and this index will build. The app-level findBySlug
+-- pre-check is retained as a friendly 409-with-message; this index is the last-line race guard.
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_collection_slug_unique ON collection (slug);

--- a/src/test/java/edens/zac/portfolio/backend/controller/prod/UserFollowsControllerProdTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/prod/UserFollowsControllerProdTest.java
@@ -10,6 +10,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import edens.zac.portfolio.backend.config.GlobalExceptionHandler;
+import edens.zac.portfolio.backend.config.ResourceNotFoundException;
 import edens.zac.portfolio.backend.model.AuthPrincipal;
 import edens.zac.portfolio.backend.services.UserFollowsService;
 import java.util.List;
@@ -19,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -44,6 +47,7 @@ class UserFollowsControllerProdTest {
     mockMvc =
         MockMvcBuilders.standaloneSetup(controller)
             .setCustomArgumentResolvers(new AuthenticationPrincipalArgumentResolver())
+            .setControllerAdvice(new GlobalExceptionHandler())
             .build();
   }
 
@@ -83,6 +87,41 @@ class UserFollowsControllerProdTest {
         .andExpect(status().isCreated());
 
     verify(userFollowsService).add(7L, 3L);
+  }
+
+  @Test
+  void addNullCollectionIdIsBadRequest() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/read/user/follows")
+                .with(asUser(client))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"collectionId\":null}"))
+        .andExpect(status().isBadRequest());
+
+    verify(userFollowsService, never()).add(anyLong(), anyLong());
+  }
+
+  @Test
+  void addNonexistentCollectionIsNotFound() throws Exception {
+    Mockito.doThrow(new ResourceNotFoundException("Collection not found with ID: 999"))
+        .when(userFollowsService)
+        .add(7L, 999L);
+
+    mockMvc
+        .perform(
+            post("/api/read/user/follows")
+                .with(asUser(client))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"collectionId\":999}"))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void deleteAnonymousIsUnauthorized() throws Exception {
+    mockMvc.perform(delete("/api/read/user/follows/3")).andExpect(status().isUnauthorized());
+
+    verify(userFollowsService, never()).remove(anyLong(), anyLong());
   }
 
   @Test

--- a/src/test/java/edens/zac/portfolio/backend/controller/prod/UserFollowsControllerProdTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/prod/UserFollowsControllerProdTest.java
@@ -1,0 +1,114 @@
+package edens.zac.portfolio.backend.controller.prod;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import edens.zac.portfolio.backend.model.AuthPrincipal;
+import edens.zac.portfolio.backend.services.UserFollowsService;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(MockitoExtension.class)
+class UserFollowsControllerProdTest {
+
+  @Mock private UserFollowsService userFollowsService;
+
+  @InjectMocks private UserFollowsControllerProd controller;
+
+  private MockMvc mockMvc;
+
+  private final AuthPrincipal client = new AuthPrincipal(7L, "c@b.com", true);
+
+  @BeforeEach
+  void setUp() {
+    mockMvc =
+        MockMvcBuilders.standaloneSetup(controller)
+            .setCustomArgumentResolvers(new AuthenticationPrincipalArgumentResolver())
+            .build();
+  }
+
+  @AfterEach
+  void clearContext() {
+    SecurityContextHolder.clearContext();
+  }
+
+  private RequestPostProcessor asUser(AuthPrincipal principal) {
+    return request -> {
+      SecurityContextHolder.getContext()
+          .setAuthentication(new UsernamePasswordAuthenticationToken(principal, null, List.of()));
+      return request;
+    };
+  }
+
+  @Test
+  void addAnonymousIsUnauthorized() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/read/user/follows")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"collectionId\":3}"))
+        .andExpect(status().isUnauthorized());
+
+    verify(userFollowsService, never()).add(anyLong(), anyLong());
+  }
+
+  @Test
+  void addAuthenticatedReturns201AndCallsService() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/read/user/follows")
+                .with(asUser(client))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"collectionId\":3}"))
+        .andExpect(status().isCreated());
+
+    verify(userFollowsService).add(7L, 3L);
+  }
+
+  @Test
+  void deleteReturns204() throws Exception {
+    mockMvc
+        .perform(delete("/api/read/user/follows/3").with(asUser(client)))
+        .andExpect(status().isNoContent());
+
+    verify(userFollowsService).remove(7L, 3L);
+  }
+
+  @Test
+  void listReturnsArray() throws Exception {
+    when(userFollowsService.listFollowedCollectionIds(7L)).thenReturn(List.of(3L, 4L));
+
+    mockMvc
+        .perform(get("/api/read/user/follows").with(asUser(client)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0]").value(3))
+        .andExpect(jsonPath("$[1]").value(4));
+  }
+
+  @Test
+  void listAnonymousIsUnauthorized() throws Exception {
+    mockMvc.perform(get("/api/read/user/follows")).andExpect(status().isUnauthorized());
+
+    verify(userFollowsService, never()).listFollowedCollectionIds(anyLong());
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/controller/prod/UserSavesControllerProdTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/prod/UserSavesControllerProdTest.java
@@ -10,6 +10,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import edens.zac.portfolio.backend.config.GlobalExceptionHandler;
+import edens.zac.portfolio.backend.config.ResourceNotFoundException;
 import edens.zac.portfolio.backend.model.AuthPrincipal;
 import edens.zac.portfolio.backend.model.ContentModels;
 import edens.zac.portfolio.backend.services.UserSavesService;
@@ -21,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -46,6 +49,7 @@ class UserSavesControllerProdTest {
     mockMvc =
         MockMvcBuilders.standaloneSetup(controller)
             .setCustomArgumentResolvers(new AuthenticationPrincipalArgumentResolver())
+            .setControllerAdvice(new GlobalExceptionHandler())
             .build();
   }
 
@@ -85,6 +89,41 @@ class UserSavesControllerProdTest {
         .andExpect(status().isCreated());
 
     verify(userSavesService).add(7L, 42L);
+  }
+
+  @Test
+  void addNullImageIdIsBadRequest() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/read/user/saves")
+                .with(asUser(client))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"imageId\":null}"))
+        .andExpect(status().isBadRequest());
+
+    verify(userSavesService, never()).add(anyLong(), anyLong());
+  }
+
+  @Test
+  void addNonexistentImageIsNotFound() throws Exception {
+    Mockito.doThrow(new ResourceNotFoundException("Image not found with ID: 999"))
+        .when(userSavesService)
+        .add(7L, 999L);
+
+    mockMvc
+        .perform(
+            post("/api/read/user/saves")
+                .with(asUser(client))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"imageId\":999}"))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void deleteAnonymousIsUnauthorized() throws Exception {
+    mockMvc.perform(delete("/api/read/user/saves/42")).andExpect(status().isUnauthorized());
+
+    verify(userSavesService, never()).remove(anyLong(), anyLong());
   }
 
   @Test

--- a/src/test/java/edens/zac/portfolio/backend/controller/prod/UserSavesControllerProdTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/prod/UserSavesControllerProdTest.java
@@ -11,7 +11,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import edens.zac.portfolio.backend.model.AuthPrincipal;
+import edens.zac.portfolio.backend.model.ContentModels;
 import edens.zac.portfolio.backend.services.UserSavesService;
+import edens.zac.portfolio.backend.types.ContentType;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -110,5 +112,64 @@ class UserSavesControllerProdTest {
     mockMvc.perform(get("/api/read/user/saves")).andExpect(status().isUnauthorized());
 
     verify(userSavesService, never()).listSavedImageIds(anyLong());
+  }
+
+  private ContentModels.Image imageModel(Long id, String title, String imageUrl) {
+    return new ContentModels.Image(
+        id,
+        ContentType.IMAGE,
+        title,
+        null,
+        null,
+        null,
+        imageUrl,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        List.of(),
+        null,
+        List.of(),
+        List.of(),
+        List.of());
+  }
+
+  @Test
+  void listImagesReturnsModels() throws Exception {
+    when(userSavesService.listSavedImages(7L))
+        .thenReturn(
+            List.of(
+                imageModel(42L, "Newer", "https://cdn.example.com/newer.jpg"),
+                imageModel(43L, "Older", "https://cdn.example.com/older.jpg")));
+
+    mockMvc
+        .perform(get("/api/read/user/saves/images").with(asUser(client)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].id").value(42))
+        .andExpect(jsonPath("$[0].title").value("Newer"))
+        .andExpect(jsonPath("$[0].imageUrl").value("https://cdn.example.com/newer.jpg"))
+        .andExpect(jsonPath("$[1].id").value(43));
+  }
+
+  @Test
+  void listImagesAnonymousIsUnauthorized() throws Exception {
+    mockMvc.perform(get("/api/read/user/saves/images")).andExpect(status().isUnauthorized());
+
+    verify(userSavesService, never()).listSavedImages(anyLong());
   }
 }

--- a/src/test/java/edens/zac/portfolio/backend/controller/prod/UserSavesControllerProdTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/prod/UserSavesControllerProdTest.java
@@ -1,0 +1,114 @@
+package edens.zac.portfolio.backend.controller.prod;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import edens.zac.portfolio.backend.model.AuthPrincipal;
+import edens.zac.portfolio.backend.services.UserSavesService;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(MockitoExtension.class)
+class UserSavesControllerProdTest {
+
+  @Mock private UserSavesService userSavesService;
+
+  @InjectMocks private UserSavesControllerProd controller;
+
+  private MockMvc mockMvc;
+
+  private final AuthPrincipal client = new AuthPrincipal(7L, "c@b.com", true);
+
+  @BeforeEach
+  void setUp() {
+    mockMvc =
+        MockMvcBuilders.standaloneSetup(controller)
+            .setCustomArgumentResolvers(new AuthenticationPrincipalArgumentResolver())
+            .build();
+  }
+
+  @AfterEach
+  void clearContext() {
+    SecurityContextHolder.clearContext();
+  }
+
+  private RequestPostProcessor asUser(AuthPrincipal principal) {
+    return request -> {
+      SecurityContextHolder.getContext()
+          .setAuthentication(new UsernamePasswordAuthenticationToken(principal, null, List.of()));
+      return request;
+    };
+  }
+
+  @Test
+  void addAnonymousIsUnauthorized() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/read/user/saves")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"imageId\":42}"))
+        .andExpect(status().isUnauthorized());
+
+    verify(userSavesService, never()).add(anyLong(), anyLong());
+  }
+
+  @Test
+  void addAuthenticatedReturns201AndCallsService() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/read/user/saves")
+                .with(asUser(client))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"imageId\":42}"))
+        .andExpect(status().isCreated());
+
+    verify(userSavesService).add(7L, 42L);
+  }
+
+  @Test
+  void deleteReturns204() throws Exception {
+    mockMvc
+        .perform(delete("/api/read/user/saves/42").with(asUser(client)))
+        .andExpect(status().isNoContent());
+
+    verify(userSavesService).remove(7L, 42L);
+  }
+
+  @Test
+  void listReturnsArray() throws Exception {
+    when(userSavesService.listSavedImageIds(7L)).thenReturn(List.of(42L, 43L));
+
+    mockMvc
+        .perform(get("/api/read/user/saves").with(asUser(client)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0]").value(42))
+        .andExpect(jsonPath("$[1]").value(43));
+  }
+
+  @Test
+  void listAnonymousIsUnauthorized() throws Exception {
+    mockMvc.perform(get("/api/read/user/saves")).andExpect(status().isUnauthorized());
+
+    verify(userSavesService, never()).listSavedImageIds(anyLong());
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/dao/TagRepositoryTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/dao/TagRepositoryTest.java
@@ -1,0 +1,77 @@
+package edens.zac.portfolio.backend.dao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+
+@ExtendWith(MockitoExtension.class)
+class TagRepositoryTest {
+
+  @Mock private JdbcTemplate jdbcTemplate;
+  @Mock private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+  @Captor private ArgumentCaptor<String> sqlCaptor;
+  @Captor private ArgumentCaptor<SqlParameterSource> paramsCaptor;
+
+  private TagRepository tagRepository;
+
+  @BeforeEach
+  void setUp() {
+    tagRepository = new TagRepository(jdbcTemplate);
+    setNamedParameterJdbcTemplate(tagRepository, namedParameterJdbcTemplate);
+  }
+
+  private void setNamedParameterJdbcTemplate(
+      TagRepository repository, NamedParameterJdbcTemplate template) {
+    try {
+      java.lang.reflect.Field field = BaseDao.class.getDeclaredField("namedParameterJdbcTemplate");
+      field.setAccessible(true);
+      field.set(repository, template);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to set mock NamedParameterJdbcTemplate", e);
+    }
+  }
+
+  @Test
+  void updateConvertedCollectionId_emitsUpdateSqlAndParams() {
+    when(namedParameterJdbcTemplate.update(anyString(), any(SqlParameterSource.class)))
+        .thenReturn(1);
+
+    tagRepository.updateConvertedCollectionId(7L, 42L);
+
+    verify(namedParameterJdbcTemplate).update(sqlCaptor.capture(), paramsCaptor.capture());
+
+    assertThat(sqlCaptor.getValue())
+        .isEqualTo("UPDATE tag SET converted_collection_id = :collectionId WHERE id = :id");
+
+    MapSqlParameterSource params = (MapSqlParameterSource) paramsCaptor.getValue();
+    assertThat(params.getValue("id")).isEqualTo(7L);
+    assertThat(params.getValue("collectionId")).isEqualTo(42L);
+  }
+
+  @Test
+  void updateConvertedCollectionId_nullCollectionId_clearsColumn() {
+    when(namedParameterJdbcTemplate.update(anyString(), any(SqlParameterSource.class)))
+        .thenReturn(1);
+
+    tagRepository.updateConvertedCollectionId(7L, null);
+
+    verify(namedParameterJdbcTemplate).update(anyString(), paramsCaptor.capture());
+    MapSqlParameterSource params = (MapSqlParameterSource) paramsCaptor.getValue();
+    assertThat(params.getValue("collectionId")).isNull();
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/dao/UserFollowedCollectionRepositoryIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/dao/UserFollowedCollectionRepositoryIntegrationTest.java
@@ -1,0 +1,77 @@
+package edens.zac.portfolio.backend.dao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import edens.zac.portfolio.backend.AbstractPostgresIntegrationTest;
+import edens.zac.portfolio.backend.entity.UserFollowedCollectionEntity;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Exercises {@link UserFollowedCollectionRepository} against the real V40 schema (boots Postgres +
+ * Flyway). Seeds minimal FK-satisfying rows: {@code users} and {@code collection}.
+ */
+class UserFollowedCollectionRepositoryIntegrationTest extends AbstractPostgresIntegrationTest {
+
+  @Autowired private UserFollowedCollectionRepository userFollowedCollectionRepository;
+  @Autowired private JdbcTemplate jdbcTemplate;
+
+  private Long seedUser(String email) {
+    return jdbcTemplate.queryForObject(
+        "INSERT INTO users (name, email, webauthn_user_handle, status) "
+            + "VALUES (?, ?, gen_random_uuid(), 'ACTIVE') RETURNING id",
+        Long.class,
+        email,
+        email);
+  }
+
+  private Long seedCollection(String slug) {
+    return jdbcTemplate.queryForObject(
+        "INSERT INTO collection (type, title, slug, visibility) "
+            + "VALUES ('CLIENT_GALLERY', ?, ?, 'HIDDEN') RETURNING id",
+        Long.class,
+        "Title " + slug,
+        slug);
+  }
+
+  @Test
+  void insertThenListReturnsTheCollection() {
+    Long userId = seedUser("follow-1-" + UUID.randomUUID() + "@example.com");
+    Long collectionId = seedCollection("follow-collection-1-" + UUID.randomUUID());
+
+    userFollowedCollectionRepository.insert(
+        UserFollowedCollectionEntity.builder().userId(userId).collectionId(collectionId).build());
+
+    assertThat(userFollowedCollectionRepository.findCollectionIdsByUserId(userId))
+        .containsExactly(collectionId);
+  }
+
+  @Test
+  void insertIsIdempotentOnConflict() {
+    Long userId = seedUser("follow-2-" + UUID.randomUUID() + "@example.com");
+    Long collectionId = seedCollection("follow-collection-2-" + UUID.randomUUID());
+
+    UserFollowedCollectionEntity row =
+        UserFollowedCollectionEntity.builder().userId(userId).collectionId(collectionId).build();
+    userFollowedCollectionRepository.insert(row);
+    userFollowedCollectionRepository.insert(row);
+
+    assertThat(userFollowedCollectionRepository.findCollectionIdsByUserId(userId))
+        .containsExactly(collectionId);
+  }
+
+  @Test
+  void deleteRemovesTheFollow() {
+    Long userId = seedUser("follow-3-" + UUID.randomUUID() + "@example.com");
+    Long collectionId = seedCollection("follow-collection-3-" + UUID.randomUUID());
+
+    userFollowedCollectionRepository.insert(
+        UserFollowedCollectionEntity.builder().userId(userId).collectionId(collectionId).build());
+
+    assertThat(userFollowedCollectionRepository.deleteByUserIdAndCollectionId(userId, collectionId))
+        .isEqualTo(1);
+    assertThat(userFollowedCollectionRepository.findCollectionIdsByUserId(userId)).isEmpty();
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/dao/UserSavedImageRepositoryIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/dao/UserSavedImageRepositoryIntegrationTest.java
@@ -1,0 +1,78 @@
+package edens.zac.portfolio.backend.dao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import edens.zac.portfolio.backend.AbstractPostgresIntegrationTest;
+import edens.zac.portfolio.backend.entity.UserSavedImageEntity;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Exercises {@link UserSavedImageRepository} against the real V40 schema (boots Postgres + Flyway).
+ * Seeds minimal FK-satisfying rows: {@code users} and an image (a {@code content} row plus its
+ * {@code content_image} detail on a shared PK).
+ */
+class UserSavedImageRepositoryIntegrationTest extends AbstractPostgresIntegrationTest {
+
+  @Autowired private UserSavedImageRepository userSavedImageRepository;
+  @Autowired private JdbcTemplate jdbcTemplate;
+
+  private Long seedUser(String email) {
+    return jdbcTemplate.queryForObject(
+        "INSERT INTO users (name, email, webauthn_user_handle, status) "
+            + "VALUES (?, ?, gen_random_uuid(), 'ACTIVE') RETURNING id",
+        Long.class,
+        email,
+        email);
+  }
+
+  private Long seedImage() {
+    Long imageId =
+        jdbcTemplate.queryForObject(
+            "INSERT INTO content (content_type) VALUES ('IMAGE') RETURNING id", Long.class);
+    jdbcTemplate.update(
+        "INSERT INTO content_image (id, title, image_url_web) VALUES (?, ?, ?)",
+        imageId,
+        "img",
+        "https://cdn.example.com/" + UUID.randomUUID() + ".jpg");
+    return imageId;
+  }
+
+  @Test
+  void insertThenListReturnsTheImage() {
+    Long userId = seedUser("save-1-" + UUID.randomUUID() + "@example.com");
+    Long imageId = seedImage();
+
+    userSavedImageRepository.insert(
+        UserSavedImageEntity.builder().userId(userId).imageId(imageId).build());
+
+    assertThat(userSavedImageRepository.findImageIdsByUserId(userId)).containsExactly(imageId);
+  }
+
+  @Test
+  void insertIsIdempotentOnConflict() {
+    Long userId = seedUser("save-2-" + UUID.randomUUID() + "@example.com");
+    Long imageId = seedImage();
+
+    UserSavedImageEntity row =
+        UserSavedImageEntity.builder().userId(userId).imageId(imageId).build();
+    userSavedImageRepository.insert(row);
+    userSavedImageRepository.insert(row);
+
+    assertThat(userSavedImageRepository.findImageIdsByUserId(userId)).containsExactly(imageId);
+  }
+
+  @Test
+  void deleteRemovesTheSave() {
+    Long userId = seedUser("save-3-" + UUID.randomUUID() + "@example.com");
+    Long imageId = seedImage();
+
+    userSavedImageRepository.insert(
+        UserSavedImageEntity.builder().userId(userId).imageId(imageId).build());
+
+    assertThat(userSavedImageRepository.deleteByUserIdAndImageId(userId, imageId)).isEqualTo(1);
+    assertThat(userSavedImageRepository.findImageIdsByUserId(userId)).isEmpty();
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/services/ImageProcessingServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/ImageProcessingServiceTest.java
@@ -12,6 +12,7 @@ import edens.zac.portfolio.backend.entity.ContentImageEntity;
 import edens.zac.portfolio.backend.entity.ContentLensEntity;
 import edens.zac.portfolio.backend.services.validator.ContentValidator;
 import edens.zac.portfolio.backend.types.ContentType;
+import edens.zac.portfolio.backend.types.FilmFormat;
 import java.awt.image.BufferedImage;
 import java.time.LocalDateTime;
 import java.util.HashMap;
@@ -258,6 +259,100 @@ class ImageProcessingServiceTest {
         Integer.valueOf(5),
         result.entity().getRating(),
         "re-export without a rating tag must preserve the existing curated rating");
+  }
+
+  // ============================================================================
+  // Tests for hardcoded film-camera detection
+  // ============================================================================
+
+  private ImageProcessingService.PreparedImageData createPreparedImageDataWithCamera(
+      String filename, String cameraName, int width, int height) {
+    Map<String, String> metadata = new HashMap<>();
+    metadata.put("imageWidth", String.valueOf(width));
+    metadata.put("imageHeight", String.valueOf(height));
+    metadata.put("author", "Test Author");
+    metadata.put("camera", cameraName);
+    return new ImageProcessingService.PreparedImageData(
+        filename,
+        "https://cdn/full/image.jpg",
+        "https://cdn/web/image.webp",
+        null,
+        null,
+        metadata,
+        List.of(),
+        List.of(),
+        2026,
+        1,
+        LocalDateTime.of(2026, 1, 15, 14, 23, 5),
+        LocalDateTime.of(2026, 1, 15, 10, 0));
+  }
+
+  private void stubCameraCreationEcho() {
+    when(equipmentRepository.findCameraByBodySerialNumber(any())).thenReturn(Optional.empty());
+    when(equipmentRepository.findCameraByNameIgnoreCase(any())).thenReturn(Optional.empty());
+    when(equipmentRepository.saveCamera(any(ContentCameraEntity.class)))
+        .thenAnswer(inv -> inv.getArgument(0));
+    when(contentRepository.findByOriginalFilenameAndCaptureDate(any(), any()))
+        .thenReturn(Optional.empty());
+    when(contentRepository.saveImage(any(ContentImageEntity.class)))
+        .thenAnswer(inv -> inv.getArgument(0));
+    // The extractor is a mock; make the width/height parse real so aspect-ratio logic runs.
+    when(imageMetadataExtractor.parseIntegerOrDefault(any(), any()))
+        .thenAnswer(
+            inv -> {
+              String value = inv.getArgument(0);
+              Integer fallback = inv.getArgument(1);
+              if (value == null || value.isBlank()) {
+                return fallback;
+              }
+              return Integer.parseInt(value.replaceAll("[^0-9-]", ""));
+            });
+  }
+
+  @Test
+  void ezController_squareFrame_mapsToHasselbladWith120Film() {
+    stubCameraCreationEcho();
+    ImageProcessingService.PreparedImageData prepared =
+        createPreparedImageDataWithCamera("scan.jpg", "EZ Controller", 1000, 1000);
+
+    ImageProcessingService.DedupeResult result =
+        imageProcessingService.savePreparedImageWithDedupe(prepared, "Test");
+
+    ContentImageEntity entity = result.entity();
+    assertEquals("Hasselblad 500cm", entity.getCamera().getCameraName());
+    assertTrue(entity.getIsFilm());
+    assertEquals(FilmFormat.MM_120, entity.getFilmFormat());
+  }
+
+  @Test
+  void ezController_rectangularFrame_mapsToMamiyaWith120Film() {
+    stubCameraCreationEcho();
+    // ~5x7 / 645 aspect ratio (1.4) -> Mamiya, not square Hasselblad.
+    ImageProcessingService.PreparedImageData prepared =
+        createPreparedImageDataWithCamera("scan.jpg", "EZ Controller", 1000, 1400);
+
+    ImageProcessingService.DedupeResult result =
+        imageProcessingService.savePreparedImageWithDedupe(prepared, "Test");
+
+    ContentImageEntity entity = result.entity();
+    assertEquals("Mamiya 645 Pro", entity.getCamera().getCameraName());
+    assertTrue(entity.getIsFilm());
+    assertEquals(FilmFormat.MM_120, entity.getFilmFormat());
+  }
+
+  @Test
+  void opticFilm_mapsTo35mmFilmAndKeepsCameraName() {
+    stubCameraCreationEcho();
+    ImageProcessingService.PreparedImageData prepared =
+        createPreparedImageDataWithCamera("scan.jpg", "OpticFilm 8300i", 1000, 1500);
+
+    ImageProcessingService.DedupeResult result =
+        imageProcessingService.savePreparedImageWithDedupe(prepared, "Test");
+
+    ContentImageEntity entity = result.entity();
+    assertEquals("OpticFilm 8300i", entity.getCamera().getCameraName());
+    assertTrue(entity.getIsFilm());
+    assertEquals(FilmFormat.MM_35, entity.getFilmFormat());
   }
 
   // ============================================================================

--- a/src/test/java/edens/zac/portfolio/backend/services/MetadataServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/MetadataServiceTest.java
@@ -1,0 +1,109 @@
+package edens.zac.portfolio.backend.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import edens.zac.portfolio.backend.dao.EquipmentRepository;
+import edens.zac.portfolio.backend.dao.LocationRepository;
+import edens.zac.portfolio.backend.dao.PersonRepository;
+import edens.zac.portfolio.backend.dao.TagRepository;
+import edens.zac.portfolio.backend.entity.ContentCameraEntity;
+import edens.zac.portfolio.backend.services.validator.MetadataValidator;
+import edens.zac.portfolio.backend.types.FilmFormat;
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+/**
+ * Unit coverage for {@link MetadataService#createCamera} — the camera upsert added in commit
+ * 9d500f7. Pure Mockito (no Spring / DB) matching the other service unit tests in this package.
+ */
+@ExtendWith(MockitoExtension.class)
+class MetadataServiceTest {
+
+  @Mock private TagRepository tagRepository;
+  @Mock private PersonRepository personRepository;
+  @Mock private EquipmentRepository equipmentRepository;
+  @Mock private LocationRepository locationRepository;
+  @Mock private MetadataValidator metadataValidator;
+
+  @InjectMocks private MetadataService metadataService;
+
+  private ContentCameraEntity camera(
+      Long id, String name, Boolean isFilm, FilmFormat format, String serial) {
+    return ContentCameraEntity.builder()
+        .id(id)
+        .cameraName(name)
+        .isFilm(isFilm)
+        .defaultFilmFormat(format)
+        .bodySerialNumber(serial)
+        .createdAt(LocalDateTime.now())
+        .build();
+  }
+
+  @Test
+  void createCamera_updatesExisting_whenNameAlreadyPresent() {
+    ContentCameraEntity existing = camera(42L, "Leica M6", false, null, null);
+    when(equipmentRepository.findCameraByNameIgnoreCase("Leica M6"))
+        .thenReturn(Optional.of(existing));
+
+    Map<String, Object> result =
+        metadataService.createCamera("Leica M6", null, true, FilmFormat.MM_35);
+
+    // Applies the requested film metadata to the existing camera rather than inserting a new one.
+    verify(equipmentRepository).updateCameraFilmMetadata(42L, true, FilmFormat.MM_35);
+    verify(equipmentRepository, never()).saveCamera(any());
+    assertThat(result.get("id")).isEqualTo(42L);
+    assertThat(result.get("cameraName")).isEqualTo("Leica M6");
+    assertThat(result.get("isFilm")).isEqualTo(true);
+  }
+
+  @Test
+  void createCamera_createsNew_whenNameNotPresent() {
+    when(equipmentRepository.findCameraByNameIgnoreCase("Nikon Z6")).thenReturn(Optional.empty());
+    when(equipmentRepository.saveCamera(any()))
+        .thenReturn(camera(7L, "Nikon Z6", false, null, "SN-123"));
+
+    Map<String, Object> result = metadataService.createCamera("Nikon Z6", "SN-123", false, null);
+
+    ArgumentCaptor<ContentCameraEntity> saved = ArgumentCaptor.forClass(ContentCameraEntity.class);
+    verify(equipmentRepository).saveCamera(saved.capture());
+    assertThat(saved.getValue().getCameraName()).isEqualTo("Nikon Z6");
+    assertThat(saved.getValue().getBodySerialNumber()).isEqualTo("SN-123");
+    verify(equipmentRepository, never()).updateCameraFilmMetadata(any(), any(), any());
+    assertThat(result.get("id")).isEqualTo(7L);
+  }
+
+  @Test
+  void createCamera_rejectsSerialNumberConflict() {
+    when(equipmentRepository.findCameraByBodySerialNumber("DUP-SERIAL"))
+        .thenReturn(Optional.of(camera(99L, "Other", false, null, "DUP-SERIAL")));
+
+    assertThatThrownBy(() -> metadataService.createCamera("Any Camera", "DUP-SERIAL", false, null))
+        .isInstanceOf(DataIntegrityViolationException.class)
+        .hasMessageContaining("DUP-SERIAL");
+
+    verify(equipmentRepository, never()).saveCamera(any());
+    verify(equipmentRepository, never()).updateCameraFilmMetadata(eq(99L), any(), any());
+  }
+
+  @Test
+  void createCamera_rejectsBlankName() {
+    assertThatThrownBy(() -> metadataService.createCamera("   ", null, false, null))
+        .isInstanceOf(IllegalArgumentException.class);
+
+    verify(equipmentRepository, never()).saveCamera(any());
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/services/TagConversionIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/TagConversionIntegrationTest.java
@@ -81,7 +81,8 @@ class TagConversionIntegrationTest extends AbstractPostgresIntegrationTest {
     CollectionRequests.UpdateResponse response =
         tagService.convertTagToCollection(
             tag,
-            new SaveAsCollectionRequest(CollectionType.PORTFOLIO, CollectionVisibility.LISTED));
+            new SaveAsCollectionRequest(
+                CollectionType.PORTFOLIO, CollectionVisibility.LISTED, null));
 
     Long newCollectionId = response.collection().getId();
 
@@ -121,6 +122,78 @@ class TagConversionIntegrationTest extends AbstractPostgresIntegrationTest {
     // (e) Re-convert is rejected.
     assertThatThrownBy(() -> tagService.convertTagToCollection(tag, null))
         .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void convert_defaultScope_doesNotCopyHiddenMembers() {
+    long tag = seedTag("Private", "private");
+
+    // A HIDDEN member collection tagged directly, plus a LISTED one.
+    long listedMember = seedCollection("listed-member", CollectionVisibility.LISTED, 5);
+    long hiddenMember = seedCollection("hidden-member", CollectionVisibility.HIDDEN, 5);
+    tagCollection(listedMember, tag);
+    tagCollection(hiddenMember, tag);
+
+    // A tagged image visible ONLY through a HIDDEN collection membership.
+    long hiddenHost = seedCollection("hidden-host", CollectionVisibility.HIDDEN, 1);
+    long hiddenImage = seedImage("https://cdn/hidden.jpg");
+    tagContent(hiddenImage, tag);
+    addMembership(hiddenHost, hiddenImage, true);
+
+    // A tagged image visible through a LISTED collection membership.
+    long listedHost = seedCollection("listed-host", CollectionVisibility.LISTED, 1);
+    long listedImage = seedImage("https://cdn/listed.jpg");
+    tagContent(listedImage, tag);
+    addMembership(listedHost, listedImage, true);
+
+    CollectionRequests.UpdateResponse response =
+        tagService.convertTagToCollection(
+            tag,
+            new SaveAsCollectionRequest(
+                CollectionType.PORTFOLIO, CollectionVisibility.LISTED, null));
+    Long newCollectionId = response.collection().getId();
+
+    // The HIDDEN-only image is NOT snapshotted.
+    Integer hiddenImageRows =
+        jdbc.queryForObject(
+            "SELECT COUNT(*) FROM collection_content WHERE collection_id = ? AND content_id = ?",
+            Integer.class,
+            newCollectionId,
+            hiddenImage);
+    assertThat(hiddenImageRows).isZero();
+
+    // The LISTED image IS snapshotted.
+    Integer listedImageRows =
+        jdbc.queryForObject(
+            "SELECT COUNT(*) FROM collection_content WHERE collection_id = ? AND content_id = ?",
+            Integer.class,
+            newCollectionId,
+            listedImage);
+    assertThat(listedImageRows).isEqualTo(1);
+
+    // Exactly two content rows total: 1 LISTED member-collection wrapper + 1 LISTED image. The
+    // HIDDEN member collection and the HIDDEN-only image are both excluded. We assert the total
+    // count (not a per-member-id lookup) because linkCollectionToParent stores the child's
+    // content-wrapper id in content_id, not the child collection id.
+    Integer totalRows =
+        jdbc.queryForObject(
+            "SELECT COUNT(*) FROM collection_content WHERE collection_id = ?",
+            Integer.class,
+            newCollectionId);
+    assertThat(totalRows).isEqualTo(2);
+
+    // And the LISTED member collection's content-wrapper is linked (proves the LISTED path works).
+    Integer listedChildRows =
+        jdbc.queryForObject(
+            """
+            SELECT COUNT(*) FROM collection_content cc
+            JOIN content_collection ccn ON ccn.id = cc.content_id
+            WHERE cc.collection_id = ? AND ccn.referenced_collection_id = ?
+            """,
+            Integer.class,
+            newCollectionId,
+            listedMember);
+    assertThat(listedChildRows).isEqualTo(1);
   }
 
   @Test

--- a/src/test/java/edens/zac/portfolio/backend/services/TagConversionIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/TagConversionIntegrationTest.java
@@ -1,0 +1,136 @@
+package edens.zac.portfolio.backend.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import edens.zac.portfolio.backend.AbstractPostgresIntegrationTest;
+import edens.zac.portfolio.backend.model.CollectionModel;
+import edens.zac.portfolio.backend.model.CollectionRequests;
+import edens.zac.portfolio.backend.model.SaveAsCollectionRequest;
+import edens.zac.portfolio.backend.types.CollectionType;
+import edens.zac.portfolio.backend.types.CollectionVisibility;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Real-Postgres coverage for A3 tag-to-collection conversion: the snapshot lands real {@code
+ * collection_content} rows, the new collection takes over the tag's slug so it wins resolution, and
+ * a converted tag no longer renders a tag-view.
+ */
+class TagConversionIntegrationTest extends AbstractPostgresIntegrationTest {
+
+  @Autowired private TagService tagService;
+  @Autowired private CollectionService collectionService;
+  @Autowired private JdbcTemplate jdbc;
+
+  private long seedTag(String name, String slug) {
+    jdbc.update("INSERT INTO tag (tag_name, slug) VALUES (?, ?)", name, slug);
+    return jdbc.queryForObject("SELECT id FROM tag WHERE slug = ?", Long.class, slug);
+  }
+
+  private long seedCollection(String slug, CollectionVisibility visibility, Integer rating) {
+    jdbc.update(
+        "INSERT INTO collection (title, slug, type, visibility, rating) VALUES (?, ?, 'BLOG', ?, ?)",
+        slug,
+        slug,
+        visibility.name(),
+        rating);
+    return jdbc.queryForObject("SELECT id FROM collection WHERE slug = ?", Long.class, slug);
+  }
+
+  private long seedImage(String urlWeb) {
+    jdbc.update("INSERT INTO content (content_type) VALUES ('IMAGE')");
+    long id = jdbc.queryForObject("SELECT MAX(id) FROM content", Long.class);
+    jdbc.update(
+        "INSERT INTO content_image (id, title, image_url_web) VALUES (?, ?, ?)",
+        id,
+        "img-" + id,
+        urlWeb);
+    return id;
+  }
+
+  private void tagCollection(long collectionId, long tagId) {
+    jdbc.update(
+        "INSERT INTO collection_tags (collection_id, tag_id) VALUES (?, ?)", collectionId, tagId);
+  }
+
+  private void tagContent(long contentId, long tagId) {
+    jdbc.update("INSERT INTO content_tags (content_id, tag_id) VALUES (?, ?)", contentId, tagId);
+  }
+
+  private void addMembership(long collectionId, long contentId, boolean visible) {
+    jdbc.update(
+        "INSERT INTO collection_content (collection_id, content_id, visible) VALUES (?, ?, ?)",
+        collectionId,
+        contentId,
+        visible);
+  }
+
+  @Test
+  void convert_promotesTagIntoCollectionThatOwnsSlugAndSnapshotsMembers() {
+    long tag = seedTag("Sunsets", "sunsets");
+    long memberCollection = seedCollection("sunset-trip", CollectionVisibility.LISTED, 5);
+    tagCollection(memberCollection, tag);
+
+    long host = seedCollection("sunset-host", CollectionVisibility.LISTED, 1);
+    long image = seedImage("https://cdn/sunset.jpg");
+    tagContent(image, tag);
+    addMembership(host, image, true);
+
+    CollectionRequests.UpdateResponse response =
+        tagService.convertTagToCollection(
+            tag,
+            new SaveAsCollectionRequest(CollectionType.PORTFOLIO, CollectionVisibility.LISTED));
+
+    Long newCollectionId = response.collection().getId();
+
+    // (a) A real collection owns the tag's slug.
+    Long slugOwnerId =
+        jdbc.queryForObject("SELECT id FROM collection WHERE slug = ?", Long.class, "sunsets");
+    assertThat(slugOwnerId).isEqualTo(newCollectionId);
+
+    // (b) collection_content holds the snapshot: the member collection (via its content row) +
+    // image.
+    Integer contentCount =
+        jdbc.queryForObject(
+            "SELECT COUNT(*) FROM collection_content WHERE collection_id = ?",
+            Integer.class,
+            newCollectionId);
+    assertThat(contentCount).isEqualTo(2);
+    Integer imageRows =
+        jdbc.queryForObject(
+            "SELECT COUNT(*) FROM collection_content WHERE collection_id = ? AND content_id = ?",
+            Integer.class,
+            newCollectionId,
+            image);
+    assertThat(imageRows).isEqualTo(1);
+
+    // (c) Resolution returns the real collection (not the synthetic tag-view).
+    CollectionModel resolved = collectionService.getCollectionWithPagination("sunsets", 0, 30);
+    assertThat(resolved.getId()).isEqualTo(newCollectionId);
+    assertThat(resolved.getType()).isEqualTo(CollectionType.PORTFOLIO);
+    assertThat(resolved.isDerived()).isFalse();
+
+    // (d) The tag is flagged converted and no longer resolves a tag-view.
+    Long convertedCollectionId =
+        jdbc.queryForObject(
+            "SELECT converted_collection_id FROM tag WHERE id = ?", Long.class, tag);
+    assertThat(convertedCollectionId).isEqualTo(newCollectionId);
+
+    // (e) Re-convert is rejected.
+    assertThatThrownBy(() -> tagService.convertTagToCollection(tag, null))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void convert_rejectedWhenRealCollectionAlreadyOwnsSlug() {
+    seedCollection("already-taken", CollectionVisibility.LISTED, 1);
+    long tag = seedTag("AlreadyTaken", "already-taken");
+    long member = seedCollection("at-member", CollectionVisibility.LISTED, 5);
+    tagCollection(member, tag);
+
+    assertThatThrownBy(() -> tagService.convertTagToCollection(tag, null))
+        .isInstanceOf(IllegalStateException.class);
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/services/TagServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/TagServiceTest.java
@@ -1,0 +1,164 @@
+package edens.zac.portfolio.backend.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import edens.zac.portfolio.backend.dao.CollectionRepository;
+import edens.zac.portfolio.backend.dao.TagRepository;
+import edens.zac.portfolio.backend.entity.CollectionContentEntity;
+import edens.zac.portfolio.backend.entity.CollectionEntity;
+import edens.zac.portfolio.backend.entity.TagEntity;
+import edens.zac.portfolio.backend.model.CollectionModel;
+import edens.zac.portfolio.backend.model.CollectionRequests;
+import edens.zac.portfolio.backend.model.SaveAsCollectionRequest;
+import edens.zac.portfolio.backend.types.CollectionType;
+import edens.zac.portfolio.backend.types.CollectionVisibility;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TagServiceTest {
+
+  @Mock private TagRepository tagRepository;
+  @Mock private CollectionRepository collectionRepository;
+  @Mock private CollectionService collectionService;
+
+  @InjectMocks private TagService tagService;
+
+  private TagEntity unconvertedTag() {
+    return TagEntity.builder().id(5L).tagName("Landscape").slug("landscape").build();
+  }
+
+  private CollectionRequests.UpdateResponse responseWithId(Long id, String slug) {
+    CollectionModel model = CollectionModel.builder().id(id).slug(slug).build();
+    return new CollectionRequests.UpdateResponse(model, null);
+  }
+
+  @Test
+  void convertTagToCollection_createsCollectionWithTagSlug_copiesMembers_flagsTag() {
+    TagEntity tag = unconvertedTag();
+    when(tagRepository.findById(5L)).thenReturn(Optional.of(tag));
+    when(collectionRepository.findBySlug("landscape")).thenReturn(Optional.empty());
+
+    when(collectionService.createCollection(any())).thenReturn(responseWithId(99L, "landscape-1"));
+
+    CollectionEntity created = new CollectionEntity();
+    created.setId(99L);
+    created.setSlug("landscape-1");
+    when(collectionRepository.findById(99L)).thenReturn(Optional.of(created));
+
+    CollectionEntity memberCollection = new CollectionEntity();
+    memberCollection.setId(200L);
+    when(tagRepository.findCollectionsByTagId(eq(5L), anyList()))
+        .thenReturn(List.of(memberCollection));
+    when(tagRepository.findImageContentByTagId(eq(5L), anyList())).thenReturn(List.of(300L, 301L));
+    when(collectionRepository.getMaxOrderIndexForCollection(99L)).thenReturn(0);
+
+    when(collectionService.getUpdateCollectionData("landscape"))
+        .thenReturn(responseWithId(99L, "landscape"));
+
+    CollectionRequests.UpdateResponse result =
+        tagService.convertTagToCollection(
+            5L,
+            new SaveAsCollectionRequest(CollectionType.PORTFOLIO, CollectionVisibility.UNLISTED));
+
+    // Create used the tag NAME as title.
+    ArgumentCaptor<CollectionRequests.Create> createCaptor =
+        ArgumentCaptor.forClass(CollectionRequests.Create.class);
+    verify(collectionService).createCollection(createCaptor.capture());
+    assertThat(createCaptor.getValue().title()).isEqualTo("Landscape");
+    assertThat(createCaptor.getValue().type()).isEqualTo(CollectionType.PORTFOLIO);
+
+    // New collection took over the tag slug and requested visibility.
+    ArgumentCaptor<CollectionEntity> saveCaptor = ArgumentCaptor.forClass(CollectionEntity.class);
+    verify(collectionRepository).save(saveCaptor.capture());
+    assertThat(saveCaptor.getValue().getSlug()).isEqualTo("landscape");
+    assertThat(saveCaptor.getValue().getVisibility()).isEqualTo(CollectionVisibility.UNLISTED);
+
+    // Member collection linked; two images snapshotted with incrementing order indexes.
+    verify(collectionService).linkCollectionToParent(99L, 200L);
+    ArgumentCaptor<CollectionContentEntity> contentCaptor =
+        ArgumentCaptor.forClass(CollectionContentEntity.class);
+    verify(collectionRepository, org.mockito.Mockito.times(2)).saveContent(contentCaptor.capture());
+    assertThat(contentCaptor.getAllValues())
+        .extracting(CollectionContentEntity::getContentId)
+        .containsExactly(300L, 301L);
+    assertThat(contentCaptor.getAllValues())
+        .extracting(CollectionContentEntity::getOrderIndex)
+        .containsExactly(1, 2);
+
+    // Tag flagged converted; response is the real collection at the tag slug.
+    verify(tagRepository).updateConvertedCollectionId(5L, 99L);
+    assertThat(result.collection().getSlug()).isEqualTo("landscape");
+  }
+
+  @Test
+  void convertTagToCollection_defaultsTypeAndVisibility_whenRequestNull() {
+    TagEntity tag = unconvertedTag();
+    when(tagRepository.findById(5L)).thenReturn(Optional.of(tag));
+    when(collectionRepository.findBySlug("landscape")).thenReturn(Optional.empty());
+    when(collectionService.createCollection(any())).thenReturn(responseWithId(99L, "landscape-1"));
+    CollectionEntity created = new CollectionEntity();
+    created.setId(99L);
+    when(collectionRepository.findById(99L)).thenReturn(Optional.of(created));
+    when(tagRepository.findCollectionsByTagId(eq(5L), anyList())).thenReturn(List.of());
+    when(tagRepository.findImageContentByTagId(eq(5L), anyList())).thenReturn(List.of());
+    when(collectionService.getUpdateCollectionData("landscape"))
+        .thenReturn(responseWithId(99L, "landscape"));
+
+    tagService.convertTagToCollection(5L, null);
+
+    ArgumentCaptor<CollectionRequests.Create> createCaptor =
+        ArgumentCaptor.forClass(CollectionRequests.Create.class);
+    verify(collectionService).createCollection(createCaptor.capture());
+    assertThat(createCaptor.getValue().type()).isEqualTo(CollectionType.PORTFOLIO);
+
+    ArgumentCaptor<CollectionEntity> saveCaptor = ArgumentCaptor.forClass(CollectionEntity.class);
+    verify(collectionRepository).save(saveCaptor.capture());
+    assertThat(saveCaptor.getValue().getVisibility()).isEqualTo(CollectionVisibility.UNLISTED);
+  }
+
+  @Test
+  void convertTagToCollection_missingTag_throwsNotFound() {
+    when(tagRepository.findById(5L)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> tagService.convertTagToCollection(5L, null))
+        .isInstanceOf(edens.zac.portfolio.backend.config.ResourceNotFoundException.class);
+    verify(collectionService, never()).createCollection(any());
+  }
+
+  @Test
+  void convertTagToCollection_alreadyConverted_isRejected() {
+    TagEntity tag = TagEntity.builder().id(5L).tagName("Landscape").slug("landscape").build();
+    tag.setConvertedCollectionId(99L);
+    when(tagRepository.findById(5L)).thenReturn(Optional.of(tag));
+
+    assertThatThrownBy(() -> tagService.convertTagToCollection(5L, null))
+        .isInstanceOf(IllegalStateException.class);
+    verify(collectionService, never()).createCollection(any());
+  }
+
+  @Test
+  void convertTagToCollection_slugCollision_isRejected() {
+    TagEntity tag = unconvertedTag();
+    when(tagRepository.findById(5L)).thenReturn(Optional.of(tag));
+    when(collectionRepository.findBySlug("landscape"))
+        .thenReturn(Optional.of(new CollectionEntity()));
+
+    assertThatThrownBy(() -> tagService.convertTagToCollection(5L, null))
+        .isInstanceOf(IllegalStateException.class);
+    verify(collectionService, never()).createCollection(any());
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/services/TagServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/TagServiceTest.java
@@ -72,7 +72,8 @@ class TagServiceTest {
     CollectionRequests.UpdateResponse result =
         tagService.convertTagToCollection(
             5L,
-            new SaveAsCollectionRequest(CollectionType.PORTFOLIO, CollectionVisibility.UNLISTED));
+            new SaveAsCollectionRequest(
+                CollectionType.PORTFOLIO, CollectionVisibility.UNLISTED, null));
 
     // Create used the tag NAME as title.
     ArgumentCaptor<CollectionRequests.Create> createCaptor =
@@ -128,6 +129,82 @@ class TagServiceTest {
     ArgumentCaptor<CollectionEntity> saveCaptor = ArgumentCaptor.forClass(CollectionEntity.class);
     verify(collectionRepository).save(saveCaptor.capture());
     assertThat(saveCaptor.getValue().getVisibility()).isEqualTo(CollectionVisibility.UNLISTED);
+  }
+
+  @Test
+  void convertTagToCollection_defaultScope_excludesHiddenAndSkipsPasswordGatedMembers() {
+    TagEntity tag = unconvertedTag();
+    when(tagRepository.findById(5L)).thenReturn(Optional.of(tag));
+    when(collectionRepository.findBySlug("landscape")).thenReturn(Optional.empty());
+    when(collectionService.createCollection(any())).thenReturn(responseWithId(99L, "landscape-1"));
+    CollectionEntity created = new CollectionEntity();
+    created.setId(99L);
+    when(collectionRepository.findById(99L)).thenReturn(Optional.of(created));
+
+    // One plain member collection and one password-gated member collection.
+    CollectionEntity plain = new CollectionEntity();
+    plain.setId(200L);
+    CollectionEntity gated = new CollectionEntity();
+    gated.setId(201L);
+    gated.setGalleryPassword("secret");
+
+    ArgumentCaptor<List<CollectionVisibility>> scopeCaptor = scopeCaptor();
+    when(tagRepository.findCollectionsByTagId(eq(5L), scopeCaptor.capture()))
+        .thenReturn(List.of(plain, gated));
+    when(tagRepository.findImageContentByTagId(eq(5L), anyList())).thenReturn(List.of());
+    when(collectionService.getUpdateCollectionData("landscape"))
+        .thenReturn(responseWithId(99L, "landscape"));
+
+    tagService.convertTagToCollection(
+        5L,
+        new SaveAsCollectionRequest(CollectionType.PORTFOLIO, CollectionVisibility.UNLISTED, null));
+
+    // Default scope is LISTED + UNLISTED (HIDDEN excluded).
+    assertThat(scopeCaptor.getValue())
+        .containsExactlyInAnyOrder(CollectionVisibility.LISTED, CollectionVisibility.UNLISTED)
+        .doesNotContain(CollectionVisibility.HIDDEN);
+    // Password-gated member collection is skipped; only the plain one is linked.
+    verify(collectionService).linkCollectionToParent(99L, 200L);
+    verify(collectionService, never()).linkCollectionToParent(99L, 201L);
+  }
+
+  @Test
+  void convertTagToCollection_includeHidden_widensScopeAndKeepsPasswordGatedMembers() {
+    TagEntity tag = unconvertedTag();
+    when(tagRepository.findById(5L)).thenReturn(Optional.of(tag));
+    when(collectionRepository.findBySlug("landscape")).thenReturn(Optional.empty());
+    when(collectionService.createCollection(any())).thenReturn(responseWithId(99L, "landscape-1"));
+    CollectionEntity created = new CollectionEntity();
+    created.setId(99L);
+    when(collectionRepository.findById(99L)).thenReturn(Optional.of(created));
+
+    CollectionEntity gated = new CollectionEntity();
+    gated.setId(201L);
+    gated.setGalleryPassword("secret");
+
+    ArgumentCaptor<List<CollectionVisibility>> scopeCaptor = scopeCaptor();
+    when(tagRepository.findCollectionsByTagId(eq(5L), scopeCaptor.capture()))
+        .thenReturn(List.of(gated));
+    when(tagRepository.findImageContentByTagId(eq(5L), anyList())).thenReturn(List.of());
+    when(collectionService.getUpdateCollectionData("landscape"))
+        .thenReturn(responseWithId(99L, "landscape"));
+
+    tagService.convertTagToCollection(
+        5L,
+        new SaveAsCollectionRequest(CollectionType.PORTFOLIO, CollectionVisibility.UNLISTED, true));
+
+    // Opt-in widens scope to include HIDDEN and keeps the password-gated member.
+    assertThat(scopeCaptor.getValue())
+        .containsExactlyInAnyOrder(
+            CollectionVisibility.LISTED,
+            CollectionVisibility.UNLISTED,
+            CollectionVisibility.HIDDEN);
+    verify(collectionService).linkCollectionToParent(99L, 201L);
+  }
+
+  @SuppressWarnings("unchecked")
+  private ArgumentCaptor<List<CollectionVisibility>> scopeCaptor() {
+    return ArgumentCaptor.forClass(List.class);
   }
 
   @Test

--- a/src/test/java/edens/zac/portfolio/backend/services/TagViewResolverTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/TagViewResolverTest.java
@@ -140,6 +140,35 @@ class TagViewResolverTest {
   }
 
   @Test
+  void imageOrder_followsIdOrder_evenWhenRepositoryReturnsScrambled_andDropsMissing() {
+    TagEntity travel = tag(7L, "Travel", "travel");
+    when(tagRepository.findBySlug("travel")).thenReturn(Optional.of(travel));
+    when(tagRepository.findCollectionsByTagId(eq(7L), eq(PROD_VISIBILITIES))).thenReturn(List.of());
+    when(collectionProcessingUtil.batchConvertToBasicModels(any())).thenReturn(List.of());
+
+    // findImageContentByTagId returns the intended order: 200, 201, 202.
+    when(tagRepository.findImageContentByTagId(eq(7L), eq(PROD_VISIBILITIES)))
+        .thenReturn(List.of(200L, 201L, 202L));
+
+    // findImagesByIds (unordered IN query) returns them scrambled AND omits 201 (e.g. deleted).
+    ContentImageEntity img202 = ContentImageEntity.builder().id(202L).build();
+    ContentImageEntity img200 = ContentImageEntity.builder().id(200L).build();
+    when(contentRepository.findImagesByIds(eq(List.of(200L, 201L, 202L))))
+        .thenReturn(List.of(img202, img200));
+
+    // The resolver must re-order to [200, 202] (201 dropped) before converting.
+    when(contentModelConverter.batchConvertImageEntitiesToModels(eq(List.of(img200, img202))))
+        .thenReturn(List.of(imageModel(200L), imageModel(202L)));
+
+    CollectionModel out = resolver.resolveTagView("travel", false).orElseThrow();
+
+    List<ContentModel> content = out.getContent();
+    assertThat(content).hasSize(2);
+    assertThat(((ContentModels.Image) content.get(0)).id()).isEqualTo(200L);
+    assertThat(((ContentModels.Image) content.get(1)).id()).isEqualTo(202L);
+  }
+
+  @Test
   void tagWithOnlyImages_rendersImageSectionAndCoverFromFirstImage() {
     TagEntity film = tag(9L, "Film", "film");
     when(tagRepository.findBySlug("film")).thenReturn(Optional.of(film));

--- a/src/test/java/edens/zac/portfolio/backend/services/UserSavesServiceIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/UserSavesServiceIntegrationTest.java
@@ -1,0 +1,83 @@
+package edens.zac.portfolio.backend.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import edens.zac.portfolio.backend.AbstractPostgresIntegrationTest;
+import edens.zac.portfolio.backend.model.ContentModels;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Exercises {@link UserSavesService#listSavedImages} end-to-end against the real schema: seeds a
+ * user + saved images and asserts full {@link ContentModels.Image} models come back newest-saved
+ * first with real fields populated.
+ */
+class UserSavesServiceIntegrationTest extends AbstractPostgresIntegrationTest {
+
+  @Autowired private UserSavesService userSavesService;
+  @Autowired private JdbcTemplate jdbcTemplate;
+
+  private Long seedUser(String email) {
+    return jdbcTemplate.queryForObject(
+        "INSERT INTO users (name, email, webauthn_user_handle, status) "
+            + "VALUES (?, ?, gen_random_uuid(), 'ACTIVE') RETURNING id",
+        Long.class,
+        email,
+        email);
+  }
+
+  private Long seedImage(String title, String webUrl) {
+    Long imageId =
+        jdbcTemplate.queryForObject(
+            "INSERT INTO content (content_type) VALUES ('IMAGE') RETURNING id", Long.class);
+    jdbcTemplate.update(
+        "INSERT INTO content_image (id, title, image_url_web) VALUES (?, ?, ?)",
+        imageId,
+        title,
+        webUrl);
+    return imageId;
+  }
+
+  private void save(Long userId, Long imageId, Instant createdAt) {
+    jdbcTemplate.update(
+        "INSERT INTO user_saved_image (user_id, image_id, created_at) VALUES (?, ?, ?)",
+        userId,
+        imageId,
+        Timestamp.from(createdAt));
+  }
+
+  @Test
+  void listSavedImagesReturnsFullModelsNewestFirst() {
+    Long userId = seedUser("saves-img-" + UUID.randomUUID() + "@example.com");
+    String olderUrl = "https://cdn.example.com/" + UUID.randomUUID() + ".jpg";
+    String newerUrl = "https://cdn.example.com/" + UUID.randomUUID() + ".jpg";
+    Long olderImage = seedImage("Older", olderUrl);
+    Long newerImage = seedImage("Newer", newerUrl);
+
+    Instant now = Instant.now();
+    save(userId, olderImage, now.minusSeconds(60));
+    save(userId, newerImage, now);
+
+    List<ContentModels.Image> images = userSavesService.listSavedImages(userId);
+
+    assertThat(images).hasSize(2);
+    assertThat(images.get(0).id()).isEqualTo(newerImage);
+    assertThat(images.get(0).title()).isEqualTo("Newer");
+    assertThat(images.get(0).imageUrl()).isEqualTo(newerUrl);
+    assertThat(images.get(1).id()).isEqualTo(olderImage);
+    assertThat(images.get(1).title()).isEqualTo("Older");
+    assertThat(images.get(1).imageUrl()).isEqualTo(olderUrl);
+  }
+
+  @Test
+  void listSavedImagesIsEmptyWhenNoneSaved() {
+    Long userId = seedUser("saves-img-empty-" + UUID.randomUUID() + "@example.com");
+
+    assertThat(userSavesService.listSavedImages(userId)).isEmpty();
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/services/UserSavesServiceIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/UserSavesServiceIntegrationTest.java
@@ -80,4 +80,26 @@ class UserSavesServiceIntegrationTest extends AbstractPostgresIntegrationTest {
 
     assertThat(userSavesService.listSavedImages(userId)).isEmpty();
   }
+
+  @Test
+  void savesAreIsolatedPerUser_userAneverSeesUserBsaves() {
+    Long userA = seedUser("saves-a-" + UUID.randomUUID() + "@example.com");
+    Long userB = seedUser("saves-b-" + UUID.randomUUID() + "@example.com");
+    Long imageA = seedImage("A's image", "https://cdn.example.com/" + UUID.randomUUID() + ".jpg");
+    Long imageB = seedImage("B's image", "https://cdn.example.com/" + UUID.randomUUID() + ".jpg");
+
+    userSavesService.add(userA, imageA);
+    userSavesService.add(userB, imageB);
+
+    // User A sees only their own save; user B's save never leaks into A's list.
+    assertThat(userSavesService.listSavedImageIds(userA)).containsExactly(imageA);
+    assertThat(userSavesService.listSavedImageIds(userA)).doesNotContain(imageB);
+    assertThat(userSavesService.listSavedImages(userA))
+        .extracting(ContentModels.Image::id)
+        .containsExactly(imageA);
+
+    // And symmetrically for user B.
+    assertThat(userSavesService.listSavedImageIds(userB)).containsExactly(imageB);
+    assertThat(userSavesService.listSavedImageIds(userB)).doesNotContain(imageA);
+  }
 }

--- a/src/test/java/edens/zac/portfolio/backend/services/UserSavesServiceIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/UserSavesServiceIntegrationTest.java
@@ -1,9 +1,12 @@
 package edens.zac.portfolio.backend.services;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import edens.zac.portfolio.backend.AbstractPostgresIntegrationTest;
+import edens.zac.portfolio.backend.config.ResourceNotFoundException;
 import edens.zac.portfolio.backend.model.ContentModels;
+import edens.zac.portfolio.backend.types.CollectionVisibility;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.List;
@@ -13,9 +16,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 /**
- * Exercises {@link UserSavesService#listSavedImages} end-to-end against the real schema: seeds a
- * user + saved images and asserts full {@link ContentModels.Image} models come back newest-saved
- * first with real fields populated.
+ * Exercises {@link UserSavesService} end-to-end against the real schema: seeds a user + saved
+ * images and asserts full {@link ContentModels.Image} models come back newest-saved first with real
+ * fields populated, and that the B4 visibility gate blocks saving (and reading) images the caller
+ * cannot see.
  */
 class UserSavesServiceIntegrationTest extends AbstractPostgresIntegrationTest {
 
@@ -43,6 +47,43 @@ class UserSavesServiceIntegrationTest extends AbstractPostgresIntegrationTest {
     return imageId;
   }
 
+  /** Seed a collection with the given visibility and return its id. */
+  private Long seedCollection(CollectionVisibility visibility) {
+    String slug = "coll-" + UUID.randomUUID();
+    return jdbcTemplate.queryForObject(
+        "INSERT INTO collection (title, slug, type, visibility) "
+            + "VALUES (?, ?, 'BLOG', ?) RETURNING id",
+        Long.class,
+        slug,
+        slug,
+        visibility.name());
+  }
+
+  /** Add {@code imageId} to {@code collectionId} with the given per-membership visibility flag. */
+  private void addMembership(Long collectionId, Long imageId, boolean visible) {
+    jdbcTemplate.update(
+        "INSERT INTO collection_content (collection_id, content_id, visible) VALUES (?, ?, ?)",
+        collectionId,
+        imageId,
+        visible);
+  }
+
+  /** Grant {@code userId} a GENERAL membership on {@code collectionId} (view access). */
+  private void grantMembership(Long userId, Long collectionId) {
+    jdbcTemplate.update(
+        "INSERT INTO user_collection (user_id, collection_id, role) VALUES (?, ?, 'GENERAL')",
+        userId,
+        collectionId);
+  }
+
+  /** Seed an image that is publicly visible (in a LISTED collection, membership visible). */
+  private Long seedVisibleImage(String title, String webUrl) {
+    Long imageId = seedImage(title, webUrl);
+    Long listed = seedCollection(CollectionVisibility.LISTED);
+    addMembership(listed, imageId, true);
+    return imageId;
+  }
+
   private void save(Long userId, Long imageId, Instant createdAt) {
     jdbcTemplate.update(
         "INSERT INTO user_saved_image (user_id, image_id, created_at) VALUES (?, ?, ?)",
@@ -56,8 +97,8 @@ class UserSavesServiceIntegrationTest extends AbstractPostgresIntegrationTest {
     Long userId = seedUser("saves-img-" + UUID.randomUUID() + "@example.com");
     String olderUrl = "https://cdn.example.com/" + UUID.randomUUID() + ".jpg";
     String newerUrl = "https://cdn.example.com/" + UUID.randomUUID() + ".jpg";
-    Long olderImage = seedImage("Older", olderUrl);
-    Long newerImage = seedImage("Newer", newerUrl);
+    Long olderImage = seedVisibleImage("Older", olderUrl);
+    Long newerImage = seedVisibleImage("Newer", newerUrl);
 
     Instant now = Instant.now();
     save(userId, olderImage, now.minusSeconds(60));
@@ -85,8 +126,10 @@ class UserSavesServiceIntegrationTest extends AbstractPostgresIntegrationTest {
   void savesAreIsolatedPerUser_userAneverSeesUserBsaves() {
     Long userA = seedUser("saves-a-" + UUID.randomUUID() + "@example.com");
     Long userB = seedUser("saves-b-" + UUID.randomUUID() + "@example.com");
-    Long imageA = seedImage("A's image", "https://cdn.example.com/" + UUID.randomUUID() + ".jpg");
-    Long imageB = seedImage("B's image", "https://cdn.example.com/" + UUID.randomUUID() + ".jpg");
+    Long imageA =
+        seedVisibleImage("A's image", "https://cdn.example.com/" + UUID.randomUUID() + ".jpg");
+    Long imageB =
+        seedVisibleImage("B's image", "https://cdn.example.com/" + UUID.randomUUID() + ".jpg");
 
     userSavesService.add(userA, imageA);
     userSavesService.add(userB, imageB);
@@ -101,5 +144,104 @@ class UserSavesServiceIntegrationTest extends AbstractPostgresIntegrationTest {
     // And symmetrically for user B.
     assertThat(userSavesService.listSavedImageIds(userB)).containsExactly(imageB);
     assertThat(userSavesService.listSavedImageIds(userB)).doesNotContain(imageA);
+  }
+
+  // ---- B4 visibility gate ----------------------------------------------------
+
+  @Test
+  void addAllowsImageInListedCollection() {
+    Long userId = seedUser("saves-listed-" + UUID.randomUUID() + "@example.com");
+    Long imageId =
+        seedVisibleImage("Listed", "https://cdn.example.com/" + UUID.randomUUID() + ".jpg");
+
+    userSavesService.add(userId, imageId);
+
+    assertThat(userSavesService.listSavedImageIds(userId)).containsExactly(imageId);
+  }
+
+  @Test
+  void addBlocksImageOnlyInHiddenCollection() {
+    Long userId = seedUser("saves-hidden-" + UUID.randomUUID() + "@example.com");
+    Long imageId = seedImage("Hidden", "https://cdn.example.com/" + UUID.randomUUID() + ".jpg");
+    Long hidden = seedCollection(CollectionVisibility.HIDDEN);
+    addMembership(hidden, imageId, true);
+
+    assertThatThrownBy(() -> userSavesService.add(userId, imageId))
+        .isInstanceOf(ResourceNotFoundException.class);
+
+    assertThat(userSavesService.listSavedImageIds(userId)).isEmpty();
+  }
+
+  @Test
+  void addBlocksImageOnlyInUnlistedCollection() {
+    // Policy default: UNLISTED-only images are NOT saveable (LISTED or explicit membership only).
+    Long userId = seedUser("saves-unlisted-" + UUID.randomUUID() + "@example.com");
+    Long imageId = seedImage("Unlisted", "https://cdn.example.com/" + UUID.randomUUID() + ".jpg");
+    Long unlisted = seedCollection(CollectionVisibility.UNLISTED);
+    addMembership(unlisted, imageId, true);
+
+    assertThatThrownBy(() -> userSavesService.add(userId, imageId))
+        .isInstanceOf(ResourceNotFoundException.class);
+  }
+
+  @Test
+  void addAllowsImageInCollectionUserHasExplicitAccessTo() {
+    Long userId = seedUser("saves-grant-" + UUID.randomUUID() + "@example.com");
+    Long imageId = seedImage("Gated", "https://cdn.example.com/" + UUID.randomUUID() + ".jpg");
+    Long gated = seedCollection(CollectionVisibility.UNLISTED);
+    addMembership(gated, imageId, true);
+    grantMembership(userId, gated);
+
+    userSavesService.add(userId, imageId);
+
+    assertThat(userSavesService.listSavedImageIds(userId)).containsExactly(imageId);
+  }
+
+  @Test
+  void addBlocksImageWhoseOnlyMembershipIsSoftRemoved() {
+    // cc.visible = false must not count as a visible membership even in a LISTED collection.
+    Long userId = seedUser("saves-softremoved-" + UUID.randomUUID() + "@example.com");
+    Long imageId =
+        seedImage("SoftRemoved", "https://cdn.example.com/" + UUID.randomUUID() + ".jpg");
+    Long listed = seedCollection(CollectionVisibility.LISTED);
+    addMembership(listed, imageId, false);
+
+    assertThatThrownBy(() -> userSavesService.add(userId, imageId))
+        .isInstanceOf(ResourceNotFoundException.class);
+  }
+
+  @Test
+  void addBlocksNonexistentImage() {
+    Long userId = seedUser("saves-missing-" + UUID.randomUUID() + "@example.com");
+
+    assertThatThrownBy(() -> userSavesService.add(userId, 999_999_999L))
+        .isInstanceOf(ResourceNotFoundException.class);
+  }
+
+  @Test
+  void savedImageDropsFromListWhenLaterHidden() {
+    // Defense-in-depth: an image saved while visible must fall out of the list once its only
+    // membership is soft-removed (owner hides it).
+    Long userId = seedUser("saves-hide-later-" + UUID.randomUUID() + "@example.com");
+    Long imageId =
+        seedImage("HiddenLater", "https://cdn.example.com/" + UUID.randomUUID() + ".jpg");
+    Long listed = seedCollection(CollectionVisibility.LISTED);
+    addMembership(listed, imageId, true);
+
+    userSavesService.add(userId, imageId);
+    assertThat(userSavesService.listSavedImageIds(userId)).containsExactly(imageId);
+    assertThat(userSavesService.listSavedImages(userId))
+        .extracting(ContentModels.Image::id)
+        .containsExactly(imageId);
+
+    // Owner hides the image (soft-remove the membership).
+    jdbcTemplate.update(
+        "UPDATE collection_content SET visible = false WHERE collection_id = ? AND content_id = ?",
+        listed,
+        imageId);
+
+    // The raw save row still exists, but the full-model read filters it out.
+    assertThat(userSavesService.listSavedImageIds(userId)).containsExactly(imageId);
+    assertThat(userSavesService.listSavedImages(userId)).isEmpty();
   }
 }

--- a/src/test/java/edens/zac/portfolio/backend/services/UserSavesServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/UserSavesServiceTest.java
@@ -1,0 +1,63 @@
+package edens.zac.portfolio.backend.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import edens.zac.portfolio.backend.config.ResourceNotFoundException;
+import edens.zac.portfolio.backend.dao.ContentRepository;
+import edens.zac.portfolio.backend.dao.UserSavedImageRepository;
+import edens.zac.portfolio.backend.entity.UserSavedImageEntity;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserSavesServiceTest {
+
+  @Mock private UserSavedImageRepository userSavedImageRepository;
+  @Mock private ContentRepository contentRepository;
+  @Mock private ContentModelConverter contentModelConverter;
+
+  @InjectMocks private UserSavesService service;
+
+  @Test
+  void addInsertsWhenImageIsVisibleToUser() {
+    when(contentRepository.isImageVisibleToUser(42L, 7L)).thenReturn(true);
+
+    service.add(7L, 42L);
+
+    ArgumentCaptor<UserSavedImageEntity> captor =
+        ArgumentCaptor.forClass(UserSavedImageEntity.class);
+    verify(userSavedImageRepository).insert(captor.capture());
+    UserSavedImageEntity inserted = captor.getValue();
+    assertThat(inserted.getUserId()).isEqualTo(7L);
+    assertThat(inserted.getImageId()).isEqualTo(42L);
+  }
+
+  @Test
+  void addThrowsNotFoundWhenImageNotVisibleToUser() {
+    when(contentRepository.isImageVisibleToUser(42L, 7L)).thenReturn(false);
+
+    assertThatThrownBy(() -> service.add(7L, 42L))
+        .isInstanceOf(ResourceNotFoundException.class)
+        .hasMessageContaining("42");
+
+    // Not-visible (or nonexistent) image must never reach the insert.
+    verify(userSavedImageRepository, never()).insert(any());
+  }
+
+  @Test
+  void removeDeletesWithoutVisibilityCheck() {
+    service.remove(7L, 42L);
+
+    verify(userSavedImageRepository).deleteByUserIdAndImageId(7L, 42L);
+    verify(contentRepository, never()).isImageVisibleToUser(any(), any());
+  }
+}


### PR DESCRIPTION
## A3 · Save as Collection + Track C · saves/follows (backend)

Stacked on `0194-tag-view-read-model-be`. Frontend counterpart: `0195-save-as-collection`.

### A3 — Save as Collection
- `V39__add_tag_converted_collection_id.sql` — nullable FK `tag.converted_collection_id → collection(id) ON DELETE SET NULL`.
- `POST /api/admin/tags/{id}/save-as-collection` (`TagAdminController` + `TagService`, `@Transactional`): create a collection with `slug = tag.slug` (type/visibility from body, default PORTFOLIO/UNLISTED) → snapshot the tag's members into `collection_content` (reusing `linkCollectionToParent` + `saveContent`) → flag the tag converted → return the new collection (`UpdateResponse`, slug at `collection.slug`). Rejects missing tag (404), already-converted, and slug already owned by a real collection.
- `TagViewResolver` now returns empty for converted tags and stamps `derived=true` on synthetic payloads; `CollectionModel` gains a `derived` flag (false for real collections).

### Track C — saves + follows
- `V40__create_user_saves_and_follows.sql` — `user_saved_image(user_id, image_id)` + `user_followed_collection(user_id, collection_id)`, FK `users(id)` (canonical after the V35 `app_user`→`users` rename).
- `/api/read/user/saves/*` + `/api/read/user/follows/*` (controllers + services + repos mirroring the Selects stack). **401 when anonymous; NO per-collection access check = bookmark semantics.**

### ⚠️ Notes for review
- **Security review**: the bookmark semantics (save/follow without collection access) are intentional but should be signed off before merge.
- Build: `./mvnw clean install` green — **906 tests, 0 failures** (16 new: 6 repository integration + 10 MockMvc controller unit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
