### PR TITLE
feat(admin): accept email changes on the user-update endpoint

### DIFF
--- a/src/main/java/edens/zac/portfolio/backend/controller/admin/AdminUserController.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/admin/AdminUserController.java
@@ -180,9 +180,10 @@ public class AdminUserController {
 
   /**
    * Update the admin-editable fields (email, display name, status, description). Email is the login
-   * identity: when non-null and non-blank it is normalized to lowercase and updated, returning
+   * identity: when non-null and non-empty it is normalized to lowercase and updated, returning
    * {@code 409 Conflict} if another user already owns it — resubmitting the user's own email (any
-   * casing) succeeds. A {@code null} or blank email leaves it unchanged.
+   * casing) succeeds. A {@code null}, empty, or omitted email leaves it unchanged (whitespace-only
+   * is rejected with {@code 400} by the {@code @Email} constraint before this method runs).
    *
    * @param id the {@code app_user.id}
    * @param request the new email (nullable = unchanged), display name (nullable), status

--- a/src/main/java/edens/zac/portfolio/backend/controller/admin/AdminUserController.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/admin/AdminUserController.java
@@ -179,11 +179,16 @@ public class AdminUserController {
   }
 
   /**
-   * Update the two admin-editable fields (display name + status). Email is immutable here.
+   * Update the admin-editable fields (email, display name, status, description). Email is the login
+   * identity: when non-null and non-blank it is normalized to lowercase and updated, returning
+   * {@code 409 Conflict} if another user already owns it — resubmitting the user's own email (any
+   * casing) succeeds. A {@code null} or blank email leaves it unchanged.
    *
    * @param id the {@code app_user.id}
-   * @param request the new display name (nullable) and status (required)
-   * @return {@code 200} with the refreshed {@link AdminUserSummary}, or {@code 404} if no such user
+   * @param request the new email (nullable = unchanged), display name (nullable), status
+   *     (required), and description (nullable)
+   * @return {@code 200} with the refreshed {@link AdminUserSummary}, {@code 404} if no such user,
+   *     or {@code 409} if another user owns the requested email
    */
   @PatchMapping("/{id}")
   @Transactional
@@ -191,6 +196,16 @@ public class AdminUserController {
       @PathVariable Long id, @Valid @RequestBody UpdateUserRequest request) {
     if (appUserRepository.findById(id).isEmpty()) {
       return ResponseEntity.notFound().build();
+    }
+    if (request.email() != null && !request.email().isBlank()) {
+      String email = request.email().toLowerCase();
+      Optional<AppUserEntity> owner = appUserRepository.findByEmail(email);
+      if (owner.isPresent() && !owner.get().getId().equals(id)) {
+        log.warn(
+            "Admin update-user rejected: email already exists (userId={}, email={})", id, email);
+        return ResponseEntity.status(HttpStatus.CONFLICT).build();
+      }
+      appUserRepository.updateEmail(id, email);
     }
     appUserRepository.updateName(id, request.displayName());
     appUserRepository.updateStatus(id, request.status());

--- a/src/main/java/edens/zac/portfolio/backend/controller/admin/UserRequests.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/admin/UserRequests.java
@@ -43,16 +43,21 @@ public final class UserRequests {
   public record CreateUserResponse(Long userId, String inviteUrl) {}
 
   /**
-   * Body for {@code PATCH /api/admin/users/{id}} — updates the admin-editable fields. Email is
-   * deliberately immutable (it is the login identity and invite target). {@code displayName} may be
-   * {@code null} to clear it; {@code status} is required.
+   * Body for {@code PATCH /api/admin/users/{id}} — updates the admin-editable fields. {@code email}
+   * is optional: {@code null} or blank leaves the login email unchanged; when present the
+   * controller normalizes it to lowercase and returns {@code 409 Conflict} if another user already
+   * owns it. {@code displayName} may be {@code null} to clear it; {@code status} is required.
    *
+   * @param email the new account email, or {@code null}/blank to leave it unchanged
    * @param displayName the new display name, or {@code null} to clear
    * @param status the new lifecycle status (INVITED / ACTIVE / DISABLED)
    * @param description the admin-authored per-user description, or {@code null} to clear
    */
   public record UpdateUserRequest(
-      String displayName, @NotNull UserStatus status, @Size(max = 500) String description) {}
+      @Email String email,
+      String displayName,
+      @NotNull UserStatus status,
+      @Size(max = 500) String description) {}
 
   /**
    * One associated-collection row in the admin user detail. {@code role} is {@code null} when the

--- a/src/main/java/edens/zac/portfolio/backend/controller/admin/UserRequests.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/admin/UserRequests.java
@@ -44,11 +44,12 @@ public final class UserRequests {
 
   /**
    * Body for {@code PATCH /api/admin/users/{id}} — updates the admin-editable fields. {@code email}
-   * is optional: {@code null} or blank leaves the login email unchanged; when present the
-   * controller normalizes it to lowercase and returns {@code 409 Conflict} if another user already
-   * owns it. {@code displayName} may be {@code null} to clear it; {@code status} is required.
+   * is optional: {@code null}, empty, or omitted leaves the login email unchanged (whitespace-only
+   * fails the {@code @Email} constraint with {@code 400}); when non-empty the controller normalizes
+   * it to lowercase and returns {@code 409 Conflict} if another user already owns it. {@code
+   * displayName} may be {@code null} to clear it; {@code status} is required.
    *
-   * @param email the new account email, or {@code null}/blank to leave it unchanged
+   * @param email the new account email, or {@code null}/empty to leave it unchanged
    * @param displayName the new display name, or {@code null} to clear
    * @param status the new lifecycle status (INVITED / ACTIVE / DISABLED)
    * @param description the admin-authored per-user description, or {@code null} to clear

--- a/src/main/java/edens/zac/portfolio/backend/dao/AppUserRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/AppUserRepository.java
@@ -121,4 +121,12 @@ public class AppUserRepository extends BaseDao {
         createParameterSource().addValue("description", description).addValue("id", id);
     update(sql, params);
   }
+
+  @Transactional
+  public void updateEmail(Long id, String email) {
+    String sql = "UPDATE users SET email = :email, updated_at = now() WHERE id = :id";
+    MapSqlParameterSource params =
+        createParameterSource().addValue("email", email).addValue("id", id);
+    update(sql, params);
+  }
 }

--- a/src/test/java/edens/zac/portfolio/backend/controller/admin/AdminUserControllerTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/admin/AdminUserControllerTest.java
@@ -372,6 +372,150 @@ class AdminUserControllerTest {
 
       verify(appUserRepository, never()).updateName(anyLong(), anyString());
     }
+
+    @Test
+    void updateUserChangesEmailAndReturnsSummary() throws Exception {
+      AppUserEntity before =
+          AppUserEntity.builder()
+              .id(8L)
+              .email("ken@example.com")
+              .name("Ken")
+              .status(UserStatus.INVITED)
+              .build();
+      AppUserEntity after =
+          AppUserEntity.builder()
+              .id(8L)
+              .email("kenneth@example.com")
+              .name("Ken")
+              .status(UserStatus.INVITED)
+              .build();
+      when(appUserRepository.findById(8L))
+          .thenReturn(Optional.of(before))
+          .thenReturn(Optional.of(after));
+      when(appUserRepository.findByEmail("kenneth@example.com")).thenReturn(Optional.empty());
+
+      mockMvc
+          .perform(
+              patch("/api/admin/users/8")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(
+                      "{\"email\":\"kenneth@example.com\",\"displayName\":\"Ken\","
+                          + "\"status\":\"INVITED\"}"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.email").value("kenneth@example.com"));
+
+      verify(appUserRepository).updateEmail(8L, "kenneth@example.com");
+    }
+
+    @Test
+    void updateUserWithEmailOwnedByAnotherUserReturns409() throws Exception {
+      AppUserEntity ken =
+          AppUserEntity.builder()
+              .id(8L)
+              .email("ken@example.com")
+              .status(UserStatus.INVITED)
+              .build();
+      when(appUserRepository.findById(8L)).thenReturn(Optional.of(ken));
+      when(appUserRepository.findByEmail("alice@example.com"))
+          .thenReturn(Optional.of(AppUserEntity.builder().id(1L).build()));
+
+      mockMvc
+          .perform(
+              patch("/api/admin/users/8")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"email\":\"alice@example.com\",\"status\":\"INVITED\"}"))
+          .andExpect(status().isConflict());
+
+      verify(appUserRepository, never()).updateEmail(anyLong(), anyString());
+      verify(appUserRepository, never()).updateStatus(anyLong(), any());
+    }
+
+    @Test
+    void updateEmailIsNormalizedToLowercase() throws Exception {
+      AppUserEntity before =
+          AppUserEntity.builder()
+              .id(8L)
+              .email("ken@example.com")
+              .status(UserStatus.INVITED)
+              .build();
+      AppUserEntity after =
+          AppUserEntity.builder()
+              .id(8L)
+              .email("kenneth@example.com")
+              .status(UserStatus.INVITED)
+              .build();
+      when(appUserRepository.findById(8L))
+          .thenReturn(Optional.of(before))
+          .thenReturn(Optional.of(after));
+      when(appUserRepository.findByEmail("kenneth@example.com")).thenReturn(Optional.empty());
+
+      mockMvc
+          .perform(
+              patch("/api/admin/users/8")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"email\":\"KENNETH@EXAMPLE.COM\",\"status\":\"INVITED\"}"))
+          .andExpect(status().isOk());
+
+      // Both the duplicate check and the write must see the lowercased email.
+      verify(appUserRepository).findByEmail("kenneth@example.com");
+      verify(appUserRepository).updateEmail(8L, "kenneth@example.com");
+    }
+
+    @Test
+    void resubmittingOwnEmailWithDifferentCaseReturns200NotConflict() throws Exception {
+      // The frontend always sends the email field, so "unchanged email" (possibly re-cased) is
+      // the common path — the duplicate check must not trip on the user's own row.
+      AppUserEntity ken =
+          AppUserEntity.builder()
+              .id(8L)
+              .email("ken@example.com")
+              .status(UserStatus.INVITED)
+              .build();
+      when(appUserRepository.findById(8L)).thenReturn(Optional.of(ken));
+      when(appUserRepository.findByEmail("ken@example.com")).thenReturn(Optional.of(ken));
+
+      mockMvc
+          .perform(
+              patch("/api/admin/users/8")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"email\":\"KEN@EXAMPLE.COM\",\"status\":\"INVITED\"}"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.email").value("ken@example.com"));
+
+      verify(appUserRepository).updateEmail(8L, "ken@example.com");
+    }
+
+    @Test
+    void updateWithoutEmailFieldLeavesEmailUntouched() throws Exception {
+      AppUserEntity before =
+          AppUserEntity.builder()
+              .id(8L)
+              .email("ken@example.com")
+              .name("Ken")
+              .status(UserStatus.INVITED)
+              .build();
+      AppUserEntity after =
+          AppUserEntity.builder()
+              .id(8L)
+              .email("ken@example.com")
+              .name("Kenneth")
+              .status(UserStatus.ACTIVE)
+              .build();
+      when(appUserRepository.findById(8L))
+          .thenReturn(Optional.of(before))
+          .thenReturn(Optional.of(after));
+
+      mockMvc
+          .perform(
+              patch("/api/admin/users/8")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"displayName\":\"Kenneth\",\"status\":\"ACTIVE\"}"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.email").value("ken@example.com"));
+
+      verify(appUserRepository, never()).updateEmail(anyLong(), anyString());
+      verify(appUserRepository, never()).findByEmail(anyString());
+    }
   }
 
   @Nested

--- a/src/test/java/edens/zac/portfolio/backend/controller/admin/AdminUserControllerTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/admin/AdminUserControllerTest.java
@@ -426,8 +426,12 @@ class AdminUserControllerTest {
                   .content("{\"email\":\"alice@example.com\",\"status\":\"INVITED\"}"))
           .andExpect(status().isConflict());
 
+      // 409 is a normal return, so @Transactional commits this path: NO field may have been
+      // written by the time the conflict is detected, or a partial update would persist.
       verify(appUserRepository, never()).updateEmail(anyLong(), anyString());
+      verify(appUserRepository, never()).updateName(anyLong(), any());
       verify(appUserRepository, never()).updateStatus(anyLong(), any());
+      verify(appUserRepository, never()).updateDescription(anyLong(), any());
     }
 
     @Test
@@ -515,6 +519,20 @@ class AdminUserControllerTest {
 
       verify(appUserRepository, never()).updateEmail(anyLong(), anyString());
       verify(appUserRepository, never()).findByEmail(anyString());
+    }
+
+    @Test
+    void updateWithMalformedEmailReturns400() throws Exception {
+      // Pins the @Email constraint on UpdateUserRequest: bean validation rejects the body
+      // before the controller body runs, so no findById stub is needed and nothing is written.
+      mockMvc
+          .perform(
+              patch("/api/admin/users/8")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"email\":\"not-an-email\",\"status\":\"INVITED\"}"))
+          .andExpect(status().isBadRequest());
+
+      verify(appUserRepository, never()).updateEmail(anyLong(), anyString());
     }
   }
 


### PR DESCRIPTION
## Summary
- `UpdateUserRequest` gains `@Email String email` (null/empty/omitted = unchanged; whitespace-only → 400).
- `PATCH /api/admin/users/{id}`: lowercases exactly like `createUser`, duplicate check via `findByEmail` with self-exemption (re-saving your own email, any casing, succeeds), returns **409 before any write**, then `updateEmail` ahead of the existing field writes. `@Transactional` keeps the four writes atomic.
- New `AppUserRepository.updateEmail` mirroring the sibling update methods.
- Safe by design: WebAuthn credentials, sessions, and invites key off `user.id`, so an email change breaks no logins. Sessions resolve the principal from the DB per request — the renamed user sees the new email immediately.

## Verification
- `AdminUserControllerTest` **27/27** (UpdateUser nest 10, incl. no-writes-on-409 pins and `@Email` 400 pin); full suite **943 run / 0 failures** with testcontainers; Spotless clean.
- Spec-compliance + adversarial quality review + whole-branch integration review: 0 critical / 0 important.

## Companion
Frontend PR: `0202-logout-state-and-user-email` (unlocks the email field in the admin UI). Known follow-up (documented in roadmap): changing an INVITED user's email doesn't auto-invalidate the old invite link — re-send does the right thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)