### PR TITLE
fix(auth): close anonymous admin API authorization hole

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,16 @@ INTERNAL_API_SECRET=your_secure_secret_here
 # docs/runbooks/secret-rotation.md. Leave blank otherwise.
 INTERNAL_API_SECRET_NEXT=
 
+# Designates the SPECIFIC admin user on startup (AdminBootstrap). No default — the
+# repo is public and carries no identity. Leave both blank to skip bootstrap entirely.
+ADMIN_BOOTSTRAP_EMAIL=
+ADMIN_BOOTSTRAP_PASSWORD=
+
+# Inner app-layer gate for /api/admin/**: requires hasRole("ADMIN") when true (default).
+# Only ever set to false for a non-prod deployment that intentionally wants a login-free
+# admin surface (mirrors application-dev.properties); prod must leave this unset/true.
+ADMIN_ENFORCE_AUTHZ=true
+
 # Photography directory mount for RAW file uploads (local dev only, not needed on EC2)
 # PHOTOGRAPHY_PATH=/Users/yourname/Photography
 # External drives root, so RAW files stored on external HDDs (/Volumes/<drive>/...) can be

--- a/src/main/java/edens/zac/portfolio/backend/config/SecurityConfig.java
+++ b/src/main/java/edens/zac/portfolio/backend/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package edens.zac.portfolio.backend.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -19,7 +20,10 @@ import org.springframework.security.web.access.intercept.AuthorizationFilter;
 public class SecurityConfig {
 
   @Bean
-  public SecurityFilterChain filterChain(HttpSecurity http, SessionAuthenticationFilter saf)
+  public SecurityFilterChain filterChain(
+      HttpSecurity http,
+      SessionAuthenticationFilter saf,
+      @Value("${app.admin.enforce-authz:true}") boolean enforceAdminAuthz)
       throws Exception {
     http
         // CSRF defense for the API is provided by SameSite=Strict cookies + the BFF write-method
@@ -31,26 +35,31 @@ public class SecurityConfig {
         .sessionManagement(
             session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests(
-            auth ->
-                auth.requestMatchers(HttpMethod.POST, "/api/auth/login")
-                    .permitAll()
-                    .requestMatchers("/api/auth/webauthn/login/**")
-                    .permitAll()
-                    .requestMatchers(HttpMethod.GET, "/api/auth/invite/*")
-                    .permitAll()
-                    .requestMatchers(HttpMethod.POST, "/api/auth/invite/*/accept")
-                    .permitAll()
-                    .requestMatchers("/api/auth/me", "/api/auth/logout")
-                    .authenticated()
-                    .requestMatchers("/api/auth/webauthn/register/**")
-                    .authenticated()
-                    // Everything else (including /api/admin/**) is permitAll at the Spring layer.
-                    // Admin/write protection is the prod-only InternalSecretFilter + BFF perimeter,
-                    // not this matrix — outside prod these routes are unauthenticated. Per-user
-                    // admin RBAC is deferred (Phase A). Do NOT switch /api/admin/** to
-                    // authenticated(): admin calls carry the BFF secret, not a session principal.
-                    .anyRequest()
-                    .permitAll())
+            auth -> {
+              auth.requestMatchers(HttpMethod.POST, "/api/auth/login")
+                  .permitAll()
+                  .requestMatchers("/api/auth/webauthn/login/**")
+                  .permitAll()
+                  .requestMatchers(HttpMethod.GET, "/api/auth/invite/*")
+                  .permitAll()
+                  .requestMatchers(HttpMethod.POST, "/api/auth/invite/*/accept")
+                  .permitAll()
+                  .requestMatchers("/api/auth/me", "/api/auth/logout")
+                  .authenticated()
+                  .requestMatchers("/api/auth/webauthn/register/**")
+                  .authenticated();
+              // /api/admin/** is the inner, app-layer gate. When enforce-authz is on (prod, and
+              // the default everywhere else), these routes require a session principal whose user
+              // row carries is_admin=true — ROLE_ADMIN, granted by SessionAuthenticationFilter.
+              // In prod this sits INSIDE the InternalSecretFilter perimeter: a request must both
+              // carry the BFF secret AND resolve to an admin. The toggle is flipped off only in
+              // application-dev.properties, where /api/admin/** then falls through to permitAll
+              // below so local dev stays login-free (mirrors InternalSecretFilter being prod-only).
+              if (enforceAdminAuthz) {
+                auth.requestMatchers("/api/admin/**").hasRole("ADMIN");
+              }
+              auth.anyRequest().permitAll();
+            })
         .addFilterBefore(saf, AuthorizationFilter.class)
         .exceptionHandling(
             ex ->

--- a/src/main/java/edens/zac/portfolio/backend/config/SessionAuthenticationFilter.java
+++ b/src/main/java/edens/zac/portfolio/backend/config/SessionAuthenticationFilter.java
@@ -8,7 +8,7 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.List;
+import java.util.ArrayList;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -35,9 +35,12 @@ public class SessionAuthenticationFilter extends OncePerRequestFilter {
       Optional<AuthPrincipal> principal = sessionService.resolve(token);
       principal.ifPresent(
           p -> {
-            var auth =
-                new UsernamePasswordAuthenticationToken(
-                    p, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+            var authorities = new ArrayList<SimpleGrantedAuthority>();
+            authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+            if (p.isAdmin()) {
+              authorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
+            }
+            var auth = new UsernamePasswordAuthenticationToken(p, null, authorities);
             SecurityContext context = SecurityContextHolder.createEmptyContext();
             context.setAuthentication(auth);
             SecurityContextHolder.setContext(context);

--- a/src/main/java/edens/zac/portfolio/backend/controller/admin/AdminUserController.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/admin/AdminUserController.java
@@ -42,13 +42,16 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * Admin endpoints for user account management.
  *
- * <p>Authorization is perimeter-based, not role-based. In the {@code prod} profile every request is
- * gated by {@link edens.zac.portfolio.backend.config.InternalSecretFilter} on the {@code
- * X-Internal-Secret} header that the BFF proxy injects for same-origin admin calls. Spring
- * Security's authorization matrix does NOT gate these routes — {@link
- * edens.zac.portfolio.backend.config.SecurityConfig} falls through to {@code permitAll}, so outside
- * {@code prod} (e.g. local dev) they are unauthenticated. Per-user admin RBAC is deferred (Phase
- * A).
+ * <p>Authorization is two-layer. In the {@code prod} profile, {@link
+ * edens.zac.portfolio.backend.config.InternalSecretFilter} gates every request as an outer
+ * transport perimeter, checking the {@code X-Internal-Secret} header the BFF proxy injects for
+ * same-origin admin calls — this proves the request came through the BFF, not who the caller is.
+ * Inside that perimeter, {@link edens.zac.portfolio.backend.config.SecurityConfig} enforces the
+ * app-layer gate: these routes require {@code hasRole("ADMIN")}, granted only to a session
+ * principal whose user row carries {@code users.is_admin = true}. That inner gate is controlled by
+ * the {@code app.admin.enforce-authz} toggle (default {@code true} — enforced everywhere except
+ * where {@code application-dev.properties} flips it off, so local dev stays login-free without a
+ * prod-only transport perimeter to otherwise protect it).
  */
 @Slf4j
 @RestController

--- a/src/main/java/edens/zac/portfolio/backend/controller/admin/AdminUserController.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/admin/AdminUserController.java
@@ -195,9 +195,11 @@ public class AdminUserController {
   @Transactional
   public ResponseEntity<AdminUserSummary> updateUser(
       @PathVariable Long id, @Valid @RequestBody UpdateUserRequest request) {
-    if (appUserRepository.findById(id).isEmpty()) {
+    Optional<AppUserEntity> maybeExisting = appUserRepository.findById(id);
+    if (maybeExisting.isEmpty()) {
       return ResponseEntity.notFound().build();
     }
+    AppUserEntity existing = maybeExisting.get();
     if (request.email() != null && !request.email().isBlank()) {
       String email = request.email().toLowerCase();
       Optional<AppUserEntity> owner = appUserRepository.findByEmail(email);
@@ -207,6 +209,14 @@ public class AdminUserController {
         return ResponseEntity.status(HttpStatus.CONFLICT).build();
       }
       appUserRepository.updateEmail(id, email);
+      // When an INVITED user's login email actually changes, kill their outstanding invite: the
+      // old link was bound to the prior address, so whoever still holds it (e.g. the prior inbox)
+      // could otherwise redeem it onto the now-corrected account. The admin must issue a fresh
+      // invite to the new address. A no-op change (same address, any casing) leaves the invite
+      // live; ACTIVE users have no pending onboarding invite to hijack.
+      if (existing.getStatus() == UserStatus.INVITED && !email.equals(existing.getEmail())) {
+        userInviteService.invalidateInvites(id);
+      }
     }
     appUserRepository.updateName(id, request.displayName());
     appUserRepository.updateStatus(id, request.status());

--- a/src/main/java/edens/zac/portfolio/backend/controller/auth/AuthController.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/auth/AuthController.java
@@ -103,7 +103,8 @@ public class AuthController {
             .map(m -> new GalleryMembership(m.getCollectionId(), m.getRole()))
             .toList();
     return ResponseEntity.ok(
-        new MeResponse(principal.email(), principal.mfaSatisfied(), galleries));
+        new MeResponse(
+            principal.email(), principal.isAdmin(), principal.mfaSatisfied(), galleries));
   }
 
   private static String readCookie(HttpServletRequest request) {

--- a/src/main/java/edens/zac/portfolio/backend/dao/AppUserRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/AppUserRepository.java
@@ -23,7 +23,7 @@ public class AppUserRepository extends BaseDao {
   private static final String SELECT_APP_USER =
       """
       SELECT id, email, password_hash, webauthn_user_handle, name, description, status,
-             created_at, updated_at
+             is_admin, created_at, updated_at
       FROM users
       """;
 
@@ -38,6 +38,7 @@ public class AppUserRepository extends BaseDao {
             .name(rs.getString("name"))
             .description(rs.getString("description"))
             .status(UserStatus.valueOf(rs.getString("status")))
+            .isAdmin(rs.getBoolean("is_admin"))
             .createdAt(getLocalDateTime(rs, "created_at"))
             .updatedAt(getLocalDateTime(rs, "updated_at"))
             .build();
@@ -127,6 +128,14 @@ public class AppUserRepository extends BaseDao {
     String sql = "UPDATE users SET email = :email, updated_at = now() WHERE id = :id";
     MapSqlParameterSource params =
         createParameterSource().addValue("email", email).addValue("id", id);
+    update(sql, params);
+  }
+
+  @Transactional
+  public void setAdmin(Long id, boolean isAdmin) {
+    String sql = "UPDATE users SET is_admin = :isAdmin, updated_at = now() WHERE id = :id";
+    MapSqlParameterSource params =
+        createParameterSource().addValue("isAdmin", isAdmin).addValue("id", id);
     update(sql, params);
   }
 }

--- a/src/main/java/edens/zac/portfolio/backend/entity/AppUserEntity.java
+++ b/src/main/java/edens/zac/portfolio/backend/entity/AppUserEntity.java
@@ -20,6 +20,7 @@ public class AppUserEntity {
   private String name;
   private String description;
   private UserStatus status;
+  private boolean isAdmin;
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
 }

--- a/src/main/java/edens/zac/portfolio/backend/model/AuthPrincipal.java
+++ b/src/main/java/edens/zac/portfolio/backend/model/AuthPrincipal.java
@@ -1,3 +1,3 @@
 package edens.zac.portfolio.backend.model;
 
-public record AuthPrincipal(Long userId, String email, boolean mfaSatisfied) {}
+public record AuthPrincipal(Long userId, String email, boolean isAdmin, boolean mfaSatisfied) {}

--- a/src/main/java/edens/zac/portfolio/backend/model/AuthPrincipal.java
+++ b/src/main/java/edens/zac/portfolio/backend/model/AuthPrincipal.java
@@ -1,3 +1,14 @@
 package edens.zac.portfolio.backend.model;
 
-public record AuthPrincipal(Long userId, String email, boolean isAdmin, boolean mfaSatisfied) {}
+public record AuthPrincipal(Long userId, String email, boolean isAdmin, boolean mfaSatisfied) {
+
+  /**
+   * Constructs a non-admin (client) principal. Prefer this over the full constructor at new call
+   * sites: {@code isAdmin} and {@code mfaSatisfied} are adjacent, same-typed booleans with no
+   * compiler-enforced positional check, so a transposed pair compiles cleanly and silently grants
+   * or denies admin. This factory pins {@code isAdmin=false} by name instead of position.
+   */
+  public static AuthPrincipal client(Long userId, String email, boolean mfaSatisfied) {
+    return new AuthPrincipal(userId, email, false, mfaSatisfied);
+  }
+}

--- a/src/main/java/edens/zac/portfolio/backend/model/MeResponse.java
+++ b/src/main/java/edens/zac/portfolio/backend/model/MeResponse.java
@@ -2,4 +2,5 @@ package edens.zac.portfolio.backend.model;
 
 import java.util.List;
 
-public record MeResponse(String email, boolean mfaSatisfied, List<GalleryMembership> galleries) {}
+public record MeResponse(
+    String email, boolean isAdmin, boolean mfaSatisfied, List<GalleryMembership> galleries) {}

--- a/src/main/java/edens/zac/portfolio/backend/services/AdminBootstrap.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/AdminBootstrap.java
@@ -78,7 +78,12 @@ public class AdminBootstrap {
             .isAdmin(true)
             .build();
     Long id = appUserRepository.insert(admin);
-    // insert() intentionally omits is_admin (DB default false), so flip it on explicitly.
+    // insert() intentionally omits is_admin (DB default false), so flip it on explicitly. This
+    // two-step sequence is not atomic, but it is intentionally fail-safe-by-restart: a crash
+    // between the two calls leaves a non-admin row, which the existing.isPresent() &&
+    // !user.isAdmin() branch above self-heals to admin on the next boot -- the failure direction
+    // is always "not enough admin," never "accidental admin." Do not "fix" this into a single
+    // statement without preserving that property.
     appUserRepository.setAdmin(id, true);
     log.info("Admin bootstrap: seeded new admin user: {}", bootstrapEmail);
   }

--- a/src/main/java/edens/zac/portfolio/backend/services/AdminBootstrap.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/AdminBootstrap.java
@@ -1,0 +1,89 @@
+package edens.zac.portfolio.backend.services;
+
+import edens.zac.portfolio.backend.dao.AppUserRepository;
+import edens.zac.portfolio.backend.entity.AppUserEntity;
+import edens.zac.portfolio.backend.types.UserStatus;
+import jakarta.annotation.PostConstruct;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+/**
+ * Designates the SPECIFIC admin from environment variables on startup, so no admin identity lives
+ * in git (the repo is public). Admin capability is the {@code users.is_admin} boolean — never a
+ * mere session — so it survives independently of who is logged in and impersonation stays
+ * non-admin. Idempotent: if the configured user already exists it flips {@code is_admin} on (a
+ * no-op once already set); if the user is absent and a bootstrap password is provided it seeds a
+ * new ACTIVE admin. Never throws on normal paths.
+ */
+@Component
+@Slf4j
+public class AdminBootstrap {
+
+  private final AppUserRepository appUserRepository;
+  private final PasswordEncoder passwordEncoder;
+  private final String bootstrapEmail;
+  private final String bootstrapPassword;
+
+  /** Binds the repository, password encoder, and the env-driven bootstrap email/password. */
+  public AdminBootstrap(
+      AppUserRepository appUserRepository,
+      PasswordEncoder passwordEncoder,
+      @Value("${app.auth.admin.bootstrap-email:}") String bootstrapEmail,
+      @Value("${app.auth.admin.bootstrap-password:}") String bootstrapPassword) {
+    this.appUserRepository = appUserRepository;
+    this.passwordEncoder = passwordEncoder;
+    this.bootstrapEmail = bootstrapEmail;
+    this.bootstrapPassword = bootstrapPassword;
+  }
+
+  /** Runs once on startup (Flyway has already migrated by context init); designates or skips. */
+  @PostConstruct
+  void init() {
+    if (isBlank(bootstrapEmail)) {
+      return;
+    }
+
+    Optional<AppUserEntity> existing = appUserRepository.findByEmail(bootstrapEmail);
+    if (existing.isPresent()) {
+      AppUserEntity user = existing.get();
+      if (!user.isAdmin()) {
+        appUserRepository.setAdmin(user.getId(), true);
+        log.info("Admin bootstrap: designated existing user as admin: {}", bootstrapEmail);
+      } else if (!isBlank(bootstrapPassword)) {
+        log.warn(
+            "Admin bootstrap: {} is already admin but ADMIN_BOOTSTRAP_PASSWORD is still set;"
+                + " remove it from the environment.",
+            bootstrapEmail);
+      }
+      return;
+    }
+
+    if (isBlank(bootstrapPassword)) {
+      log.warn(
+          "Admin bootstrap: no user with the configured email and no bootstrap-password to seed"
+              + " one; skipping.");
+      return;
+    }
+
+    AppUserEntity admin =
+        AppUserEntity.builder()
+            .email(bootstrapEmail)
+            .passwordHash(passwordEncoder.encode(bootstrapPassword))
+            .webauthnUserHandle(UUID.randomUUID())
+            .status(UserStatus.ACTIVE)
+            .isAdmin(true)
+            .build();
+    Long id = appUserRepository.insert(admin);
+    // insert() intentionally omits is_admin (DB default false), so flip it on explicitly.
+    appUserRepository.setAdmin(id, true);
+    log.info("Admin bootstrap: seeded new admin user: {}", bootstrapEmail);
+  }
+
+  private static boolean isBlank(String value) {
+    return value == null || value.isBlank();
+  }
+}

--- a/src/main/java/edens/zac/portfolio/backend/services/SessionService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/SessionService.java
@@ -142,7 +142,8 @@ public class SessionService {
       return Optional.empty();
     }
     AppUserEntity user = maybeUser.get();
-    return Optional.of(new AuthPrincipal(user.getId(), user.getEmail(), session.isMfaSatisfied()));
+    return Optional.of(
+        new AuthPrincipal(user.getId(), user.getEmail(), user.isAdmin(), session.isMfaSatisfied()));
   }
 
   /**

--- a/src/main/java/edens/zac/portfolio/backend/services/UserInviteService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/UserInviteService.java
@@ -61,6 +61,20 @@ public class UserInviteService {
   }
 
   /**
+   * Kill any still-unused invites for a user without minting a replacement. Used when the account's
+   * login email changes out from under an outstanding invite: the old link was bound to the prior
+   * address and must not remain redeemable, so the admin has to issue a fresh invite to the new
+   * address. Used invites are untouched.
+   *
+   * @param userId the id of the {@code app_user} record whose outstanding invites should be killed
+   * @return the number of invites invalidated
+   */
+  @Transactional
+  public int invalidateInvites(Long userId) {
+    return inviteRepository.invalidateUnusedForUser(userId);
+  }
+
+  /**
    * Validate a raw invite token. Returns the invite entity if the token is found, unexpired, and
    * not yet redeemed. Returns empty for unknown, expired, or already-used tokens.
    *

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -11,3 +11,7 @@ app.auth.cookie-secure=false
 # Invite/gallery links must point at the local Next dev server (port 3000) so a
 # locally-generated invite URL is clickable, instead of the prod default.
 email.frontend-base-url=${EMAIL_FRONTEND_BASE_URL:http://localhost:3000}
+
+# Admin authZ is prod's inner gate; disable it locally so dev stays login-free
+# (mirrors InternalSecretFilter being prod-only). /api/admin/** then falls through to permitAll.
+app.admin.enforce-authz=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -87,6 +87,20 @@ app.contact.rate-limit-per-email-per-hour=5
 app.gallery-access.cookie-secure=${GALLERY_COOKIE_SECURE:true}
 
 #----------------------------------------#
+# Admin bootstrap (env-driven; designates the SPECIFIC admin on startup).
+# The repo is public — carry NO identity here. Both are empty by default and supplied via the
+# prod .env (NEVER committed). AdminBootstrap flips users.is_admin on for this email, or seeds a
+# new admin when the user is absent and a password is provided.
+app.auth.admin.bootstrap-email=${ADMIN_BOOTSTRAP_EMAIL:}
+app.auth.admin.bootstrap-password=${ADMIN_BOOTSTRAP_PASSWORD:}
+
+#----------------------------------------#
+# Admin API authorization. When true (prod + the default everywhere), /api/admin/** requires
+# ROLE_ADMIN (is_admin=true) in addition to the prod-only InternalSecretFilter perimeter.
+# application-dev.properties flips this off so local dev stays login-free.
+app.admin.enforce-authz=${ADMIN_ENFORCE_AUTHZ:true}
+
+#----------------------------------------#
 # Auth session + cookie
 app.auth.cookie-secure=${AUTH_COOKIE_SECURE:true}
 app.auth.session.ttl-days=60

--- a/src/main/resources/db/migration/V42__add_users_is_admin.sql
+++ b/src/main/resources/db/migration/V42__add_users_is_admin.sql
@@ -1,0 +1,5 @@
+-- V42: Restore an admin capability flag on users, dropped in V37 when "admin = perimeter".
+-- Reintroduced as a plain boolean (not the old role enum): a SPECIFIC user is admin,
+-- separate from being a logged-in USER. No user is seeded here — the PUBLIC repo carries
+-- no identity. AdminBootstrap (env-driven) designates the admin on startup.
+ALTER TABLE users ADD COLUMN is_admin BOOLEAN NOT NULL DEFAULT false;

--- a/src/test/java/edens/zac/portfolio/backend/config/AdminAuthorizationDisabledWebMvcTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/config/AdminAuthorizationDisabledWebMvcTest.java
@@ -1,0 +1,57 @@
+package edens.zac.portfolio.backend.config;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import edens.zac.portfolio.backend.services.SessionService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Dev-parity companion to {@link AdminAuthorizationEnforcedWebMvcTest}: with the authZ toggle OFF
+ * (as in application-dev.properties), /api/admin/** falls through to permitAll so local dev stays
+ * login-free. The prod-only InternalSecretFilter is the perimeter there, not this matrix.
+ */
+@WebMvcTest
+@Import({
+  SecurityConfig.class,
+  SessionAuthenticationFilter.class,
+  AdminAuthorizationDisabledWebMvcTest.StubAdminControllers.class
+})
+@TestPropertySource(properties = "app.admin.enforce-authz=false")
+class AdminAuthorizationDisabledWebMvcTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockBean private SessionService sessionService;
+
+  @Configuration
+  static class StubAdminControllers {
+    @Bean
+    StubAdminController stubAdminController() {
+      return new StubAdminController();
+    }
+  }
+
+  @RestController
+  static class StubAdminController {
+    @GetMapping("/api/admin/ping")
+    String pingGet() {
+      return "pong";
+    }
+  }
+
+  @Test
+  void anonGetIsNotForbidden() throws Exception {
+    mockMvc.perform(get("/api/admin/ping")).andExpect(status().isOk());
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/config/AdminAuthorizationEnforcedWebMvcTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/config/AdminAuthorizationEnforcedWebMvcTest.java
@@ -1,0 +1,100 @@
+package edens.zac.portfolio.backend.config;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import edens.zac.portfolio.backend.model.AuthPrincipal;
+import edens.zac.portfolio.backend.services.SessionService;
+import jakarta.servlet.http.Cookie;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * The exploit-chain regression for the anonymous /api/admin/** hole, with the authZ toggle ON (prod
+ * behaviour, and the default everywhere). Exercises the REAL security filter chain (@WebMvcTest +
+ * SecurityConfig + SessionAuthenticationFilter) — standalone MockMvc would not run the chain and
+ * could not assert authZ. A stub controller stands in for the admin surface so the test is
+ * decoupled from any specific AdminController route.
+ */
+@WebMvcTest
+@Import({
+  SecurityConfig.class,
+  SessionAuthenticationFilter.class,
+  AdminAuthorizationEnforcedWebMvcTest.StubAdminControllers.class
+})
+@TestPropertySource(properties = "app.admin.enforce-authz=true")
+class AdminAuthorizationEnforcedWebMvcTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockBean private SessionService sessionService;
+
+  @Configuration
+  static class StubAdminControllers {
+    @Bean
+    StubAdminController stubAdminController() {
+      return new StubAdminController();
+    }
+  }
+
+  @RestController
+  static class StubAdminController {
+    @GetMapping("/api/admin/ping")
+    String pingGet() {
+      return "pong";
+    }
+
+    @PostMapping("/api/admin/ping")
+    String pingPost() {
+      return "pong";
+    }
+  }
+
+  // Anonymous (no credentials) is rejected by the authenticationEntryPoint, which this app wires to
+  // sendError(401) — the same 401-for-unauthenticated contract SecurityConfigWebMvcTest pins for
+  // /api/auth/me. An authenticated-but-non-admin principal instead trips the accessDeniedHandler
+  // (403). Either way /api/admin/** is closed to non-admins; only the status code differs by cause.
+  @Test
+  void anonPostIsRejected() throws Exception {
+    mockMvc.perform(post("/api/admin/ping")).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void anonGetIsRejected() throws Exception {
+    mockMvc.perform(get("/api/admin/ping")).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void nonAdminSessionIsForbidden() throws Exception {
+    when(sessionService.resolve(eq("user-token")))
+        .thenReturn(Optional.of(new AuthPrincipal(7L, "user@example.com", false, false)));
+
+    mockMvc
+        .perform(get("/api/admin/ping").cookie(new Cookie("ezac_session", "user-token")))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void adminSessionIsAllowed() throws Exception {
+    when(sessionService.resolve(eq("admin-token")))
+        .thenReturn(Optional.of(new AuthPrincipal(1L, "admin@example.com", true, false)));
+
+    mockMvc
+        .perform(get("/api/admin/ping").cookie(new Cookie("ezac_session", "admin-token")))
+        .andExpect(status().isOk());
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/config/SecurityConfigWebMvcTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/config/SecurityConfigWebMvcTest.java
@@ -87,7 +87,7 @@ class SecurityConfigWebMvcTest {
   @Test
   void meResolvesPrincipalWhenCookiePresent() throws Exception {
     when(sessionService.resolve(eq("valid-token")))
-        .thenReturn(Optional.of(new AuthPrincipal(7L, "admin@example.com", false)));
+        .thenReturn(Optional.of(new AuthPrincipal(7L, "admin@example.com", false, false)));
 
     mockMvc
         .perform(get("/api/auth/me").cookie(new Cookie("ezac_session", "valid-token")))

--- a/src/test/java/edens/zac/portfolio/backend/config/SessionAuthenticationFilterTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/config/SessionAuthenticationFilterTest.java
@@ -1,0 +1,68 @@
+package edens.zac.portfolio.backend.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import edens.zac.portfolio.backend.model.AuthPrincipal;
+import edens.zac.portfolio.backend.services.SessionService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.Cookie;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Unit-tests the authority grant: every resolved session is a ROLE_USER, and ROLE_ADMIN is granted
+ * iff the principal's {@code isAdmin} flag is set. This is what makes admin capability derive from
+ * {@code users.is_admin} rather than from merely holding a session.
+ */
+class SessionAuthenticationFilterTest {
+
+  private final SessionService sessionService = mock(SessionService.class);
+  private final SessionAuthenticationFilter filter =
+      new SessionAuthenticationFilter(sessionService);
+
+  @AfterEach
+  void clearContext() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  void adminPrincipalGetsRoleAdmin() throws Exception {
+    when(sessionService.resolve("admin-token"))
+        .thenReturn(Optional.of(new AuthPrincipal(1L, "admin@example.com", true, false)));
+
+    var authorities = runFilterWithCookie("admin-token");
+
+    assertThat(authorities).contains("ROLE_USER", "ROLE_ADMIN");
+  }
+
+  @Test
+  void nonAdminPrincipalDoesNotGetRoleAdmin() throws Exception {
+    when(sessionService.resolve("user-token"))
+        .thenReturn(Optional.of(new AuthPrincipal(7L, "user@example.com", false, false)));
+
+    var authorities = runFilterWithCookie("user-token");
+
+    assertThat(authorities).contains("ROLE_USER").doesNotContain("ROLE_ADMIN");
+  }
+
+  private java.util.List<String> runFilterWithCookie(String token) throws Exception {
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/admin/ping");
+    request.setCookies(new Cookie("ezac_session", token));
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain chain = mock(FilterChain.class);
+
+    filter.doFilter(request, response, chain);
+
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    assertThat(auth).isNotNull();
+    return auth.getAuthorities().stream().map(GrantedAuthority::getAuthority).toList();
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/controller/admin/AdminUserControllerTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/admin/AdminUserControllerTest.java
@@ -534,6 +534,126 @@ class AdminUserControllerTest {
 
       verify(appUserRepository, never()).updateEmail(anyLong(), anyString());
     }
+
+    @Test
+    void changingInvitedUserEmailInvalidatesOutstandingInvite() throws Exception {
+      // Account-takeover guard: an INVITED user has an outstanding invite bound to their OLD
+      // address. When the admin corrects the email, the old link must die so whoever holds it
+      // (e.g. the prior address's inbox) can no longer redeem it onto the corrected account.
+      AppUserEntity before =
+          AppUserEntity.builder()
+              .id(8L)
+              .email("ken@example.com")
+              .status(UserStatus.INVITED)
+              .build();
+      AppUserEntity after =
+          AppUserEntity.builder()
+              .id(8L)
+              .email("kenneth@example.com")
+              .status(UserStatus.INVITED)
+              .build();
+      when(appUserRepository.findById(8L))
+          .thenReturn(Optional.of(before))
+          .thenReturn(Optional.of(after));
+      when(appUserRepository.findByEmail("kenneth@example.com")).thenReturn(Optional.empty());
+
+      mockMvc
+          .perform(
+              patch("/api/admin/users/8")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"email\":\"kenneth@example.com\",\"status\":\"INVITED\"}"))
+          .andExpect(status().isOk());
+
+      verify(appUserRepository).updateEmail(8L, "kenneth@example.com");
+      verify(userInviteService).invalidateInvites(8L);
+    }
+
+    @Test
+    void changingActiveUserEmailDoesNotTouchInvites() throws Exception {
+      // Scope guard: an ACTIVE user has no pending onboarding invite to hijack, so an email
+      // change must NOT reach into invite rows (an ACTIVE user's stray unused invite, if one
+      // even exists, is not the account-takeover concern here).
+      AppUserEntity before =
+          AppUserEntity.builder().id(8L).email("ken@example.com").status(UserStatus.ACTIVE).build();
+      AppUserEntity after =
+          AppUserEntity.builder()
+              .id(8L)
+              .email("kenneth@example.com")
+              .status(UserStatus.ACTIVE)
+              .build();
+      when(appUserRepository.findById(8L))
+          .thenReturn(Optional.of(before))
+          .thenReturn(Optional.of(after));
+      when(appUserRepository.findByEmail("kenneth@example.com")).thenReturn(Optional.empty());
+
+      mockMvc
+          .perform(
+              patch("/api/admin/users/8")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"email\":\"kenneth@example.com\",\"status\":\"ACTIVE\"}"))
+          .andExpect(status().isOk());
+
+      verify(appUserRepository).updateEmail(8L, "kenneth@example.com");
+      verify(userInviteService, never()).invalidateInvites(anyLong());
+    }
+
+    @Test
+    void resubmittingInvitedUserSameEmailDoesNotInvalidateInvite() throws Exception {
+      // No-op email change (same address, re-cased) must NOT kill the outstanding invite: the
+      // link is still bound to the same address, so it stays live. The frontend always sends the
+      // email field, so this re-cased-but-unchanged path is common.
+      AppUserEntity ken =
+          AppUserEntity.builder()
+              .id(8L)
+              .email("ken@example.com")
+              .status(UserStatus.INVITED)
+              .build();
+      when(appUserRepository.findById(8L)).thenReturn(Optional.of(ken));
+      when(appUserRepository.findByEmail("ken@example.com")).thenReturn(Optional.of(ken));
+
+      mockMvc
+          .perform(
+              patch("/api/admin/users/8")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"email\":\"KEN@EXAMPLE.COM\",\"status\":\"INVITED\"}"))
+          .andExpect(status().isOk());
+
+      // The email write still fires (idempotent same-value write), but the invite is left alone.
+      verify(userInviteService, never()).invalidateInvites(anyLong());
+    }
+
+    @Test
+    void emaillessPatchOnInvitedUserDoesNotInvalidateInvite() throws Exception {
+      // An email-less PATCH (status/name only) never touches the email, so an INVITED user's
+      // outstanding invite must survive — nothing about the login identity changed.
+      AppUserEntity before =
+          AppUserEntity.builder()
+              .id(8L)
+              .email("ken@example.com")
+              .name("Ken")
+              .status(UserStatus.INVITED)
+              .build();
+      AppUserEntity after =
+          AppUserEntity.builder()
+              .id(8L)
+              .email("ken@example.com")
+              .name("Kenneth")
+              .status(UserStatus.INVITED)
+              .build();
+      when(appUserRepository.findById(8L))
+          .thenReturn(Optional.of(before))
+          .thenReturn(Optional.of(after));
+
+      mockMvc
+          .perform(
+              patch("/api/admin/users/8")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"displayName\":\"Kenneth\",\"status\":\"INVITED\"}"))
+          .andExpect(status().isOk());
+
+      verify(appUserRepository, never()).updateEmail(anyLong(), anyString());
+      verify(userInviteService, never()).invalidateInvites(anyLong());
+    }
   }
 
   @Nested

--- a/src/test/java/edens/zac/portfolio/backend/controller/auth/AuthControllerTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/auth/AuthControllerTest.java
@@ -219,7 +219,7 @@ class AuthControllerTest {
 
   @Test
   void meReturns200WithPrincipal() throws Exception {
-    AuthPrincipal principal = new AuthPrincipal(1L, "admin@example.com", false);
+    AuthPrincipal principal = new AuthPrincipal(1L, "admin@example.com", true, false);
     SecurityContextHolder.getContext()
         .setAuthentication(
             new UsernamePasswordAuthenticationToken(
@@ -230,6 +230,7 @@ class AuthControllerTest {
         .perform(get("/api/auth/me"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.email", org.hamcrest.Matchers.is("admin@example.com")))
+        .andExpect(jsonPath("$.isAdmin", org.hamcrest.Matchers.is(true)))
         .andExpect(jsonPath("$.mfaSatisfied", org.hamcrest.Matchers.is(false)))
         .andExpect(jsonPath("$.galleries", org.hamcrest.Matchers.hasSize(0)));
   }

--- a/src/test/java/edens/zac/portfolio/backend/controller/auth/WebAuthnControllerTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/auth/WebAuthnControllerTest.java
@@ -46,7 +46,7 @@ class WebAuthnControllerTest {
   private AuthLoginLimiter loginLimiter;
   private MockMvc mockMvc;
 
-  private final AuthPrincipal admin = new AuthPrincipal(1L, "admin@example.com", false);
+  private final AuthPrincipal admin = new AuthPrincipal(1L, "admin@example.com", true, false);
 
   @BeforeEach
   void setUp() {

--- a/src/test/java/edens/zac/portfolio/backend/controller/prod/ContentDownloadAuthTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/prod/ContentDownloadAuthTest.java
@@ -70,7 +70,7 @@ class ContentDownloadAuthTest {
   }
 
   private void authenticate(Long userId) {
-    var principal = new AuthPrincipal(userId, "c@example.com", true);
+    var principal = new AuthPrincipal(userId, "c@example.com", false, true);
     SecurityContextHolder.getContext()
         .setAuthentication(new UsernamePasswordAuthenticationToken(principal, null, List.of()));
   }

--- a/src/test/java/edens/zac/portfolio/backend/controller/prod/UserControllerProdTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/prod/UserControllerProdTest.java
@@ -69,7 +69,7 @@ class UserControllerProdTest {
 
   @Test
   void authenticatedRequestReturnsAssembledPage() throws Exception {
-    AuthPrincipal user = new AuthPrincipal(7L, "c@example.com", true);
+    AuthPrincipal user = new AuthPrincipal(7L, "c@example.com", false, true);
     CollectionModel assembled =
         CollectionModel.builder()
             .slug("user")

--- a/src/test/java/edens/zac/portfolio/backend/controller/prod/UserFollowsControllerProdTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/prod/UserFollowsControllerProdTest.java
@@ -40,7 +40,7 @@ class UserFollowsControllerProdTest {
 
   private MockMvc mockMvc;
 
-  private final AuthPrincipal client = new AuthPrincipal(7L, "c@b.com", true);
+  private final AuthPrincipal client = new AuthPrincipal(7L, "c@b.com", false, true);
 
   @BeforeEach
   void setUp() {

--- a/src/test/java/edens/zac/portfolio/backend/controller/prod/UserSavesControllerProdTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/prod/UserSavesControllerProdTest.java
@@ -42,7 +42,7 @@ class UserSavesControllerProdTest {
 
   private MockMvc mockMvc;
 
-  private final AuthPrincipal client = new AuthPrincipal(7L, "c@b.com", true);
+  private final AuthPrincipal client = new AuthPrincipal(7L, "c@b.com", false, true);
 
   @BeforeEach
   void setUp() {

--- a/src/test/java/edens/zac/portfolio/backend/controller/prod/UserSelectsControllerProdTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/prod/UserSelectsControllerProdTest.java
@@ -38,7 +38,7 @@ class UserSelectsControllerProdTest {
 
   private MockMvc mockMvc;
 
-  private final AuthPrincipal client = new AuthPrincipal(7L, "c@b.com", true);
+  private final AuthPrincipal client = new AuthPrincipal(7L, "c@b.com", false, true);
 
   @BeforeEach
   void setUp() {

--- a/src/test/java/edens/zac/portfolio/backend/services/AdminBootstrapTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/AdminBootstrapTest.java
@@ -1,0 +1,93 @@
+package edens.zac.portfolio.backend.services;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import edens.zac.portfolio.backend.dao.AppUserRepository;
+import edens.zac.portfolio.backend.entity.AppUserEntity;
+import edens.zac.portfolio.backend.types.UserStatus;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * AdminBootstrap designates the SPECIFIC admin from env config, keeping identity out of the public
+ * repo. Covers the three paths: designate an existing non-admin, seed when absent + password given,
+ * and no-op when the email is blank.
+ */
+@ExtendWith(MockitoExtension.class)
+class AdminBootstrapTest {
+
+  @Mock private AppUserRepository appUserRepository;
+  @Mock private PasswordEncoder passwordEncoder;
+
+  @Test
+  void designatesExistingNonAdminUser() {
+    AppUserEntity existing =
+        AppUserEntity.builder().id(42L).email("boss@example.com").isAdmin(false).build();
+    when(appUserRepository.findByEmail("boss@example.com")).thenReturn(Optional.of(existing));
+
+    new AdminBootstrap(appUserRepository, passwordEncoder, "boss@example.com", "").init();
+
+    verify(appUserRepository).setAdmin(42L, true);
+    verify(appUserRepository, never()).insert(any());
+  }
+
+  @Test
+  void noOpWhenExistingUserAlreadyAdmin() {
+    AppUserEntity existing =
+        AppUserEntity.builder().id(42L).email("boss@example.com").isAdmin(true).build();
+    when(appUserRepository.findByEmail("boss@example.com")).thenReturn(Optional.of(existing));
+
+    new AdminBootstrap(appUserRepository, passwordEncoder, "boss@example.com", "").init();
+
+    verify(appUserRepository, never()).setAdmin(anyLong(), anyBoolean());
+    verify(appUserRepository, never()).insert(any());
+  }
+
+  @Test
+  void seedsNewAdminWhenAbsentAndPasswordProvided() {
+    when(appUserRepository.findByEmail("boss@example.com")).thenReturn(Optional.empty());
+    when(passwordEncoder.encode("s3cret")).thenReturn("{bcrypt}hashed");
+    when(appUserRepository.insert(any())).thenReturn(99L);
+
+    new AdminBootstrap(appUserRepository, passwordEncoder, "boss@example.com", "s3cret").init();
+
+    ArgumentCaptor<AppUserEntity> captor = ArgumentCaptor.forClass(AppUserEntity.class);
+    verify(appUserRepository).insert(captor.capture());
+    AppUserEntity seeded = captor.getValue();
+    org.assertj.core.api.Assertions.assertThat(seeded.getEmail()).isEqualTo("boss@example.com");
+    org.assertj.core.api.Assertions.assertThat(seeded.getPasswordHash())
+        .isEqualTo("{bcrypt}hashed");
+    org.assertj.core.api.Assertions.assertThat(seeded.getStatus()).isEqualTo(UserStatus.ACTIVE);
+    org.assertj.core.api.Assertions.assertThat(seeded.getWebauthnUserHandle()).isNotNull();
+    verify(appUserRepository).setAdmin(99L, true);
+  }
+
+  @Test
+  void skipsSeedWhenAbsentAndNoPassword() {
+    when(appUserRepository.findByEmail("boss@example.com")).thenReturn(Optional.empty());
+
+    new AdminBootstrap(appUserRepository, passwordEncoder, "boss@example.com", "").init();
+
+    verify(appUserRepository, never()).insert(any());
+    verify(appUserRepository, never()).setAdmin(anyLong(), anyBoolean());
+  }
+
+  @Test
+  void noOpWhenEmailBlank() {
+    new AdminBootstrap(appUserRepository, passwordEncoder, "", "s3cret").init();
+
+    verifyNoInteractions(appUserRepository);
+    verifyNoInteractions(passwordEncoder);
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/services/CollectionServiceGalleryBypassTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/CollectionServiceGalleryBypassTest.java
@@ -60,7 +60,7 @@ class CollectionServiceGalleryBypassTest {
   }
 
   private void authenticate(Long userId) {
-    var principal = new AuthPrincipal(userId, "c@example.com", true);
+    var principal = new AuthPrincipal(userId, "c@example.com", false, true);
     SecurityContextHolder.getContext()
         .setAuthentication(new UsernamePasswordAuthenticationToken(principal, null, List.of()));
   }

--- a/src/test/java/edens/zac/portfolio/backend/services/WebAuthnServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/WebAuthnServiceTest.java
@@ -70,7 +70,7 @@ class WebAuthnServiceTest {
   }
 
   private AuthPrincipal principal() {
-    return new AuthPrincipal(1L, "admin@example.com", false);
+    return new AuthPrincipal(1L, "admin@example.com", true, false);
   }
 
   @Test


### PR DESCRIPTION
## Summary

`/api/admin/**` was `permitAll` at the Spring Security layer in **every profile**. Prod's only gate was `InternalSecretFilter`, which proves a request came through the frontend BFF — not *who* the caller is. Combined with the FE proxy injecting the BFF secret on every forwarded request with no session check (see paired FE PR), this meant **any anonymous internet client could reach every `/api/admin/**` endpoint in production**.

**Confirmed live before this fix** (read-only status-code checks against `https://zacedens.com`, response bodies discarded):
- `GET /api/proxy/api/admin/users` → **200** (real user emails exposed)
- `GET /api/proxy/api/admin/messages` → **200** (contact-form PII exposed)

Worst reachable chain: anonymous `POST /api/admin/users` (invite-create) → invite URL → `POST /api/auth/invite/{token}/accept` → full account takeover, with zero authentication required at any step.

## The fix

- **V42 migration** restores `users.is_admin` (boolean, schema-only — no identity committed to this public repo).
- `AuthPrincipal` gains `isAdmin`; `SessionAuthenticationFilter` grants `ROLE_ADMIN` when the resolved user's flag is set (always grants `ROLE_USER` too).
- `SecurityConfig` gates `/api/admin/**` on `hasRole("ADMIN")`, layered **inside** the existing `InternalSecretFilter` perimeter (both must pass in prod). A fail-closed toggle (`app.admin.enforce-authz`, default `true`) is set `false` only in `application-dev.properties`, preserving today's frictionless local admin workflow.
- `/api/auth/me` now exposes `isAdmin` for the paired frontend PR.
- **`AdminBootstrap`** (env-driven, resurrected from a prior deleted implementation) designates a *specific* admin user at startup via `ADMIN_BOOTSTRAP_EMAIL`/`ADMIN_BOOTSTRAP_PASSWORD` — no PII committed, idempotent, self-healing if interrupted mid-seed.
- Admin capability derives from the **user row**, never from session/impersonation state — an admin who impersonates another user (dev-only) correctly resolves to a non-admin principal.
- **Follow-on P1 fix included**: an `INVITED` user's outstanding invite is now invalidated when an admin changes their email (closes a stale-invite takeover angle from the prior email-editing feature).

## Review process

Every commit went through independent spec-compliance review + code-quality review (two-stage, separate subagents, "don't trust the implementer's report" verification). The full branch then went through a holistic whole-branch review and a dedicated cross-repo adversarial exploit-chain hunt that traced all 9 attack-surface questions (matcher shadowing, dev/prod toggle safety, FE-gate-is-truly-optional, bootstrap race safety, impersonation invariant, invite-bypass, cookie-name contract, etc.) through the actual final code. Verdict: **the hole is genuinely and fully closed.**

## Test plan

- `./mvnw clean install`: **960 tests, 0 failures, 0 errors, 1 skipped** (pre-existing, unrelated skip)
- Exploit-chain regression tests run the *real* Spring Security filter chain (not standalone mocks): anonymous → 401, non-admin session → 403, admin session → 200, toggle-disabled → dev parity preserved
- `AdminBootstrap`, `SessionAuthenticationFilter`, invite-invalidation all independently unit-tested

## ⚠️ Deploy requirements — read before merging

1. **Merge this PR before (or together with) the paired frontend PR.** The frontend forwards a session cookie this backend now requires; an old backend simply ignores the extra header (graceful no-op), so backend-first is safe.
2. **Merging is not sufficient — this must be deployed to production to close the hole.** The vulnerability above is live in prod right now.
3. **After deploying, set `ADMIN_BOOTSTRAP_EMAIL` and `ADMIN_BOOTSTRAP_PASSWORD` in the prod environment** (or manually flip an existing user row's `is_admin` column via SQL) — otherwise **zero users will be admins** after this ships, locking out `/admin` entirely.
4. Re-run the prod smoke checklist post-deploy to confirm `/api/admin/**` now returns 401/403 for anonymous requests.

Paired PR: themancalledzac/edens.zac#(FE PR — see below)