### PR TITLE
fix(admin): serve AdminController in all profiles behind the admin gate

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -14,7 +14,7 @@ Package: `edens.zac.portfolio.backend`
 
 ## Project Structure
 ```
-controller/dev/   - Development endpoints (@Profile("dev"))
+controller/admin/ - Admin/write endpoints, all profiles (gated by SecurityConfig hasRole("ADMIN"))
 controller/prod/  - Production endpoints (@Profile("prod"))
 services/         - Business logic (concrete *Service classes, no interface/Impl split)
 dao/              - Data access (JDBC via NamedParameterJdbcTemplate, not JPA repositories)
@@ -28,7 +28,7 @@ config/           - Spring configuration
 - **Entities**: `*Entity` (e.g., `CollectionEntity`, `ContentEntity`, `ContentImageEntity`)
 - **Models/DTOs**: `*Model`, `*Request`, `*ResponseDTO`
 - **Services**: Concrete class `*Service` (no interface, no `*ServiceImpl` suffix)
-- **Controllers**: `*ControllerDev` (dev profile) / `*ControllerProd` (prod profile)
+- **Controllers**: `AdminController` (admin, all profiles, security-gated) / `*ControllerProd` (prod profile)
 
 ## Key Rules
 

--- a/.claude/api-patterns.md
+++ b/.claude/api-patterns.md
@@ -3,7 +3,8 @@
 ## Endpoint Structure
 ```
 /api/read/...    - Public GET endpoints (prod, @Profile("prod"))
-/api/admin/...   - Admin/write endpoints (dev, @Profile("dev"))
+/api/admin/...   - Admin/write endpoints (all profiles, gated by SecurityConfig
+                   hasRole("ADMIN") + InternalSecretFilter in prod, not @Profile)
 ```
 
 ## Error Handling
@@ -31,6 +32,7 @@ Controllers do NOT use try-catch blocks -- they throw exceptions and let the han
 | `ConstraintViolationException` | 400 BAD_REQUEST | `@Validated` failures |
 | `MethodArgumentTypeMismatchException` | 400 BAD_REQUEST | Wrong param type |
 | `DataIntegrityViolationException` | 409 CONFLICT | Duplicate/FK violation |
+| `NoResourceFoundException` | 404 NOT_FOUND | No route matches the request path |
 | `Exception` (catch-all) | 500 INTERNAL_SERVER_ERROR | Unexpected errors |
 
 ## Controller Pattern
@@ -117,8 +119,9 @@ Key points:
 - Use typed `ResponseEntity<T>` -- never `ResponseEntity<?>`
 
 ## Dev vs Prod Controllers
-- `*ControllerDev` (`/api/admin/...`): Write/admin endpoints, `@Profile("dev")`
+- `AdminController` (`/api/admin/...`): Write/admin endpoints, active in all profiles —
+  gated by SecurityConfig's `hasRole("ADMIN")` (+ InternalSecretFilter in prod), not `@Profile`
 - `*ControllerProd` (`/api/read/...`): Read-only public endpoints, `@Profile("prod")`
-- Never expose dev/admin endpoints in production
+- Admin/write endpoints must stay behind the SecurityConfig admin gate; never permitAll them
 
 <!-- Phase 3a DONE: Interface/Impl split removed -- controllers inject concrete service classes directly -->

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Backend REST API for a photography portfolio and content management platform. Ha
 ```
 src/main/java/edens/zac/portfolio/backend/
   controller/
-    dev/              Admin endpoints (@Profile("dev"))
+    admin/            Admin endpoints, all profiles (SecurityConfig hasRole("ADMIN") gate)
     prod/             Public read endpoints (@Profile("prod"))
   services/           Business logic (concrete *Service classes)
   dao/                Data access (JDBC, NamedParameterJdbcTemplate)

--- a/src/main/java/edens/zac/portfolio/backend/config/GlobalExceptionHandler.java
+++ b/src/main/java/edens/zac/portfolio/backend/config/GlobalExceptionHandler.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.async.AsyncRequestNotUsableException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 /**
  * Global exception handler that eliminates duplicate try-catch blocks across all controllers.
@@ -44,6 +45,18 @@ public class GlobalExceptionHandler {
     log.warn("Resource not found: {}", e.getMessage());
     return ResponseEntity.status(HttpStatus.NOT_FOUND)
         .body(ErrorResponse.of(HttpStatus.NOT_FOUND, e.getMessage()));
+  }
+
+  /**
+   * Handle requests to a path with no matching route (e.g. a typo'd or retired endpoint). Without
+   * this handler it is matched by the catch-all {@link #handleGeneric} and mis-reported as 500; an
+   * unmatched path is a client error and must be 404, not 500.
+   */
+  @ExceptionHandler(NoResourceFoundException.class)
+  public ResponseEntity<ErrorResponse> handleNoResourceFound(NoResourceFoundException e) {
+    log.warn("No route found: {}", e.getMessage());
+    return ResponseEntity.status(HttpStatus.NOT_FOUND)
+        .body(ErrorResponse.of(HttpStatus.NOT_FOUND, "No route found for " + e.getResourcePath()));
   }
 
   /** Handle IllegalArgumentException - invalid input, always returns 400. */

--- a/src/main/java/edens/zac/portfolio/backend/controller/admin/AdminController.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/admin/AdminController.java
@@ -1,4 +1,4 @@
-package edens.zac.portfolio.backend.controller.dev;
+package edens.zac.portfolio.backend.controller.admin;
 
 import edens.zac.portfolio.backend.config.GlobalExceptionHandler;
 import edens.zac.portfolio.backend.model.CollectionModel;
@@ -32,7 +32,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Profile;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -55,16 +54,21 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 /**
- * Single dev-only admin controller. Owns every {@code /api/admin/*} endpoint — admin-home tiles,
- * cache eviction, collection write ops, content uploads/edits, and metadata edits. All routes are
- * profile-gated and the class is package-private. Exception handling is delegated to {@link
- * GlobalExceptionHandler}.
+ * Single admin controller, active in all profiles. Owns every {@code /api/admin/*} endpoint —
+ * admin-home tiles, cache eviction, collection write ops, content uploads/edits, and metadata
+ * edits. These are admin-ops endpoints (tiles and cache eviction included), not public reads.
+ *
+ * <p>Unlike the legacy dev/prod controller split, these routes are NOT profile-gated — they are
+ * protected at the filter-chain level: {@link edens.zac.portfolio.backend.config.SecurityConfig}
+ * requires {@code hasRole("ADMIN")} on {@code /api/admin/**} (toggle: {@code
+ * app.admin.enforce-authz}, default {@code true}, off only in local dev), and in prod that sits
+ * behind {@link edens.zac.portfolio.backend.config.InternalSecretFilter} as well. The class stays
+ * package-private. Exception handling is delegated to {@link GlobalExceptionHandler}.
  */
 @Slf4j
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/admin")
-@Profile("dev")
 class AdminController {
 
   private final AdminHomeService adminHomeService;

--- a/src/test/java/edens/zac/portfolio/backend/config/GlobalExceptionHandlerTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/config/GlobalExceptionHandlerTest.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 class GlobalExceptionHandlerTest {
 
@@ -74,6 +76,11 @@ class GlobalExceptionHandlerTest {
     @GetMapping("/generic")
     String generic() {
       throw new RuntimeException("unexpected failure");
+    }
+
+    @GetMapping("/no-route")
+    String noRoute() throws NoResourceFoundException {
+      throw new NoResourceFoundException(HttpMethod.GET, "/test/no-route");
     }
 
     @PostMapping("/echo")
@@ -201,6 +208,21 @@ class GlobalExceptionHandlerTest {
         .andExpect(status().isInternalServerError())
         .andExpect(jsonPath("$.status").value(500))
         .andExpect(jsonPath("$.message").value("An unexpected error occurred"));
+  }
+
+  @Test
+  void handleNoResourceFound_returnsStatus404() throws Exception {
+    // An unmatched path (e.g. a retired or typo'd route) is a NoResourceFoundException raised by
+    // the dispatcher. Without a dedicated handler it is caught by the catch-all Exception handler
+    // and mis-reported as 500 -- this was the 0207 prod bug's proximate symptom once
+    // AdminController was promoted out of @Profile("dev"): unknown paths must be 404, not 500.
+    mockMvc
+        .perform(get("/test/no-route").accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.status").value(404))
+        .andExpect(jsonPath("$.error").value("Not Found"))
+        .andExpect(jsonPath("$.message").value("No route found for /test/no-route"))
+        .andExpect(jsonPath("$.timestamp").exists());
   }
 
   @Test

--- a/src/test/java/edens/zac/portfolio/backend/controller/admin/AdminControllerAuthorizationWebMvcTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/admin/AdminControllerAuthorizationWebMvcTest.java
@@ -1,0 +1,81 @@
+package edens.zac.portfolio.backend.controller.admin;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import edens.zac.portfolio.backend.config.SecurityConfig;
+import edens.zac.portfolio.backend.config.SessionAuthenticationFilter;
+import edens.zac.portfolio.backend.model.AuthPrincipal;
+import edens.zac.portfolio.backend.model.GeneralMetadataDTO;
+import edens.zac.portfolio.backend.services.AdminHomeService;
+import edens.zac.portfolio.backend.services.CollectionService;
+import edens.zac.portfolio.backend.services.ContentService;
+import edens.zac.portfolio.backend.services.ImageUploadPipelineService;
+import edens.zac.portfolio.backend.services.JobTrackingService;
+import edens.zac.portfolio.backend.services.MetadataService;
+import edens.zac.portfolio.backend.services.SessionService;
+import jakarta.servlet.http.Cookie;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Pins {@link AdminController} inside the {@code /api/admin/**} authorization gate on the REAL
+ * security filter chain (not a stub controller, unlike its siblings in {@code config/}) — this is
+ * the regression test for the 0207 prod bug: the controller used to be {@code @Profile("dev")},
+ * which meant the route did not exist in prod at all (a {@code NoResourceFoundException}, mis-
+ * reported as 500) rather than being correctly rejected by the security layer. Exercises {@code GET
+ * /api/admin/collections/metadata} specifically because that was one of the two endpoints reported
+ * 500ing in prod logs.
+ *
+ * @see edens.zac.portfolio.backend.config.AdminAuthorizationEnforcedWebMvcTest
+ */
+@WebMvcTest(AdminController.class)
+@Import({SecurityConfig.class, SessionAuthenticationFilter.class})
+class AdminControllerAuthorizationWebMvcTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockBean private SessionService sessionService;
+  @MockBean private AdminHomeService adminHomeService;
+  @MockBean private CollectionService collectionService;
+  @MockBean private ContentService contentService;
+  @MockBean private ImageUploadPipelineService imageUploadPipelineService;
+  @MockBean private JobTrackingService jobTrackingService;
+  @MockBean private MetadataService metadataService;
+
+  private static final String METADATA_PATH = "/api/admin/collections/metadata";
+
+  @Test
+  void anonymousIsRejected() throws Exception {
+    mockMvc.perform(get(METADATA_PATH)).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void authenticatedNonAdminIsForbidden() throws Exception {
+    when(sessionService.resolve(eq("user-token")))
+        .thenReturn(Optional.of(new AuthPrincipal(7L, "user@example.com", false, false)));
+
+    mockMvc
+        .perform(get(METADATA_PATH).cookie(new Cookie("ezac_session", "user-token")))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void adminIsAllowed() throws Exception {
+    when(sessionService.resolve(eq("admin-token")))
+        .thenReturn(Optional.of(new AuthPrincipal(1L, "admin@example.com", true, false)));
+    when(collectionService.getGeneralMetadata())
+        .thenReturn(new GeneralMetadataDTO(null, null, null, null, null, null, null, null));
+
+    mockMvc
+        .perform(get(METADATA_PATH).cookie(new Cookie("ezac_session", "admin-token")))
+        .andExpect(status().isOk());
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/controller/admin/AdminControllerAuthorizationWebMvcTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/admin/AdminControllerAuthorizationWebMvcTest.java
@@ -17,8 +17,10 @@ import edens.zac.portfolio.backend.services.JobTrackingService;
 import edens.zac.portfolio.backend.services.MetadataService;
 import edens.zac.portfolio.backend.services.SessionService;
 import jakarta.servlet.http.Cookie;
+import java.util.List;
 import java.util.Optional;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -29,10 +31,10 @@ import org.springframework.test.web.servlet.MockMvc;
  * Pins {@link AdminController} inside the {@code /api/admin/**} authorization gate on the REAL
  * security filter chain (not a stub controller, unlike its siblings in {@code config/}) — this is
  * the regression test for the 0207 prod bug: the controller used to be {@code @Profile("dev")},
- * which meant the route did not exist in prod at all (a {@code NoResourceFoundException}, mis-
- * reported as 500) rather than being correctly rejected by the security layer. Exercises {@code GET
- * /api/admin/collections/metadata} specifically because that was one of the two endpoints reported
- * 500ing in prod logs.
+ * which meant the routes did not exist in prod at all (a {@code NoResourceFoundException}, mis-
+ * reported as 500) rather than being correctly rejected by the security layer. Exercises the two
+ * endpoints reported 500ing in prod logs: {@code GET /api/admin/admin-home/tiles} (the /admin hub
+ * fetch) and {@code GET /api/admin/collections/metadata}.
  *
  * @see edens.zac.portfolio.backend.config.AdminAuthorizationEnforcedWebMvcTest
  */
@@ -50,32 +52,37 @@ class AdminControllerAuthorizationWebMvcTest {
   @MockBean private JobTrackingService jobTrackingService;
   @MockBean private MetadataService metadataService;
 
+  private static final String TILES_PATH = "/api/admin/admin-home/tiles";
   private static final String METADATA_PATH = "/api/admin/collections/metadata";
 
-  @Test
-  void anonymousIsRejected() throws Exception {
-    mockMvc.perform(get(METADATA_PATH)).andExpect(status().isUnauthorized());
+  @ParameterizedTest
+  @ValueSource(strings = {TILES_PATH, METADATA_PATH})
+  void anonymousIsRejected(String path) throws Exception {
+    mockMvc.perform(get(path)).andExpect(status().isUnauthorized());
   }
 
-  @Test
-  void authenticatedNonAdminIsForbidden() throws Exception {
+  @ParameterizedTest
+  @ValueSource(strings = {TILES_PATH, METADATA_PATH})
+  void authenticatedNonAdminIsForbidden(String path) throws Exception {
     when(sessionService.resolve(eq("user-token")))
         .thenReturn(Optional.of(new AuthPrincipal(7L, "user@example.com", false, false)));
 
     mockMvc
-        .perform(get(METADATA_PATH).cookie(new Cookie("ezac_session", "user-token")))
+        .perform(get(path).cookie(new Cookie("ezac_session", "user-token")))
         .andExpect(status().isForbidden());
   }
 
-  @Test
-  void adminIsAllowed() throws Exception {
+  @ParameterizedTest
+  @ValueSource(strings = {TILES_PATH, METADATA_PATH})
+  void adminIsAllowed(String path) throws Exception {
     when(sessionService.resolve(eq("admin-token")))
         .thenReturn(Optional.of(new AuthPrincipal(1L, "admin@example.com", true, false)));
+    when(adminHomeService.getTiles()).thenReturn(List.of());
     when(collectionService.getGeneralMetadata())
         .thenReturn(new GeneralMetadataDTO(null, null, null, null, null, null, null, null));
 
     mockMvc
-        .perform(get(METADATA_PATH).cookie(new Cookie("ezac_session", "admin-token")))
+        .perform(get(path).cookie(new Cookie("ezac_session", "admin-token")))
         .andExpect(status().isOk());
   }
 }

--- a/src/test/java/edens/zac/portfolio/backend/controller/admin/AdminControllerSetPeopleTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/admin/AdminControllerSetPeopleTest.java
@@ -1,4 +1,4 @@
-package edens.zac.portfolio.backend.controller.dev;
+package edens.zac.portfolio.backend.controller.admin;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/edens/zac/portfolio/backend/controller/admin/AdminHomeControllerDevTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/admin/AdminHomeControllerDevTest.java
@@ -1,4 +1,4 @@
-package edens.zac.portfolio.backend.controller.dev;
+package edens.zac.portfolio.backend.controller.admin;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;

--- a/src/test/java/edens/zac/portfolio/backend/controller/admin/CacheControllerDevTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/admin/CacheControllerDevTest.java
@@ -1,4 +1,4 @@
-package edens.zac.portfolio.backend.controller.dev;
+package edens.zac.portfolio.backend.controller.admin;
 
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;

--- a/src/test/java/edens/zac/portfolio/backend/controller/admin/CollectionControllerDevTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/admin/CollectionControllerDevTest.java
@@ -1,4 +1,4 @@
-package edens.zac.portfolio.backend.controller.dev;
+package edens.zac.portfolio.backend.controller.admin;
 
 import static org.hamcrest.Matchers.*;
 import static org.mockito.ArgumentMatchers.any;

--- a/src/test/java/edens/zac/portfolio/backend/controller/admin/ContentControllerDevTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/admin/ContentControllerDevTest.java
@@ -1,4 +1,4 @@
-package edens.zac.portfolio.backend.controller.dev;
+package edens.zac.portfolio.backend.controller.admin;
 
 import static org.hamcrest.Matchers.*;
 import static org.mockito.ArgumentMatchers.any;


### PR DESCRIPTION
## Problem

The `/admin` hub renders broken/empty in prod even for a logged-in admin (confirmed 2026-07-06 during the 0206 isAdmin-gating work): `GET /api/admin/admin-home/tiles` lived on the `@Profile("dev")` `AdminController`, so the route did not exist in prod at all — every hit raised `NoResourceFoundException`, which the generic handler mis-reported as 500. Same story for every other `/api/admin/**` route the prod admin UI now exercises (collections metadata was the other endpoint seen 500ing in prod logs).

## Fix

- **Promote the whole controller, not just tiles** (`97acc03`): remove `@Profile("dev")` and relocate `controller/dev/AdminController` → `controller/admin/`. The profile gate predates real admin auth — since 0203, `/api/admin/**` is protected filter-chain-level by `SecurityConfig` `hasRole("ADMIN")` (+ `InternalSecretFilter` perimeter in prod), controller-agnostic, so the profile split was pure downside: post-0206 the prod admin UI hits collection writes, content uploads/edits, and metadata routes too. This includes `POST /api/admin/cache/clear` — originally slated to stay dev-only, but keeping one route profile-gated would preserve the exact landmine class this PR removes; the FE Clear Cache button remains local-only as a product choice.
- **Map `NoResourceFoundException` → 404** (`a8af589`) so unmatched paths stop reporting as 500.
- **Pin the gate with a real-filter-chain slice** (`97acc03` + `8f6103c`): `AdminControllerAuthorizationWebMvcTest` (`@WebMvcTest` + real `SecurityConfig`) proves 401 anon / 403 non-admin / 200 admin, parameterized over both prod-reported endpoints (`/admin-home/tiles`, `/collections/metadata`). The 200 case also pins route existence outside the dev profile — the actual regression.

## Frontend impact

None required — the URL is unchanged and the FE `fetchAdminGetApi('/admin-home/tiles')` path maps identically. A separate FE PR fixes the now-stale MenuDropdown comment that cited `controller/dev/AdminController.java` as the reason Clear Cache is local-only.

## Verification

`./mvnw spotless:apply && ./mvnw clean install`: BUILD SUCCESS — 967 tests, 0 failures (1 pre-existing skip). Authz slice: 6/6 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)