### PR TITLE
docs: fix stale admin-auth comments (0204 review follow-up)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,8 @@ services:
       SPRING_DATASOURCE_URL: jdbc:postgresql://${POSTGRES_HOST:-localhost}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-edens_zac}
       SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER:-zedens}
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
-      # Spring profile: must be explicitly set to dev or prod (no silent default).
-      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:?must be set to dev or prod}
+      # Spring profile: must be explicitly set to dev, prod, or default (no silent fallback).
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:?must be set: dev, prod, or default}
 
       # AWS Config
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}

--- a/src/main/java/edens/zac/portfolio/backend/controller/admin/AdminController.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/admin/AdminController.java
@@ -54,9 +54,11 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 /**
- * Single admin controller, active in all profiles. Owns every {@code /api/admin/*} endpoint —
- * admin-home tiles, cache eviction, collection write ops, content uploads/edits, and metadata
- * edits. These are admin-ops endpoints (tiles and cache eviction included), not public reads.
+ * Primary admin-ops controller, active in all profiles: admin-home tiles, cache eviction,
+ * collection write ops, content uploads/edits, and metadata edits. It does not own every {@code
+ * /api/admin/*} route — user, collection, tag, and messages admin ops live in sibling controllers
+ * in this package. These are admin-ops endpoints (tiles and cache eviction included), not public
+ * reads.
  *
  * <p>Unlike the legacy dev/prod controller split, these routes are NOT profile-gated — they are
  * protected at the filter-chain level: {@link edens.zac.portfolio.backend.config.SecurityConfig}

--- a/src/main/java/edens/zac/portfolio/backend/controller/admin/AdminUserController.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/admin/AdminUserController.java
@@ -288,7 +288,8 @@ public class AdminUserController {
   }
 
   /**
-   * Admin view of a user's full page (what they see at /user). Perimeter-gated.
+   * Admin view of a user's full page (what they see at /user). Gated by the two-layer admin authz
+   * described in the class Javadoc (prod transport perimeter + {@code hasRole("ADMIN")}).
    *
    * @param id the {@code app_user.id}
    * @return the assembled {@link CollectionModel}


### PR DESCRIPTION
## Summary

Follow-up to the 0204-remove-impersonation final review, which flagged pre-existing comments that misdescribe the now-shipped 0203 admin-authz state. **Text only — zero behavior change** (9 insertions / 6 deletions).

> **Rebased over 0207** (PR #116, merged): `AdminController` now lives at `controller/admin/` and serves all profiles. This PR's fix was re-targeted at 0207's rewritten Javadoc, which had re-introduced the same false ownership claim the 0204 review flagged.

### Fixed

1. **`controller/admin/AdminController.java`** class Javadoc: dropped the false *"Owns every `/api/admin/*` endpoint"* claim. It owns the admin-ops routes only — **user, collection, tag, and messages admin ops live in sibling controllers in the same package** (`AdminUserController` → `/api/admin/users`, `CollectionAdminController` → `/api/admin/collections`, `TagAdminController` → `/api/admin/tags`, `MessagesControllerAdmin` → `/api/admin/messages`). 0207's accurate filter-chain gating paragraph is preserved untouched.
2. **`controller/admin/AdminUserController.java`** `userPage()` Javadoc: *"Perimeter-gated."* understated the gate. Replaced with a pointer to the class Javadoc's two-layer model (prod transport perimeter + `hasRole("ADMIN")`).
3. **`docker-compose.yml`** (optional item): the `SPRING_PROFILES_ACTIVE:?` error listed only *"dev or prod"*, but `application.properties:1` falls back to `default` (→ `enforce-authz=true`, prod-mirroring) and `ai_docs/ai_ec2.md:228` instructs `SPRING_PROFILES_ACTIVE=default`. Error text now reads *"dev, prod, or default"*. Pure error-string change — the `:?` guard still fires only on unset/empty.

## Verification (post-rebase, on ead04e5)

- `JAVA_HOME=…/openjdk@23 ./mvnw spotless:apply` → BUILD SUCCESS (reflowed the new Javadoc; amended in)
- `./mvnw test-compile` → BUILD SUCCESS
- `git diff origin/main` reviewed: comments + one Compose error string only

🤖 Generated with [Claude Code](https://claude.com/claude-code)