### PR TITLE
fix(auth): WebAuthn attempt cookie survives the BFF proxy; prod WEBAUTHN_* env plumb

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,3 +49,9 @@ JAVA_OPTS=-Xmx384m -Xms256m
 
 # Docker container memory limit (local dev default: 1536M)
 DOCKER_MEMORY_LIMIT=768M
+
+# WebAuthn (passkey login). Defaults are localhost-only (dev); required in prod so
+# passkeys are scoped to the real domain and browsers accept the relying party.
+WEBAUTHN_RP_ID=zacedens.com
+WEBAUTHN_RP_NAME=Zac Edens Photography
+WEBAUTHN_ALLOWED_ORIGINS=https://zacedens.com,https://www.zacedens.com

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,14 @@ services:
       # Inner app-layer gate for /api/admin/**: requires ROLE_ADMIN when true (default).
       ADMIN_ENFORCE_AUTHZ: ${ADMIN_ENFORCE_AUTHZ:-true}
 
+      # WebAuthn (passkeys) relying party. The localhost defaults are correct for local dev
+      # only -- on EC2 prod set all three in .env (rp-id = registrable site domain;
+      # allowed-origins = exact https:// origin(s) the site is served from), otherwise the
+      # backend mints ceremonies for rpId=localhost and every browser rejects them.
+      WEBAUTHN_RP_ID: ${WEBAUTHN_RP_ID:-localhost}
+      WEBAUTHN_RP_NAME: ${WEBAUTHN_RP_NAME:-Zac Edens Photography}
+      WEBAUTHN_ALLOWED_ORIGINS: ${WEBAUTHN_ALLOWED_ORIGINS:-http://localhost:3000,http://localhost:3001}
+
       # Email (AWS SES v2) — disabled by default; flip EMAIL_ENABLED=true once SES domain + from-address are verified.
       EMAIL_ENABLED: ${EMAIL_ENABLED:-false}
       EMAIL_FROM_ADDRESS: ${EMAIL_FROM_ADDRESS:-no-reply@edens.zac}

--- a/src/main/java/edens/zac/portfolio/backend/controller/auth/WebAuthnController.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/auth/WebAuthnController.java
@@ -37,7 +37,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class WebAuthnController {
 
   private static final String ATTEMPT_COOKIE = "ezac_webauthn_attempt";
-  private static final String ATTEMPT_COOKIE_PATH = "/api/auth/webauthn";
+
+  /**
+   * Attempt-cookie Path. Must be {@code /}: the browser reaches these endpoints only through the
+   * frontend BFF proxy ({@code /api/proxy/api/auth/webauthn/...}), so a cookie scoped to this
+   * controller's own {@code /api/auth/webauthn} prefix would never path-match the proxied request
+   * and {@code /login/finish} would always 401. Mirrors the session cookie's {@code /} path
+   * (SessionService); the value is a random single-use attempt id, so the wider scope leaks
+   * nothing.
+   */
+  private static final String ATTEMPT_COOKIE_PATH = "/";
+
   private static final Duration ATTEMPT_COOKIE_TTL = Duration.ofMinutes(5);
 
   private final WebAuthnService webAuthnService;

--- a/src/test/java/edens/zac/portfolio/backend/controller/auth/WebAuthnControllerTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/auth/WebAuthnControllerTest.java
@@ -113,7 +113,8 @@ class WebAuthnControllerTest {
         .andExpect(status().isOk())
         .andExpect(cookie().exists("ezac_webauthn_attempt"))
         .andExpect(cookie().value("ezac_webauthn_attempt", "attempt-1"))
-        .andExpect(cookie().httpOnly("ezac_webauthn_attempt", true));
+        .andExpect(cookie().httpOnly("ezac_webauthn_attempt", true))
+        .andExpect(cookie().path("ezac_webauthn_attempt", "/"));
 
     verify(loginLimiter).recordFailure(anyString(), eq("admin@example.com"));
   }
@@ -164,7 +165,8 @@ class WebAuthnControllerTest {
                 .contentType("application/json")
                 .content("{\"id\":\"abc\"}"))
         .andExpect(status().isNoContent())
-        .andExpect(cookie().maxAge("ezac_webauthn_attempt", 0));
+        .andExpect(cookie().maxAge("ezac_webauthn_attempt", 0))
+        .andExpect(cookie().path("ezac_webauthn_attempt", "/"));
 
     verify(webAuthnService).finishLogin(eq("attempt-1"), eq("{\"id\":\"abc\"}"), any(), any());
     verify(loginLimiter).reset(anyString(), eq("admin@example.com"));
@@ -201,10 +203,14 @@ class WebAuthnControllerTest {
 
     boolean clearedCookiePresent =
         response.getHeaders(org.springframework.http.HttpHeaders.SET_COOKIE).stream()
-            .anyMatch(h -> h.contains("ezac_webauthn_attempt") && h.contains("Max-Age=0"));
+            .anyMatch(
+                h ->
+                    h.contains("ezac_webauthn_attempt")
+                        && h.contains("Max-Age=0")
+                        && h.contains("Path=/;"));
     org.junit.jupiter.api.Assertions.assertTrue(
         clearedCookiePresent,
-        "attempt cookie must be cleared (Max-Age=0) even when finishLogin throws");
+        "attempt cookie must be cleared (Max-Age=0, Path=/) even when finishLogin throws");
   }
 
   @Test


### PR DESCRIPTION
## What

Two of the four fixes from the 2026-07-06 passkey diagnosis (spike: `docs/spikes/2026-07-06-passkey-login-diagnosis.md`, local book doc — gitignored):

1. **Attempt-cookie path fix** (`7adcbef`) — `ezac_webauthn_attempt` was issued with `Path=/api/auth/webauthn`, but browsers only ever reach the backend through the FE BFF proxy at `/api/proxy/api/auth/webauthn/...`, so the cookie never path-matched the follow-up request and `login/finish` always 401'd. **Passkey login has never worked end-to-end in any environment, for any user.** The single `ATTEMPT_COOKIE_PATH` constant now emits `Path=/`; set and clear build from the same constant so they cannot drift. All other attributes unchanged (HttpOnly, SameSite=Strict, 5-minute TTL, config-driven Secure).
2. **Prod WebAuthn config plumb** (`127a42a`) — docker-compose (the EC2 prod launcher) now passes through `WEBAUTHN_RP_ID`, `WEBAUTHN_RP_NAME`, `WEBAUTHN_ALLOWED_ORIGINS` with defaults identical to `application.properties` (local/dev behavior unchanged). Previously prod could only serve `rpId=localhost` → instant browser `SecurityError`; every prod invite-checkbox passkey registration has been silently failing.
3. **`.env.example` documentation** (`75a5f89`) — the three vars with prod values.

## Deploy (required for passkeys to work in prod)

Add to EC2 `~/portfolio-backend/.env`, then redeploy:

```
WEBAUTHN_RP_ID=zacedens.com
WEBAUTHN_ALLOWED_ORIGINS=https://zacedens.com,https://www.zacedens.com
```

`WEBAUTHN_RP_NAME` may keep its default. rp-id = registrable domain covers apex + www; listing www in origins is required if it serves the site, harmless if not (exact-match set). Origin values recovered from the pre-BFF CORS allowlist (`22593c4`).

## Verification

- TDD: 3 cookie-path assertions failed red first (`path expected:</> but was:</api/auth/webauthn>`), then green — pinning `Path=/` on set, clear-on-success, and clear-on-exception.
- Full suite: **967 tests, 0 failures** (1 pre-existing skip). `spotless:apply` clean, `test-compile` clean.
- Security review of the path widening (final-review lens): the widened cookie rides all same-site requests for its ≤5-minute single-use life; verified no request/header logging exists BE or FE, no other reader of the cookie name anywhere, and `ezac_session` (longer-lived, more sensitive) already rides `Path=/`. Stale pre-fix cookies can never path-match and self-expire within 5 minutes.

## Notes

- Consciously skipped (marked optional in the spike): a prod startup guard against `rpId=localhost`. Small follow-up if wanted.
- Counterpart FE PR (enrollment UI + error surfacing): https://github.com/themancalledzac/edens.zac/pull/210
- Human E2E after both merge + env + redeploy: enroll a passkey from `/user` (admin account) → log out → passkey login through the proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
