### PR TITLE
fix(deploy): quote SPRING_PROFILES_ACTIVE — :?-message colons broke compose YAML parse

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER:-zedens}
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       # Spring profile: must be explicitly set to dev, prod, or default (no silent fallback).
-      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:?must be set: dev, prod, or default}
+      SPRING_PROFILES_ACTIVE: "${SPRING_PROFILES_ACTIVE:?must be set: dev, prod, or default}"
 
       # AWS Config
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}


### PR DESCRIPTION
## What / why

`./deploy.sh` failed at **Building images...** with `yaml: line 21, column 68: mapping values are not allowed in this context` — the first-ever deploy failure.

Line 21's `${SPRING_PROFILES_ACTIVE:?must be set: dev, prod, or default}` (error text from #117) contains `: ` inside an **unquoted** plain scalar — invalid YAML. The line had never been parsed until today: #117 was comment-only (no redeploy), so the post-#118 deploy was the first compose parse since it merged. One-line fix: quote the scalar; the `:?` guard and message are unchanged (interpolation happens on the string value after YAML parse).

## Verification
- Strict PyYAML parse of the full file: **clean** (was: exact same line-21/col-68 error as EC2)
- `docker compose config -q`: parses (only unset-env warnings locally, no .env present)
- Prod impact: none occurred — the failed deploy died before `down`/`up`; site stayed 200.

## After merge
Re-run `./deploy.sh`. Heads-up: the next deploy step has a separately-tracked chip (the `down || true && up -d` orphan race with the standalone `portfolio-postgres` — fix is `up -d --force-recreate`) — if the deploy trips there, that's the known issue, not this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)