### PR TITLE
fix(download): 302 to presigned S3 URL to bypass Amplify 5.72MB cap

### DIFF
--- a/src/main/java/edens/zac/portfolio/backend/config/S3Config.java
+++ b/src/main/java/edens/zac/portfolio/backend/config/S3Config.java
@@ -10,6 +10,7 @@ import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.cloudfront.CloudFrontClient;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Slf4j
 @Configuration
@@ -46,6 +47,21 @@ public class S3Config {
       log.error("Failed to create S3Client", e);
       throw e;
     }
+  }
+
+  /**
+   * Presigner for generating short-lived, self-authenticating S3 GET URLs. Downloads redirect (302)
+   * to these so the bytes stream straight from S3 to the client, bypassing the Amplify Web Compute
+   * 5.72 MB response cap that kills anything proxied through the Next.js BFF.
+   */
+  @Bean(destroyMethod = "close")
+  public S3Presigner s3Presigner() {
+    log.info("Creating S3Presigner");
+    AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKeyId, secretAccessKey);
+    return S3Presigner.builder()
+        .credentialsProvider(StaticCredentialsProvider.create(credentials))
+        .region(Region.of(region))
+        .build();
   }
 
   @Bean(destroyMethod = "close")

--- a/src/main/java/edens/zac/portfolio/backend/controller/prod/ContentDownloadControllerProd.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/prod/ContentDownloadControllerProd.java
@@ -7,22 +7,18 @@ import edens.zac.portfolio.backend.model.DownloadResolution;
 import edens.zac.portfolio.backend.services.ClientGalleryAuthService;
 import edens.zac.portfolio.backend.services.CollectionService;
 import edens.zac.portfolio.backend.services.ContentService;
+import edens.zac.portfolio.backend.services.DownloadUrlService;
 import edens.zac.portfolio.backend.services.UserCollectionService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import java.net.URI;
 import java.util.List;
 import java.util.Optional;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -30,31 +26,26 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import software.amazon.awssdk.core.ResponseInputStream;
-import software.amazon.awssdk.core.exception.SdkException;
-import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.GetObjectRequest;
-import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 
 /**
- * Authenticated download endpoints for client galleries. Streams assets directly from S3 to the
- * response so memory stays flat regardless of gallery size.
+ * Authenticated download endpoints for client galleries. Instead of streaming bytes through the
+ * response, these authorize the request and then <strong>302-redirect to a short-lived S3 presigned
+ * URL</strong>, so the browser pulls the actual file straight from S3.
  *
- * <p>This controller stays thin: format/field selection, fallback rules, and filename/MIME
- * decisions all live in {@link ContentService}. The controller is responsible only for HTTP
- * concerns -- parsing parameters, the gallery-access cookie auth gate, and S3 streaming.
+ * <p>This is deliberate: the frontend runs on AWS Amplify Web Compute, whose Next.js BFF caps any
+ * proxied HTTP response at 5.72 MB. A full-resolution image or a multi-image ZIP exceeds that and
+ * is killed at the CloudFront/compute layer (the client-reported {@code 413 Content Too Large}).
+ * The redirect body is a few hundred bytes — it passes the cap — and the presigned URL the browser
+ * then follows hits S3 directly, which has no such limit. See {@link DownloadUrlService}.
  *
  * <p>Endpoints:
  *
  * <ul>
- *   <li>{@code GET /api/read/content/images/{id}/download?format=web} -- single image WebP
- *   <li>{@code GET /api/read/content/images/{id}/download?format=original} -- single image JPEG
- *   <li>{@code GET /api/read/collections/{slug}/download?format=web} -- ZIP of every WebP
- *   <li>{@code GET /api/read/collections/{slug}/download?format=original} -- ZIP of full-res JPEGs
- *       (per-image fallback to WebP when no original is stored)
- *   <li>{@code GET /api/read/collections/{slug}/download?format=web&imageIds=1,2,3} -- ZIP of just
- *       the selected images (optional {@code imageIds} subset; ids not in the collection are
- *       dropped, and the ZIP filename gains a {@code -selection-N} suffix)
+ *   <li>{@code GET /api/read/content/images/{id}/download?format=web|original} — single image
+ *   <li>{@code GET /api/read/collections/{slug}/download?format=web|original} — ZIP of the
+ *       collection
+ *   <li>{@code GET /api/read/collections/{slug}/download?...&imageIds=1,2,3} — ZIP of the selected
+ *       subset (a single selected image redirects straight to that image, no ZIP)
  * </ul>
  */
 @Slf4j
@@ -63,21 +54,18 @@ import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 @RequestMapping("/api/read")
 public class ContentDownloadControllerProd {
 
-  private final S3Client s3Client;
   private final CollectionService collectionService;
   private final ContentService contentService;
   private final ClientGalleryAuthService clientGalleryAuthService;
   private final UserCollectionService userCollectionService;
-
-  @Value("${aws.portfolio.s3.bucket}")
-  private String bucketName;
+  private final DownloadUrlService downloadUrlService;
 
   // ---------------------------------------------------------------------------
   //  Image download
   // ---------------------------------------------------------------------------
 
   @GetMapping("/content/images/{id}/download")
-  public ResponseEntity<InputStreamResource> downloadImage(
+  public ResponseEntity<Void> downloadImage(
       @PathVariable Long id,
       @RequestParam(defaultValue = "web") String format,
       HttpServletRequest request) {
@@ -93,21 +81,10 @@ public class ContentDownloadControllerProd {
     }
 
     DownloadResolution resolution = contentService.resolveImageDownload(id, format);
-    GetObjectRequest s3Req =
-        GetObjectRequest.builder().bucket(bucketName).key(resolution.s3Key()).build();
-    ResponseInputStream<GetObjectResponse> stream = s3Client.getObject(s3Req);
-
-    ResponseEntity.BodyBuilder builder =
-        ResponseEntity.ok()
-            .contentType(MediaType.parseMediaType(resolution.contentType()))
-            .header(
-                HttpHeaders.CONTENT_DISPOSITION,
-                "attachment; filename=\"" + resolution.filename() + "\"");
-    Long contentLength = stream.response().contentLength();
-    if (contentLength != null && contentLength > 0L) {
-      builder = builder.contentLength(contentLength);
-    }
-    return builder.body(new InputStreamResource(stream));
+    URI url =
+        downloadUrlService.presignObject(
+            resolution.s3Key(), resolution.contentType(), resolution.filename());
+    return ResponseEntity.status(HttpStatus.FOUND).location(url).build();
   }
 
   // ---------------------------------------------------------------------------
@@ -126,7 +103,7 @@ public class ContentDownloadControllerProd {
     CollectionEntity collection = collectionService.findEntityBySlug(slug);
 
     if (collection.getGalleryPassword() != null && !isDownloadAuthorized(request, collection)) {
-      log.warn("Unauthorized collection ZIP download (slug={})", slug);
+      log.warn("Unauthorized collection download (slug={})", slug);
       response.sendError(HttpStatus.UNAUTHORIZED.value());
       return;
     }
@@ -134,47 +111,32 @@ public class ContentDownloadControllerProd {
     List<DownloadResolution> entries =
         contentService.resolveCollectionDownloadEntries(collection.getId(), format, imageIds);
 
-    boolean isSubset = imageIds != null && !imageIds.isEmpty();
-    String zipName = contentService.collectionZipFilename(collection.getSlug(), collection.getId());
-    if (isSubset) {
-      // Distinguish a selected-subset ZIP from the whole-collection one so a client who downloads
-      // "all" and then a subset doesn't get two identically named files. Count is an int -- safe.
-      zipName = zipName.replaceFirst("\\.zip$", "-selection-" + imageIds.size() + ".zip");
+    if (entries.isEmpty()) {
+      response.sendError(HttpStatus.NOT_FOUND.value());
+      return;
     }
-    response.setContentType("application/zip");
-    response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + zipName + "\"");
 
-    try (ZipOutputStream zos = new ZipOutputStream(response.getOutputStream())) {
-      int seq = 0;
-      for (DownloadResolution entry : entries) {
-        // Defensive against duplicate names within a ZIP (S3 keys are unique, original_filenames
-        // are not). Prefix with a sequence number so ZipOutputStream never throws on duplicates.
-        GetObjectRequest s3Req =
-            GetObjectRequest.builder().bucket(bucketName).key(entry.s3Key()).build();
-        try (ResponseInputStream<GetObjectResponse> in = s3Client.getObject(s3Req)) {
-          ZipEntry zipEntry = new ZipEntry(String.format("%03d_%s", seq++, entry.filename()));
-          zos.putNextEntry(zipEntry);
-          in.transferTo(zos);
-          zos.closeEntry();
-        } catch (SdkException e) {
-          // Per-image failure must not corrupt the rest of the ZIP. Write a placeholder so the
-          // recipient sees something is missing without us tearing down the whole download.
-          log.warn(
-              "Failed to fetch S3 object for ZIP entry (key={}): {}",
-              entry.s3Key(),
-              e.getMessage());
-          ZipEntry errorEntry =
-              new ZipEntry(String.format("%03d_%s.error.txt", seq++, entry.filename()));
-          zos.putNextEntry(errorEntry);
-          zos.write(
-              ("Could not include this image: " + e.getClass().getSimpleName())
-                  .getBytes(StandardCharsets.UTF_8));
-          zos.closeEntry();
-        }
+    boolean isSubset = imageIds != null && !imageIds.isEmpty();
+    URI url;
+    if (entries.size() == 1) {
+      // A single resolved image (including a one-image "Download Selected") skips the ZIP and
+      // redirects straight to that image — the recipient gets the file, not a one-entry archive.
+      DownloadResolution only = entries.get(0);
+      url = downloadUrlService.presignObject(only.s3Key(), only.contentType(), only.filename());
+    } else {
+      String zipName =
+          contentService.collectionZipFilename(collection.getSlug(), collection.getId());
+      if (isSubset) {
+        // Distinguish a selected-subset ZIP from the whole-collection one so a client who downloads
+        // "all" and then a subset doesn't get two identically named files. Count is an int -- safe.
+        zipName = zipName.replaceFirst("\\.zip$", "-selection-" + imageIds.size() + ".zip");
       }
-      zos.finish();
+      url = downloadUrlService.zipToS3AndPresign(entries, zipName);
     }
-    log.info("Streamed ZIP download (slug={}, format={}, count={})", slug, format, entries.size());
+
+    response.setStatus(HttpStatus.FOUND.value());
+    response.setHeader(HttpHeaders.LOCATION, url.toString());
+    log.info("Redirected download (slug={}, format={}, count={})", slug, format, entries.size());
   }
 
   // ---------------------------------------------------------------------------

--- a/src/main/java/edens/zac/portfolio/backend/services/DownloadUrlService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/DownloadUrlService.java
@@ -1,0 +1,129 @@
+package edens.zac.portfolio.backend.services;
+
+import edens.zac.portfolio.backend.model.DownloadResolution;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+
+/**
+ * Produces short-lived, self-authenticating S3 presigned GET URLs for downloads. Download endpoints
+ * redirect (302) to these instead of streaming bytes through the response.
+ *
+ * <p><strong>Why:</strong> the frontend runs on AWS Amplify Web Compute, which caps any HTTP
+ * response proxied through its Next.js BFF at 5.72 MB — a single full-resolution JPEG, or any
+ * multi-image ZIP, blows past that and the request dies at the CloudFront/compute layer (the
+ * client-reported {@code 413}). A 302 to a presigned URL is a few hundred bytes, so it passes the
+ * cap; the browser then pulls the actual bytes straight from S3, which has no such limit.
+ *
+ * <p>For a multi-image download we can't presign a not-yet-existing archive, so we build the ZIP
+ * into a temporary S3 object (streamed via {@link S3MultipartOutputStream}, memory-flat) and
+ * presign that. Temp objects live under {@link #TMP_PREFIX} and are reaped by an S3 lifecycle rule.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DownloadUrlService {
+
+  /** Presigned URL lifetime — long enough for the browser to follow the redirect and finish. */
+  private static final Duration URL_TTL = Duration.ofMinutes(15);
+
+  /**
+   * Key prefix for generated ZIP archives; a bucket lifecycle rule expires these (see terraform).
+   */
+  static final String TMP_PREFIX = "downloads-tmp/";
+
+  private final S3Client s3Client;
+  private final S3Presigner s3Presigner;
+
+  @Value("${aws.portfolio.s3.bucket}")
+  private String bucketName;
+
+  /**
+   * Presign a GET for an existing S3 object, forcing a browser download with the given filename and
+   * content type.
+   */
+  public URI presignObject(String s3Key, String contentType, String filename) {
+    GetObjectRequest getObject =
+        GetObjectRequest.builder()
+            .bucket(bucketName)
+            .key(s3Key)
+            .responseContentType(contentType)
+            .responseContentDisposition(contentDisposition(filename))
+            .build();
+    GetObjectPresignRequest presignRequest =
+        GetObjectPresignRequest.builder()
+            .signatureDuration(URL_TTL)
+            .getObjectRequest(getObject)
+            .build();
+    return URI.create(s3Presigner.presignGetObject(presignRequest).url().toString());
+  }
+
+  /**
+   * Build a ZIP of {@code entries} into a temporary S3 object and return a presigned URL to it. The
+   * archive is streamed to S3 part-by-part, so peak memory is one ~5 MB part regardless of gallery
+   * size. A per-image S3 failure is written into the ZIP as a small {@code .error.txt} placeholder
+   * rather than aborting the whole download.
+   */
+  public URI zipToS3AndPresign(List<DownloadResolution> entries, String zipFilename)
+      throws IOException {
+    String key = TMP_PREFIX + UUID.randomUUID() + "/" + zipFilename;
+    S3MultipartOutputStream s3Out = new S3MultipartOutputStream(s3Client, bucketName, key);
+    try {
+      ZipOutputStream zos = new ZipOutputStream(s3Out);
+      writeZipEntries(zos, entries);
+      zos.finish();
+      zos.close(); // completes the multipart upload via S3MultipartOutputStream.close()
+    } catch (IOException | RuntimeException e) {
+      s3Out.abort(); // never complete a truncated archive
+      throw e;
+    }
+    log.info("Built ZIP download to S3 (key={}, count={})", key, entries.size());
+    return presignObject(key, "application/zip", zipFilename);
+  }
+
+  private void writeZipEntries(ZipOutputStream zos, List<DownloadResolution> entries)
+      throws IOException {
+    int seq = 0;
+    for (DownloadResolution entry : entries) {
+      // S3 keys are unique but original_filenames are not — prefix with a sequence number so
+      // ZipOutputStream never throws on duplicate entry names.
+      GetObjectRequest req =
+          GetObjectRequest.builder().bucket(bucketName).key(entry.s3Key()).build();
+      try (ResponseInputStream<GetObjectResponse> in = s3Client.getObject(req)) {
+        zos.putNextEntry(new ZipEntry(String.format("%03d_%s", seq++, entry.filename())));
+        in.transferTo(zos);
+        zos.closeEntry();
+      } catch (SdkException e) {
+        // Per-image failure must not corrupt the rest of the ZIP: write a placeholder so the
+        // recipient sees something is missing without tearing down the whole download.
+        log.warn(
+            "Failed to fetch S3 object for ZIP entry (key={}): {}", entry.s3Key(), e.getMessage());
+        zos.putNextEntry(new ZipEntry(String.format("%03d_%s.error.txt", seq++, entry.filename())));
+        zos.write(
+            ("Could not include this image: " + e.getClass().getSimpleName())
+                .getBytes(StandardCharsets.UTF_8));
+        zos.closeEntry();
+      }
+    }
+  }
+
+  private static String contentDisposition(String filename) {
+    return "attachment; filename=\"" + filename + "\"";
+  }
+}

--- a/src/main/java/edens/zac/portfolio/backend/services/S3MultipartOutputStream.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/S3MultipartOutputStream.java
@@ -1,0 +1,134 @@
+package edens.zac.portfolio.backend.services;
+
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload;
+import software.amazon.awssdk.services.s3.model.CompletedPart;
+
+/**
+ * An {@link OutputStream} that streams whatever is written to it straight into an S3 object via a
+ * multipart upload, holding only one part (~5 MB) in memory at a time. This lets us build a
+ * collection ZIP of arbitrary size (a full-resolution "download all") into S3 without buffering the
+ * whole archive on disk or in heap.
+ *
+ * <p>Contract details that matter for correctness:
+ *
+ * <ul>
+ *   <li>S3 requires every part except the last to be at least 5 MB. We flush a part only when the
+ *       buffer is completely full (exactly {@link #PART_SIZE}), so every non-final part is exactly
+ *       5 MB and the trailing part (flushed on {@link #close()}) is whatever remains.
+ *   <li>The stream is single-threaded / not thread-safe — one download builds one ZIP.
+ *   <li>{@link #close()} completes the upload. If any write or the completion fails, the multipart
+ *       upload is aborted so S3 doesn't retain orphaned parts (which would otherwise accrue storage
+ *       cost until a lifecycle rule reaps them).
+ * </ul>
+ */
+@Slf4j
+public class S3MultipartOutputStream extends OutputStream {
+
+  /** 5 MiB — the S3 minimum part size for all but the final part. */
+  private static final int PART_SIZE = 5 * 1024 * 1024;
+
+  private final S3Client s3Client;
+  private final String bucket;
+  private final String key;
+  private final String uploadId;
+  private final List<CompletedPart> completedParts = new ArrayList<>();
+
+  private final byte[] buffer = new byte[PART_SIZE];
+  private int bufferLen = 0;
+  private int partNumber = 1;
+  private boolean closed = false;
+  private boolean aborted = false;
+
+  /** Opens the multipart upload immediately so writes can begin streaming parts. */
+  public S3MultipartOutputStream(S3Client s3Client, String bucket, String key) {
+    this.s3Client = s3Client;
+    this.bucket = bucket;
+    this.key = key;
+    this.uploadId = s3Client.createMultipartUpload(b -> b.bucket(bucket).key(key)).uploadId();
+  }
+
+  @Override
+  public void write(int b) {
+    buffer[bufferLen++] = (byte) b;
+    if (bufferLen == PART_SIZE) {
+      uploadBufferedPart();
+    }
+  }
+
+  @Override
+  public void write(byte[] src, int off, int len) {
+    int remaining = len;
+    int pos = off;
+    while (remaining > 0) {
+      int chunk = Math.min(remaining, PART_SIZE - bufferLen);
+      System.arraycopy(src, pos, buffer, bufferLen, chunk);
+      bufferLen += chunk;
+      pos += chunk;
+      remaining -= chunk;
+      if (bufferLen == PART_SIZE) {
+        uploadBufferedPart();
+      }
+    }
+  }
+
+  /** Uploads the current buffer as the next part (full 5 MB parts, plus the final part). */
+  private void uploadBufferedPart() {
+    final int number = partNumber;
+    String etag =
+        s3Client
+            .uploadPart(
+                b -> b.bucket(bucket).key(key).uploadId(uploadId).partNumber(number),
+                RequestBody.fromBytes(Arrays.copyOf(buffer, bufferLen)))
+            .eTag();
+    completedParts.add(CompletedPart.builder().partNumber(number).eTag(etag).build());
+    partNumber++;
+    bufferLen = 0;
+  }
+
+  /** Aborts the multipart upload, best-effort. Safe to call more than once. */
+  public void abort() {
+    if (aborted) {
+      return;
+    }
+    aborted = true;
+    try {
+      s3Client.abortMultipartUpload(b -> b.bucket(bucket).key(key).uploadId(uploadId));
+    } catch (RuntimeException e) {
+      log.warn(
+          "Failed to abort multipart upload (bucket={}, key={}): {}", bucket, key, e.getMessage());
+    }
+  }
+
+  @Override
+  public void close() {
+    if (closed) {
+      return;
+    }
+    closed = true;
+    try {
+      if (bufferLen > 0) {
+        uploadBufferedPart();
+      }
+      // A well-formed ZIP always has an end-of-central-directory record, so completedParts is never
+      // empty in practice. Guard anyway: an empty multipart upload cannot be completed.
+      if (completedParts.isEmpty()) {
+        abort();
+        return;
+      }
+      CompletedMultipartUpload completed =
+          CompletedMultipartUpload.builder().parts(completedParts).build();
+      s3Client.completeMultipartUpload(
+          b -> b.bucket(bucket).key(key).uploadId(uploadId).multipartUpload(completed));
+    } catch (RuntimeException e) {
+      abort();
+      throw e;
+    }
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/controller/prod/ContentDownloadAuthTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/prod/ContentDownloadAuthTest.java
@@ -13,10 +13,11 @@ import edens.zac.portfolio.backend.model.DownloadResolution;
 import edens.zac.portfolio.backend.services.ClientGalleryAuthService;
 import edens.zac.portfolio.backend.services.CollectionService;
 import edens.zac.portfolio.backend.services.ContentService;
+import edens.zac.portfolio.backend.services.DownloadUrlService;
 import edens.zac.portfolio.backend.services.UserCollectionService;
 import edens.zac.portfolio.backend.types.CollectionType;
 import edens.zac.portfolio.backend.types.CollectionVisibility;
-import java.io.ByteArrayInputStream;
+import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
@@ -29,30 +30,26 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import software.amazon.awssdk.core.ResponseInputStream;
-import software.amazon.awssdk.http.AbortableInputStream;
-import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.GetObjectRequest;
-import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 
 /**
  * Verifies the CLIENT-membership download bypass in {@link ContentDownloadControllerProd}: a
- * principal holding a CLIENT membership sees 200 without a cookie; no CLIENT membership sees 401;
- * and anonymous paths still consult the cookie gate unchanged.
+ * principal holding a CLIENT membership is authorized without a cookie (302 redirect to the
+ * presigned URL); no CLIENT membership yields 401; and anonymous paths still consult the cookie
+ * gate unchanged. Auth semantics only — the redirect target is produced by {@link
+ * DownloadUrlService}, stubbed here.
  */
 @ExtendWith(MockitoExtension.class)
 class ContentDownloadAuthTest {
 
-  private static final String BUCKET = "test-bucket";
+  private static final URI PRESIGNED = URI.create("https://bucket.s3.amazonaws.com/obj?sig=abc");
 
-  @Mock private S3Client s3Client;
   @Mock private CollectionService collectionService;
   @Mock private ContentService contentService;
   @Mock private ClientGalleryAuthService clientGalleryAuthService;
   @Mock private UserCollectionService userCollectionService;
+  @Mock private DownloadUrlService downloadUrlService;
 
   @InjectMocks private ContentDownloadControllerProd controller;
 
@@ -60,7 +57,6 @@ class ContentDownloadAuthTest {
 
   @BeforeEach
   void setUp() {
-    ReflectionTestUtils.setField(controller, "bucketName", BUCKET);
     mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
   }
 
@@ -73,12 +69,6 @@ class ContentDownloadAuthTest {
     var principal = new AuthPrincipal(userId, "c@example.com", false, true);
     SecurityContextHolder.getContext()
         .setAuthentication(new UsernamePasswordAuthenticationToken(principal, null, List.of()));
-  }
-
-  private static ResponseInputStream<GetObjectResponse> fakeStream() {
-    GetObjectResponse meta = GetObjectResponse.builder().contentLength(4L).build();
-    return new ResponseInputStream<>(
-        meta, AbortableInputStream.create(new ByteArrayInputStream(new byte[] {1, 2, 3, 4})));
   }
 
   private static DownloadResolution webResolution(String filename) {
@@ -104,14 +94,14 @@ class ContentDownloadAuthTest {
   class ImageDownloadGrantBypass {
 
     @Test
-    void clientMember_gets200_withoutCookie() throws Exception {
+    void clientMember_redirects_withoutCookie() throws Exception {
       authenticate(7L);
       when(contentService.findCollectionForImage(10L)).thenReturn(Optional.of(protectedGallery()));
       when(userCollectionService.isClient(7L, 1L)).thenReturn(true);
       when(contentService.resolveImageDownload(10L, "web")).thenReturn(webResolution("img.webp"));
-      when(s3Client.getObject(any(GetObjectRequest.class))).thenReturn(fakeStream());
+      when(downloadUrlService.presignObject(any(), any(), any())).thenReturn(PRESIGNED);
 
-      mockMvc.perform(get("/api/read/content/images/10/download")).andExpect(status().isOk());
+      mockMvc.perform(get("/api/read/content/images/10/download")).andExpect(status().isFound());
 
       verify(clientGalleryAuthService, never()).validateAccessToken(any(), any());
     }
@@ -121,7 +111,6 @@ class ContentDownloadAuthTest {
       authenticate(7L);
       when(contentService.findCollectionForImage(10L)).thenReturn(Optional.of(protectedGallery()));
       when(userCollectionService.isClient(7L, 1L)).thenReturn(false);
-      // No cookie present; cookie gate returns false by default, yielding 401.
 
       mockMvc
           .perform(get("/api/read/content/images/10/download"))
@@ -132,7 +121,6 @@ class ContentDownloadAuthTest {
 
     @Test
     void anonymous_noMembership_noCookie_gets401() throws Exception {
-      // No authentication set; no cookie present — cookie gate default returns false.
       when(contentService.findCollectionForImage(10L)).thenReturn(Optional.of(protectedGallery()));
 
       mockMvc
@@ -143,41 +131,41 @@ class ContentDownloadAuthTest {
     }
 
     @Test
-    void anonymous_validCookie_gets200() throws Exception {
+    void anonymous_validCookie_redirects() throws Exception {
       when(contentService.findCollectionForImage(10L)).thenReturn(Optional.of(protectedGallery()));
       when(clientGalleryAuthService.validateAccessToken("smith-wedding", "tok")).thenReturn(true);
       when(contentService.resolveImageDownload(10L, "web")).thenReturn(webResolution("img.webp"));
-      when(s3Client.getObject(any(GetObjectRequest.class))).thenReturn(fakeStream());
+      when(downloadUrlService.presignObject(any(), any(), any())).thenReturn(PRESIGNED);
 
       mockMvc
           .perform(
               get("/api/read/content/images/10/download")
                   .cookie(new jakarta.servlet.http.Cookie("gallery_access_smith-wedding", "tok")))
-          .andExpect(status().isOk());
+          .andExpect(status().isFound());
 
       verify(userCollectionService, never()).isClient(any(), any());
     }
   }
 
   // ---------------------------------------------------------------------------
-  //  Collection ZIP download — CLIENT membership bypass
+  //  Collection download — CLIENT membership bypass
   // ---------------------------------------------------------------------------
 
   @Nested
   class CollectionDownloadGrantBypass {
 
     @Test
-    void clientMember_gets200_withoutCookie() throws Exception {
+    void clientMember_redirects_withoutCookie() throws Exception {
       authenticate(7L);
       when(collectionService.findEntityBySlug("smith-wedding")).thenReturn(protectedGallery());
       when(userCollectionService.isClient(7L, 1L)).thenReturn(true);
       when(contentService.resolveCollectionDownloadEntries(1L, "web", null))
           .thenReturn(List.of(webResolution("img.webp")));
-      when(s3Client.getObject(any(GetObjectRequest.class))).thenReturn(fakeStream());
+      when(downloadUrlService.presignObject(any(), any(), any())).thenReturn(PRESIGNED);
 
       mockMvc
           .perform(get("/api/read/collections/smith-wedding/download"))
-          .andExpect(status().isOk());
+          .andExpect(status().isFound());
 
       verify(clientGalleryAuthService, never()).validateAccessToken(any(), any());
     }
@@ -187,7 +175,6 @@ class ContentDownloadAuthTest {
       authenticate(7L);
       when(collectionService.findEntityBySlug("smith-wedding")).thenReturn(protectedGallery());
       when(userCollectionService.isClient(7L, 1L)).thenReturn(false);
-      // No cookie present; cookie gate returns false by default, yielding 401.
 
       mockMvc
           .perform(get("/api/read/collections/smith-wedding/download"))
@@ -198,7 +185,6 @@ class ContentDownloadAuthTest {
 
     @Test
     void anonymous_noMembership_noCookie_gets401() throws Exception {
-      // No authentication set; no cookie present — cookie gate default returns false.
       when(collectionService.findEntityBySlug("smith-wedding")).thenReturn(protectedGallery());
 
       mockMvc
@@ -209,18 +195,18 @@ class ContentDownloadAuthTest {
     }
 
     @Test
-    void anonymous_validCookie_gets200() throws Exception {
+    void anonymous_validCookie_redirects() throws Exception {
       when(collectionService.findEntityBySlug("smith-wedding")).thenReturn(protectedGallery());
       when(clientGalleryAuthService.validateAccessToken("smith-wedding", "tok")).thenReturn(true);
       when(contentService.resolveCollectionDownloadEntries(1L, "web", null))
           .thenReturn(List.of(webResolution("img.webp")));
-      when(s3Client.getObject(any(GetObjectRequest.class))).thenReturn(fakeStream());
+      when(downloadUrlService.presignObject(any(), any(), any())).thenReturn(PRESIGNED);
 
       mockMvc
           .perform(
               get("/api/read/collections/smith-wedding/download")
                   .cookie(new jakarta.servlet.http.Cookie("gallery_access_smith-wedding", "tok")))
-          .andExpect(status().isOk());
+          .andExpect(status().isFound());
 
       verify(userCollectionService, never()).isClient(any(), any());
     }

--- a/src/test/java/edens/zac/portfolio/backend/controller/prod/ContentDownloadControllerProdTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/prod/ContentDownloadControllerProdTest.java
@@ -17,15 +17,14 @@ import edens.zac.portfolio.backend.model.DownloadResolution;
 import edens.zac.portfolio.backend.services.ClientGalleryAuthService;
 import edens.zac.portfolio.backend.services.CollectionService;
 import edens.zac.portfolio.backend.services.ContentService;
+import edens.zac.portfolio.backend.services.DownloadUrlService;
+import edens.zac.portfolio.backend.services.UserCollectionService;
 import edens.zac.portfolio.backend.types.CollectionType;
 import edens.zac.portfolio.backend.types.CollectionVisibility;
 import jakarta.servlet.http.Cookie;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
+import java.net.URI;
 import java.util.List;
 import java.util.Optional;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -34,55 +33,40 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import software.amazon.awssdk.core.ResponseInputStream;
-import software.amazon.awssdk.core.exception.SdkClientException;
-import software.amazon.awssdk.http.AbortableInputStream;
-import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.GetObjectRequest;
-import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 
 /**
- * Controller-level tests. The controller is intentionally thin -- format-vs-field, MIME, and
- * extension decisions all live in {@link ContentService}, so these tests stub the high-level
- * service methods ({@code resolveImageDownload}, {@code resolveCollectionDownloadEntries}) and
- * focus on auth gating, S3 streaming, and exception-to-HTTP-status mapping. Resolution logic is
- * exercised separately in {@code ContentServiceDownloadTest}.
+ * Controller-level tests. The controller is intentionally thin: it authorizes, then redirects (302)
+ * to a presigned S3 URL produced by {@link DownloadUrlService} — the bytes never flow through the
+ * response (that would hit the Amplify 5.72 MB proxy cap). So these tests stub the service methods
+ * and focus on auth gating, the single-vs-ZIP branch, and exception-to-HTTP-status mapping.
+ * Presign/ZIP mechanics live in {@code DownloadUrlServiceTest}; resolution in {@code
+ * ContentServiceDownloadTest}.
  */
 @ExtendWith(MockitoExtension.class)
 class ContentDownloadControllerProdTest {
 
-  private static final String BUCKET = "test-bucket";
+  private static final URI PRESIGNED = URI.create("https://bucket.s3.amazonaws.com/obj?sig=abc");
+  private static final URI ZIP_PRESIGNED =
+      URI.create("https://bucket.s3.amazonaws.com/zip?sig=xyz");
 
   private MockMvc mockMvc;
 
-  @Mock private S3Client s3Client;
   @Mock private CollectionService collectionService;
   @Mock private ContentService contentService;
   @Mock private ClientGalleryAuthService clientGalleryAuthService;
+  @Mock private UserCollectionService userCollectionService;
+  @Mock private DownloadUrlService downloadUrlService;
 
   @InjectMocks private ContentDownloadControllerProd controller;
 
   @BeforeEach
   void setUp() {
-    ReflectionTestUtils.setField(controller, "bucketName", BUCKET);
     mockMvc =
         MockMvcBuilders.standaloneSetup(controller)
             .setControllerAdvice(new GlobalExceptionHandler())
             .build();
-  }
-
-  // ---------------------------------------------------------------------------
-  //  Helpers
-  // ---------------------------------------------------------------------------
-
-  private static ResponseInputStream<GetObjectResponse> fakeS3Stream(byte[] bytes) {
-    GetObjectResponse meta = GetObjectResponse.builder().contentLength((long) bytes.length).build();
-    return new ResponseInputStream<>(
-        meta, AbortableInputStream.create(new ByteArrayInputStream(bytes)));
   }
 
   private static DownloadResolution webResolution(String filename) {
@@ -124,30 +108,22 @@ class ContentDownloadControllerProdTest {
   class ImageDownload {
 
     @Test
-    void protectedCollection_validCookie_returns200WithBytes() throws Exception {
-      byte[] body = new byte[] {0x52, 0x49, 0x46, 0x46}; // RIFF magic, just a fake stub
+    void protectedCollection_validCookie_redirectsToPresignedUrl() throws Exception {
       when(contentService.findCollectionForImage(10L)).thenReturn(Optional.of(protectedGallery()));
       when(clientGalleryAuthService.validateAccessToken("smith-wedding", "tok-123"))
           .thenReturn(true);
       when(contentService.resolveImageDownload(10L, "web"))
           .thenReturn(webResolution("smith-001.webp"));
-      when(s3Client.getObject(any(GetObjectRequest.class))).thenReturn(fakeS3Stream(body));
+      when(downloadUrlService.presignObject(
+              "Image/Web/2025/01/smith-001.webp", "image/webp", "smith-001.webp"))
+          .thenReturn(PRESIGNED);
 
-      MvcResult result =
-          mockMvc
-              .perform(
-                  get("/api/read/content/images/10/download")
-                      .cookie(new Cookie("gallery_access_smith-wedding", "tok-123")))
-              .andExpect(status().isOk())
-              .andExpect(header().string("Content-Type", "image/webp"))
-              .andExpect(
-                  header()
-                      .string(
-                          "Content-Disposition",
-                          org.hamcrest.Matchers.startsWith("attachment; filename=\"")))
-              .andReturn();
-
-      assertThat(result.getResponse().getContentAsByteArray()).isEqualTo(body);
+      mockMvc
+          .perform(
+              get("/api/read/content/images/10/download")
+                  .cookie(new Cookie("gallery_access_smith-wedding", "tok-123")))
+          .andExpect(status().isFound())
+          .andExpect(header().string("Location", PRESIGNED.toString()));
     }
 
     @Test
@@ -159,63 +135,46 @@ class ContentDownloadControllerProdTest {
           .andExpect(status().isUnauthorized());
 
       verify(contentService, never()).resolveImageDownload(any(), any());
-      verify(s3Client, never()).getObject(any(GetObjectRequest.class));
+      verify(downloadUrlService, never()).presignObject(any(), any(), any());
     }
 
     @Test
-    void unprotectedCollection_noCookie_returns200() throws Exception {
-      byte[] body = new byte[] {0x01, 0x02, 0x03, 0x04};
+    void unprotectedCollection_noCookie_redirects() throws Exception {
       when(contentService.findCollectionForImage(11L)).thenReturn(Optional.of(openCollection()));
       when(contentService.resolveImageDownload(11L, "web"))
           .thenReturn(webResolution("open-001.webp"));
-      when(s3Client.getObject(any(GetObjectRequest.class))).thenReturn(fakeS3Stream(body));
+      when(downloadUrlService.presignObject(any(), any(), any())).thenReturn(PRESIGNED);
 
-      MvcResult result =
-          mockMvc
-              .perform(get("/api/read/content/images/11/download"))
-              .andExpect(status().isOk())
-              .andReturn();
+      mockMvc
+          .perform(get("/api/read/content/images/11/download"))
+          .andExpect(status().isFound())
+          .andExpect(header().string("Location", PRESIGNED.toString()));
 
-      assertThat(result.getResponse().getContentAsByteArray()).isEqualTo(body);
-      verify(clientGalleryAuthService, never())
-          .validateAccessToken(
-              org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyString());
+      verify(clientGalleryAuthService, never()).validateAccessToken(any(), any());
     }
 
     @Test
-    void orphanImage_noCollection_returns200() throws Exception {
-      byte[] body = new byte[] {0x42};
-      when(contentService.findCollectionForImage(12L)).thenReturn(Optional.empty());
-      when(contentService.resolveImageDownload(12L, "web"))
-          .thenReturn(webResolution("orphan.webp"));
-      when(s3Client.getObject(any(GetObjectRequest.class))).thenReturn(fakeS3Stream(body));
-
-      mockMvc.perform(get("/api/read/content/images/12/download")).andExpect(status().isOk());
-    }
-
-    @Test
-    void formatOriginal_returns200WithJpeg() throws Exception {
-      byte[] body = new byte[] {(byte) 0xFF, (byte) 0xD8, (byte) 0xFF}; // JPEG magic bytes
+    void formatOriginal_redirectsWithJpegResolution() throws Exception {
       when(contentService.findCollectionForImage(10L)).thenReturn(Optional.of(protectedGallery()));
       when(clientGalleryAuthService.validateAccessToken("smith-wedding", "tok-123"))
           .thenReturn(true);
       when(contentService.resolveImageDownload(10L, "original"))
           .thenReturn(jpegResolution("smith-001.jpg"));
-      when(s3Client.getObject(any(GetObjectRequest.class))).thenReturn(fakeS3Stream(body));
+      when(downloadUrlService.presignObject(
+              "Image/Original/2025/01/smith-001.jpg", "image/jpeg", "smith-001.jpg"))
+          .thenReturn(PRESIGNED);
 
       mockMvc
           .perform(
               get("/api/read/content/images/10/download")
                   .param("format", "original")
                   .cookie(new Cookie("gallery_access_smith-wedding", "tok-123")))
-          .andExpect(status().isOk())
-          .andExpect(header().string("Content-Type", "image/jpeg"))
-          .andExpect(
-              header().string("Content-Disposition", org.hamcrest.Matchers.containsString(".jpg")));
+          .andExpect(status().isFound())
+          .andExpect(header().string("Location", PRESIGNED.toString()));
     }
 
     @Test
-    void formatOriginal_serviceThrowsNotFound_returns404() throws Exception {
+    void serviceThrowsNotFound_returns404() throws Exception {
       when(contentService.findCollectionForImage(10L)).thenReturn(Optional.empty());
       when(contentService.resolveImageDownload(10L, "original"))
           .thenThrow(new ResourceNotFoundException("No original available for image 10"));
@@ -224,11 +183,11 @@ class ContentDownloadControllerProdTest {
           .perform(get("/api/read/content/images/10/download").param("format", "original"))
           .andExpect(status().isNotFound());
 
-      verify(s3Client, never()).getObject(any(GetObjectRequest.class));
+      verify(downloadUrlService, never()).presignObject(any(), any(), any());
     }
 
     @Test
-    void formatUnsupported_serviceThrowsIllegalArgument_returns400() throws Exception {
+    void formatUnsupported_returns400() throws Exception {
       when(contentService.findCollectionForImage(10L)).thenReturn(Optional.empty());
       when(contentService.resolveImageDownload(10L, "raw"))
           .thenThrow(new IllegalArgumentException("Unsupported download format: raw"));
@@ -237,81 +196,60 @@ class ContentDownloadControllerProdTest {
           .perform(get("/api/read/content/images/10/download").param("format", "raw"))
           .andExpect(status().isBadRequest());
 
-      verify(s3Client, never()).getObject(any(GetObjectRequest.class));
-    }
-
-    @Test
-    void invalidCookie_returns401() throws Exception {
-      when(contentService.findCollectionForImage(10L)).thenReturn(Optional.of(protectedGallery()));
-      when(clientGalleryAuthService.validateAccessToken("smith-wedding", "garbage"))
-          .thenReturn(false);
-
-      mockMvc
-          .perform(
-              get("/api/read/content/images/10/download")
-                  .cookie(new Cookie("gallery_access_smith-wedding", "garbage")))
-          .andExpect(status().isUnauthorized());
-
-      verify(contentService, never()).resolveImageDownload(any(), any());
-      verify(s3Client, never()).getObject(any(GetObjectRequest.class));
+      verify(downloadUrlService, never()).presignObject(any(), any(), any());
     }
   }
 
   // ---------------------------------------------------------------------------
-  //  Collection ZIP download
+  //  Collection download
   // ---------------------------------------------------------------------------
 
   @Nested
   class CollectionDownload {
 
     @Test
-    void protectedCollection_validCookie_returnsZipWithEntries() throws Exception {
-      CollectionEntity gallery = protectedGallery();
-      when(collectionService.findEntityBySlug("smith-wedding")).thenReturn(gallery);
+    void multipleImages_buildsZipAndRedirects() throws Exception {
+      when(collectionService.findEntityBySlug("smith-wedding")).thenReturn(protectedGallery());
       when(clientGalleryAuthService.validateAccessToken("smith-wedding", "tok-123"))
           .thenReturn(true);
       when(contentService.resolveCollectionDownloadEntries(1L, "web", null))
           .thenReturn(List.of(webResolution("first.webp"), webResolution("second.webp")));
-      when(s3Client.getObject(any(GetObjectRequest.class)))
-          .thenReturn(fakeS3Stream("aaaa".getBytes()))
-          .thenReturn(fakeS3Stream("bbbb".getBytes()));
+      when(contentService.collectionZipFilename("smith-wedding", 1L))
+          .thenReturn("smith-wedding-1.zip");
+      when(downloadUrlService.zipToS3AndPresign(any(), eq("smith-wedding-1.zip")))
+          .thenReturn(ZIP_PRESIGNED);
 
-      MvcResult result =
-          mockMvc
-              .perform(
-                  get("/api/read/collections/smith-wedding/download")
-                      .cookie(new Cookie("gallery_access_smith-wedding", "tok-123")))
-              .andExpect(status().isOk())
-              .andExpect(header().string("Content-Type", "application/zip"))
-              .andReturn();
+      mockMvc
+          .perform(
+              get("/api/read/collections/smith-wedding/download")
+                  .cookie(new Cookie("gallery_access_smith-wedding", "tok-123")))
+          .andExpect(status().isFound())
+          .andExpect(header().string("Location", ZIP_PRESIGNED.toString()));
+    }
 
-      byte[] zipBytes = result.getResponse().getContentAsByteArray();
-      try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipBytes))) {
-        ZipEntry entry;
-        int count = 0;
-        boolean sawFirst = false;
-        boolean sawSecond = false;
-        while ((entry = zis.getNextEntry()) != null) {
-          count++;
-          if (entry.getName().contains("first")) {
-            sawFirst = true;
-            assertThat(entry.getName()).endsWith(".webp");
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
-            zis.transferTo(out);
-            assertThat(out.toByteArray()).isEqualTo("aaaa".getBytes());
-          }
-          if (entry.getName().contains("second")) {
-            sawSecond = true;
-            assertThat(entry.getName()).endsWith(".webp");
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
-            zis.transferTo(out);
-            assertThat(out.toByteArray()).isEqualTo("bbbb".getBytes());
-          }
-        }
-        assertThat(count).isEqualTo(2);
-        assertThat(sawFirst).isTrue();
-        assertThat(sawSecond).isTrue();
-      }
+    @Test
+    void singleImage_skipsZipAndRedirectsToImage() throws Exception {
+      // The client-reported case: "Download Selected" with ONE image (imageIds=1583). No ZIP —
+      // redirect straight to the image's presigned URL so it isn't wrapped in a one-entry archive.
+      when(collectionService.findEntityBySlug("smith-wedding")).thenReturn(protectedGallery());
+      when(clientGalleryAuthService.validateAccessToken("smith-wedding", "tok-123"))
+          .thenReturn(true);
+      when(contentService.resolveCollectionDownloadEntries(eq(1L), eq("original"), any()))
+          .thenReturn(List.of(jpegResolution("only.jpg")));
+      when(downloadUrlService.presignObject(
+              "Image/Original/2025/01/only.jpg", "image/jpeg", "only.jpg"))
+          .thenReturn(PRESIGNED);
+
+      mockMvc
+          .perform(
+              get("/api/read/collections/smith-wedding/download")
+                  .param("format", "original")
+                  .param("imageIds", "1583")
+                  .cookie(new Cookie("gallery_access_smith-wedding", "tok-123")))
+          .andExpect(status().isFound())
+          .andExpect(header().string("Location", PRESIGNED.toString()));
+
+      verify(downloadUrlService, never()).zipToS3AndPresign(any(), any());
     }
 
     @Test
@@ -323,146 +261,33 @@ class ContentDownloadControllerProdTest {
           .andExpect(status().isUnauthorized());
 
       verify(contentService, never()).resolveCollectionDownloadEntries(any(), any(), any());
-      verify(s3Client, never()).getObject(any(GetObjectRequest.class));
+      verify(downloadUrlService, never()).zipToS3AndPresign(any(), any());
+      verify(downloadUrlService, never()).presignObject(any(), any(), any());
     }
 
     @Test
-    void unprotectedCollection_noCookie_returns200() throws Exception {
-      when(collectionService.findEntityBySlug("open-portfolio")).thenReturn(openCollection());
-      when(contentService.resolveCollectionDownloadEntries(2L, "web", null))
-          .thenReturn(List.of(webResolution("open.webp")));
-      when(s3Client.getObject(any(GetObjectRequest.class)))
-          .thenReturn(fakeS3Stream("zzzz".getBytes()));
-
-      mockMvc
-          .perform(get("/api/read/collections/open-portfolio/download"))
-          .andExpect(status().isOk())
-          .andExpect(header().string("Content-Type", "application/zip"));
-    }
-
-    @Test
-    void formatOriginal_returnsZipWithJpgEntries() throws Exception {
-      when(collectionService.findEntityBySlug("smith-wedding")).thenReturn(protectedGallery());
-      when(clientGalleryAuthService.validateAccessToken("smith-wedding", "tok-123"))
-          .thenReturn(true);
-      when(contentService.resolveCollectionDownloadEntries(1L, "original", null))
-          .thenReturn(List.of(jpegResolution("first.jpg"), jpegResolution("second.jpg")));
-      when(s3Client.getObject(any(GetObjectRequest.class)))
-          .thenReturn(fakeS3Stream("JPEG1".getBytes()))
-          .thenReturn(fakeS3Stream("JPEG2".getBytes()));
-
-      MvcResult result =
-          mockMvc
-              .perform(
-                  get("/api/read/collections/smith-wedding/download")
-                      .param("format", "original")
-                      .cookie(new Cookie("gallery_access_smith-wedding", "tok-123")))
-              .andExpect(status().isOk())
-              .andReturn();
-
-      byte[] zipBytes = result.getResponse().getContentAsByteArray();
-      try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipBytes))) {
-        ZipEntry entry;
-        int count = 0;
-        while ((entry = zis.getNextEntry()) != null) {
-          count++;
-          assertThat(entry.getName()).endsWith(".jpg");
-        }
-        assertThat(count).isEqualTo(2);
-      }
-    }
-
-    @Test
-    void formatUnsupported_serviceThrowsIllegalArgument_returns400() throws Exception {
-      when(collectionService.findEntityBySlug("open-portfolio")).thenReturn(openCollection());
-      when(contentService.resolveCollectionDownloadEntries(eq(2L), eq("raw"), eq(null)))
-          .thenThrow(new IllegalArgumentException("Unsupported download format: raw"));
-
-      mockMvc
-          .perform(get("/api/read/collections/open-portfolio/download").param("format", "raw"))
-          .andExpect(status().isBadRequest());
-
-      verify(s3Client, never()).getObject(any(GetObjectRequest.class));
-    }
-
-    @Test
-    void zipsRemainingImagesWhenOneS3FetchFails() throws Exception {
-      when(collectionService.findEntityBySlug("open-portfolio")).thenReturn(openCollection());
-      when(contentService.resolveCollectionDownloadEntries(2L, "web", null))
-          .thenReturn(
-              List.of(
-                  webResolution("first.webp"),
-                  webResolution("second.webp"),
-                  webResolution("third.webp")));
-      when(s3Client.getObject(any(GetObjectRequest.class)))
-          .thenReturn(fakeS3Stream("aaaa".getBytes()))
-          .thenThrow(SdkClientException.builder().message("connection reset").build())
-          .thenReturn(fakeS3Stream("cccc".getBytes()));
-
-      MvcResult result =
-          mockMvc
-              .perform(get("/api/read/collections/open-portfolio/download"))
-              .andExpect(status().isOk())
-              .andExpect(header().string("Content-Type", "application/zip"))
-              .andReturn();
-
-      byte[] zipBytes = result.getResponse().getContentAsByteArray();
-      boolean sawFirst = false;
-      boolean sawErrorForSecond = false;
-      boolean sawThird = false;
-      try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipBytes))) {
-        ZipEntry entry;
-        while ((entry = zis.getNextEntry()) != null) {
-          if (entry.getName().contains("first") && entry.getName().endsWith(".webp")) {
-            sawFirst = true;
-          } else if (entry.getName().contains("second") && entry.getName().endsWith(".error.txt")) {
-            sawErrorForSecond = true;
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
-            zis.transferTo(out);
-            assertThat(new String(out.toByteArray()))
-                .contains("Could not include this image")
-                .contains("SdkClientException");
-          } else if (entry.getName().contains("third") && entry.getName().endsWith(".webp")) {
-            sawThird = true;
-          }
-        }
-      }
-      assertThat(sawFirst).as("first image survived").isTrue();
-      assertThat(sawErrorForSecond).as("second image got placeholder error entry").isTrue();
-      assertThat(sawThird).as("third image survived").isTrue();
-    }
-
-    @Test
-    void emptyCollection_returnsEmptyZip() throws Exception {
+    void emptyResolution_returns404() throws Exception {
       when(collectionService.findEntityBySlug("open-portfolio")).thenReturn(openCollection());
       when(contentService.resolveCollectionDownloadEntries(2L, "web", null)).thenReturn(List.of());
 
-      MvcResult result =
-          mockMvc
-              .perform(get("/api/read/collections/open-portfolio/download"))
-              .andExpect(status().isOk())
-              .andReturn();
+      mockMvc
+          .perform(get("/api/read/collections/open-portfolio/download"))
+          .andExpect(status().isNotFound());
 
-      byte[] zipBytes = result.getResponse().getContentAsByteArray();
-      try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipBytes))) {
-        assertThat(zis.getNextEntry()).isNull();
-      }
+      verify(downloadUrlService, never()).zipToS3AndPresign(any(), any());
     }
 
     @Test
     @SuppressWarnings("unchecked")
     void imageIdsSubset_passesIdsToResolverAndUsesSelectionFilename() throws Exception {
-      CollectionEntity gallery = protectedGallery();
-      when(collectionService.findEntityBySlug("smith-wedding")).thenReturn(gallery);
+      when(collectionService.findEntityBySlug("smith-wedding")).thenReturn(protectedGallery());
       when(clientGalleryAuthService.validateAccessToken("smith-wedding", "tok-123"))
           .thenReturn(true);
       when(contentService.resolveCollectionDownloadEntries(eq(1L), eq("web"), any()))
           .thenReturn(List.of(webResolution("first.webp"), webResolution("third.webp")));
       when(contentService.collectionZipFilename("smith-wedding", 1L))
           .thenReturn("smith-wedding-1.zip");
-      when(s3Client.getObject(any(GetObjectRequest.class)))
-          .thenReturn(fakeS3Stream("aaaa".getBytes()))
-          .thenReturn(fakeS3Stream("cccc".getBytes()));
+      when(downloadUrlService.zipToS3AndPresign(any(), any())).thenReturn(ZIP_PRESIGNED);
 
       mockMvc
           .perform(
@@ -470,35 +295,15 @@ class ContentDownloadControllerProdTest {
                   .param("format", "web")
                   .param("imageIds", "1", "3")
                   .cookie(new Cookie("gallery_access_smith-wedding", "tok-123")))
-          .andExpect(status().isOk())
-          .andExpect(header().string("Content-Type", "application/zip"))
-          // Subset ZIPs carry a -selection-<count> suffix so they don't collide with the "all" ZIP.
-          .andExpect(
-              header()
-                  .string(
-                      "Content-Disposition",
-                      org.hamcrest.Matchers.containsString("smith-wedding-1-selection-2.zip")));
+          .andExpect(status().isFound());
+
+      // Subset ZIPs carry a -selection-<count> suffix so they don't collide with the "all" ZIP.
+      verify(downloadUrlService).zipToS3AndPresign(any(), eq("smith-wedding-1-selection-2.zip"));
 
       ArgumentCaptor<List<Long>> idsCaptor = ArgumentCaptor.forClass(List.class);
       verify(contentService)
           .resolveCollectionDownloadEntries(eq(1L), eq("web"), idsCaptor.capture());
       assertThat(idsCaptor.getValue()).containsExactly(1L, 3L);
-    }
-
-    @Test
-    void protectedCollection_noCookie_withImageIds_returns401() throws Exception {
-      when(collectionService.findEntityBySlug("smith-wedding")).thenReturn(protectedGallery());
-
-      // Auth gate precedes resolution: a subset request from an unauthorized client is still 401.
-      mockMvc
-          .perform(
-              get("/api/read/collections/smith-wedding/download")
-                  .param("format", "web")
-                  .param("imageIds", "1", "3"))
-          .andExpect(status().isUnauthorized());
-
-      verify(contentService, never()).resolveCollectionDownloadEntries(any(), any(), any());
-      verify(s3Client, never()).getObject(any(GetObjectRequest.class));
     }
   }
 }

--- a/src/test/java/edens/zac/portfolio/backend/services/DownloadUrlServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/DownloadUrlServiceTest.java
@@ -1,0 +1,119 @@
+package edens.zac.portfolio.backend.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import edens.zac.portfolio.backend.model.DownloadResolution;
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.UploadPartResponse;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+
+/** Unit tests for {@link DownloadUrlService}. */
+@ExtendWith(MockitoExtension.class)
+class DownloadUrlServiceTest {
+
+  private static final String BUCKET = "portfolio-bucket";
+
+  @Mock private S3Client s3Client;
+  @Mock private S3Presigner s3Presigner;
+  @Mock private PresignedGetObjectRequest presigned;
+
+  @InjectMocks private DownloadUrlService service;
+
+  @BeforeEach
+  void setUp() {
+    ReflectionTestUtils.setField(service, "bucketName", BUCKET);
+  }
+
+  private void stubPresign(String url) throws Exception {
+    when(presigned.url()).thenReturn(URI.create(url).toURL());
+    when(s3Presigner.presignGetObject(any(GetObjectPresignRequest.class))).thenReturn(presigned);
+  }
+
+  private static ResponseInputStream<GetObjectResponse> fakeS3Stream(byte[] bytes) {
+    return new ResponseInputStream<>(
+        GetObjectResponse.builder().contentLength((long) bytes.length).build(),
+        AbortableInputStream.create(new ByteArrayInputStream(bytes)));
+  }
+
+  @Test
+  void presignObject_setsBucketKeyDispositionAndContentType() throws Exception {
+    stubPresign("https://portfolio-bucket.s3.amazonaws.com/Image/Original/x.jpg?sig=abc");
+
+    URI result = service.presignObject("Image/Original/x.jpg", "image/jpeg", "sunset.jpg");
+
+    assertThat(result.toString()).startsWith("https://portfolio-bucket.s3.amazonaws.com/");
+
+    ArgumentCaptor<GetObjectPresignRequest> captor =
+        ArgumentCaptor.forClass(GetObjectPresignRequest.class);
+    verify(s3Presigner).presignGetObject(captor.capture());
+    GetObjectRequest get = captor.getValue().getObjectRequest();
+    assertThat(get.bucket()).isEqualTo(BUCKET);
+    assertThat(get.key()).isEqualTo("Image/Original/x.jpg");
+    assertThat(get.responseContentType()).isEqualTo("image/jpeg");
+    assertThat(get.responseContentDisposition()).isEqualTo("attachment; filename=\"sunset.jpg\"");
+    assertThat(captor.getValue().signatureDuration().toMinutes()).isEqualTo(15);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void zipToS3AndPresign_streamsEachEntryAndPresignsTempKey() throws Exception {
+    // Multipart plumbing for the streamed ZIP.
+    when(s3Client.createMultipartUpload(any(Consumer.class)))
+        .thenReturn(CreateMultipartUploadResponse.builder().uploadId("up-1").build());
+    when(s3Client.uploadPart(any(Consumer.class), any(RequestBody.class)))
+        .thenReturn(UploadPartResponse.builder().eTag("etag-1").build());
+    when(s3Client.completeMultipartUpload(any(Consumer.class)))
+        .thenReturn(CompleteMultipartUploadResponse.builder().build());
+    // One object stream per entry.
+    when(s3Client.getObject(any(GetObjectRequest.class)))
+        .thenReturn(fakeS3Stream("first-bytes".getBytes()))
+        .thenReturn(fakeS3Stream("second-bytes".getBytes()));
+    stubPresign("https://portfolio-bucket.s3.amazonaws.com/downloads-tmp/zzz/gallery.zip?sig=abc");
+
+    List<DownloadResolution> entries =
+        List.of(
+            new DownloadResolution("Image/Original/a.jpg", ".jpg", "image/jpeg", "a.jpg"),
+            new DownloadResolution("Image/Original/b.jpg", ".jpg", "image/jpeg", "b.jpg"));
+
+    URI result = service.zipToS3AndPresign(entries, "gallery.zip");
+
+    assertThat(result.toString()).contains("downloads-tmp/");
+    // Each entry's object was fetched from S3.
+    verify(s3Client, times(2)).getObject(any(GetObjectRequest.class));
+    // The ZIP was completed (streamed to S3) and then presigned under the temp prefix.
+    verify(s3Client).completeMultipartUpload(any(Consumer.class));
+
+    ArgumentCaptor<GetObjectPresignRequest> captor =
+        ArgumentCaptor.forClass(GetObjectPresignRequest.class);
+    verify(s3Presigner).presignGetObject(captor.capture());
+    GetObjectRequest get = captor.getValue().getObjectRequest();
+    assertThat(get.key()).startsWith(DownloadUrlService.TMP_PREFIX).endsWith("/gallery.zip");
+    assertThat(get.responseContentType()).isEqualTo("application/zip");
+    assertThat(get.responseContentDisposition()).isEqualTo("attachment; filename=\"gallery.zip\"");
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/services/S3MultipartOutputStreamTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/S3MultipartOutputStreamTest.java
@@ -1,0 +1,132 @@
+package edens.zac.portfolio.backend.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.UploadPartResponse;
+
+/** Unit tests for the streaming multipart-upload {@link java.io.OutputStream}. */
+@ExtendWith(MockitoExtension.class)
+class S3MultipartOutputStreamTest {
+
+  private static final int PART_SIZE = 5 * 1024 * 1024;
+
+  @Mock private S3Client s3;
+
+  /** Concatenation of every part body, in upload order — should equal everything written. */
+  private final ByteArrayOutputStream captured = new ByteArrayOutputStream();
+
+  private int uploadPartCalls = 0;
+
+  @BeforeEach
+  @SuppressWarnings("unchecked")
+  void setUp() {
+    when(s3.createMultipartUpload(any(Consumer.class)))
+        .thenReturn(CreateMultipartUploadResponse.builder().uploadId("up-1").build());
+    lenient()
+        .when(s3.uploadPart(any(Consumer.class), any(RequestBody.class)))
+        .thenAnswer(
+            inv -> {
+              RequestBody body = inv.getArgument(1);
+              captured.write(body.contentStreamProvider().newStream().readAllBytes());
+              uploadPartCalls++;
+              return UploadPartResponse.builder().eTag("etag-" + uploadPartCalls).build();
+            });
+    lenient()
+        .when(s3.completeMultipartUpload(any(Consumer.class)))
+        .thenReturn(CompleteMultipartUploadResponse.builder().build());
+  }
+
+  private byte[] pattern(int n) {
+    byte[] b = new byte[n];
+    for (int i = 0; i < n; i++) {
+      b[i] = (byte) (i % 251); // 251 is prime → no alignment with part boundaries
+    }
+    return b;
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void splitsIntoFiveMbPartsAndPreservesBytes() throws IOException {
+    byte[] data = pattern(2 * PART_SIZE + 123); // two full parts + a small tail
+    try (S3MultipartOutputStream out = new S3MultipartOutputStream(s3, "bucket", "key")) {
+      // Write in oddly-sized chunks to exercise the buffer-fill boundary logic.
+      int off = 0;
+      int[] chunks = {1, 7, 4096, 3 * 1024 * 1024, PART_SIZE, 999};
+      for (int c : chunks) {
+        int len = Math.min(c, data.length - off);
+        out.write(data, off, len);
+        off += len;
+      }
+      out.write(data, off, data.length - off);
+    }
+    assertThat(uploadPartCalls).isEqualTo(3); // 5MB + 5MB + tail
+    assertThat(captured.toByteArray()).isEqualTo(data);
+    verify(s3, times(1)).completeMultipartUpload(any(Consumer.class));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void singleSmallPart_completesWithOnePart() throws IOException {
+    byte[] data = pattern(1234);
+    try (S3MultipartOutputStream out = new S3MultipartOutputStream(s3, "bucket", "key")) {
+      out.write(data);
+    }
+    assertThat(uploadPartCalls).isEqualTo(1);
+    assertThat(captured.toByteArray()).isEqualTo(data);
+    verify(s3, times(1)).completeMultipartUpload(any(Consumer.class));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void exactMultipleOfPartSize_noEmptyTrailingPart() throws IOException {
+    byte[] data = pattern(2 * PART_SIZE);
+    try (S3MultipartOutputStream out = new S3MultipartOutputStream(s3, "bucket", "key")) {
+      out.write(data);
+    }
+    assertThat(uploadPartCalls).isEqualTo(2);
+    assertThat(captured.toByteArray()).isEqualTo(data);
+    verify(s3, times(1)).completeMultipartUpload(any(Consumer.class));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void abort_callsAbortMultipartUpload() {
+    S3MultipartOutputStream out = new S3MultipartOutputStream(s3, "bucket", "key");
+    out.abort();
+    verify(s3).abortMultipartUpload(any(Consumer.class));
+    verify(s3, never()).completeMultipartUpload(any(Consumer.class));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void close_whenCompleteFails_abortsAndRethrows() {
+    when(s3.completeMultipartUpload(any(Consumer.class)))
+        .thenThrow(AwsServiceException.builder().message("boom").build());
+
+    S3MultipartOutputStream out = new S3MultipartOutputStream(s3, "bucket", "key");
+    out.write(pattern(10), 0, 10);
+
+    assertThatThrownBy(out::close).isInstanceOf(AwsServiceException.class);
+    verify(s3).abortMultipartUpload(any(Consumer.class));
+  }
+}

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -26,8 +26,34 @@ resource "aws_s3_bucket" "portfolio" {
 # NOTE: Versioning is not enabled on this bucket. If needed in the future,
 # add an aws_s3_bucket_versioning resource here.
 
-# NOTE: No lifecycle configuration exists on this bucket. Consider adding one
-# for the db-backups/ prefix (transition to STANDARD_IA after 30d, expire after 90d).
+# Lifecycle: expire the ephemeral download ZIPs the backend builds under downloads-tmp/.
+# The download endpoints stream a collection ZIP into S3 and hand the browser a short-lived
+# presigned URL (to bypass the Amplify 5.72 MB response cap); the object itself is disposable
+# once the client has downloaded it. Expire after 1 day and reap any parts left by an
+# interrupted multipart upload.
+#
+# NOTE: apply required -- `terraform apply` this after merge. If a lifecycle configuration is
+# ever added to this bucket outside terraform, import it first to avoid a conflict.
+resource "aws_s3_bucket_lifecycle_configuration" "portfolio" {
+  bucket = aws_s3_bucket.portfolio.id
+
+  rule {
+    id     = "expire-ephemeral-download-zips"
+    status = "Enabled"
+
+    filter {
+      prefix = "downloads-tmp/"
+    }
+
+    expiration {
+      days = 1
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
+    }
+  }
+}
 
 resource "aws_s3_bucket_public_access_block" "portfolio" {
   bucket = aws_s3_bucket.portfolio.id


### PR DESCRIPTION
## Problem (reproduced on prod)

Every client-gallery download streams through the Next.js BFF proxy running on **AWS Amplify Web Compute**, which caps any proxied HTTP response at **5.72 MB** ([AWS docs](https://docs.aws.amazon.com/amplify/latest/userguide/troubleshooting-SSR.html#http-response-size-too-large)). A full-res original — or any multi-image ZIP — exceeds that and is killed at the CloudFront/compute layer. This is the client-reported **`413 Content Too Large`**.

Reproduced against the public `amsterdam-2023` collection on prod:

| Request | Result |
|---|---|
| single image `web` (1.08 MB) | ✅ 200 |
| single image `original` (>5.72 MB) | ❌ 413 |
| collection ZIP `web` (68 imgs) | ❌ 413 |
| collection ZIP `original` | ❌ 500 |

The actual client failure: `GET /collections/hidden-lake/download?format=original&imageIds=1583` → 413 (`x-amplify-status: true`, empty body). It works on localhost because the dev server has no such cap.

## Fix

Both endpoints authorize and then **302-redirect to a short-lived (15 min) S3 presigned GET URL** (`Content-Disposition: attachment`), so bytes stream straight from S3 — no cap. The redirect is a few hundred bytes and passes the Amplify limit; the BFF proxy relays it (verified `undici`'s `redirect: 'manual'` exposes `Location`) and the browser follows it to S3.

- **`S3Config`** — add `S3Presigner` bean (same creds/region as `S3Client`)
- **`DownloadUrlService`** (new) — `presignObject` (single object) + `zipToS3AndPresign` (build the archive into a temp S3 object, then presign)
- **`S3MultipartOutputStream`** (new) — streams a ZIP of any size into S3 via multipart upload, ~5 MB peak memory, aborts on failure
- **`ContentDownloadControllerProd`** — 302 both endpoints; a single resolved image (including a one-image "Download Selected", e.g. `imageIds=1583`) redirects straight to the image instead of a one-entry ZIP
- **terraform** — lifecycle rule expiring `downloads-tmp/` objects after 1 day

Bucket policy is Allow-only for CloudFront (no explicit deny) and public-access-block doesn't affect authenticated presigned GETs, so the backend IAM creds presign successfully.

## Tests

`mvn clean install` green — **1029 tests**. New: `S3MultipartOutputStreamTest` (part boundaries, completion, abort), `DownloadUrlServiceTest` (presign request shape, ZIP-to-S3 flow). Both controller tests rewritten for the 302 model (auth gating unchanged).

## ⚠️ Deploy notes

1. **`terraform apply`** required for the `downloads-tmp/` lifecycle rule (functional without it — objects just accrue until applied).
2. **Frontend companion PR required, deploy it first:** the fullscreen single-image button used `fetch`+blob, which would be CORS-blocked following the 302 to S3. It's switched to navigation in themancalledzac/edens.zac (the collection-ZIP flow already navigates, so it needs no change). Deploying this backend PR before the frontend one would briefly break the fullscreen *web* download.
3. **Large "download all":** the ZIP is built synchronously before the redirect; a very large gallery could approach the CloudFront origin timeout. Fine for typical galleries; an async job is the follow-up if it bites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)