### PR TITLE
fix(errors): map AccessDeniedException to 403 instead of 500

### DIFF
--- a/src/main/java/edens/zac/portfolio/backend/config/GlobalExceptionHandler.java
+++ b/src/main/java/edens/zac/portfolio/backend/config/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -133,6 +134,20 @@ public class GlobalExceptionHandler {
         .body(
             ErrorResponse.of(
                 HttpStatus.CONFLICT, "Data integrity violation: duplicate or invalid data"));
+  }
+
+  /**
+   * Denied gallery/collection access is an expected authorization outcome, not a server error.
+   * Without this handler it is caught by the catch-all {@link #handleGeneric} and mis-reported as
+   * 500 with a full stack trace (e.g. the per-user selects seed read fired for every authenticated
+   * viewer of a CLIENT_GALLERY, including non-members). It must be a quiet 403. Logged at debug
+   * with no stack trace since a denial on this per-render read is expected, not noteworthy.
+   */
+  @ExceptionHandler(AccessDeniedException.class)
+  public ResponseEntity<ErrorResponse> handleAccessDenied(AccessDeniedException e) {
+    log.debug("Access denied: {}", e.getMessage());
+    return ResponseEntity.status(HttpStatus.FORBIDDEN)
+        .body(ErrorResponse.of(HttpStatus.FORBIDDEN, e.getMessage()));
   }
 
   /** Client disconnected before response was fully sent -- not a server error. */

--- a/src/test/java/edens/zac/portfolio/backend/config/GlobalExceptionHandlerTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/config/GlobalExceptionHandlerTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.validation.BeanPropertyBindingResult;
@@ -71,6 +72,11 @@ class GlobalExceptionHandlerTest {
       // Empty set — ConstraintViolationException still maps to 400
       Set<ConstraintViolation<?>> violations = Set.of();
       throw new ConstraintViolationException("constraint violated", violations);
+    }
+
+    @GetMapping("/access-denied")
+    String accessDenied() {
+      throw new AccessDeniedException("No gallery access for collection 112");
     }
 
     @GetMapping("/generic")
@@ -199,6 +205,21 @@ class GlobalExceptionHandlerTest {
     String msg = response.getBody().message();
     assert msg.contains("title: must not be blank") : "Expected title error in: " + msg;
     assert msg.contains("type: must not be null") : "Expected type error in: " + msg;
+  }
+
+  @Test
+  void handleAccessDenied_returnsStatus403() throws Exception {
+    // A non-member viewer's per-render selects seed read throws AccessDeniedException from the
+    // controller method, after the security filter chain. Without a dedicated handler it is caught
+    // by the catch-all Exception handler and mis-reported as 500 with a full stack trace; an
+    // authorization denial must be a quiet 403.
+    mockMvc
+        .perform(get("/test/access-denied").accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.status").value(403))
+        .andExpect(jsonPath("$.error").value("Forbidden"))
+        .andExpect(jsonPath("$.message").value("No gallery access for collection 112"))
+        .andExpect(jsonPath("$.timestamp").exists());
   }
 
   @Test


### PR DESCRIPTION
## Problem
The backend logged a full-stack-trace `ERROR "Unhandled exception"` and returned **HTTP 500** on every `CLIENT_GALLERY` render by a logged-in viewer who is not a member of that gallery.

The frontend calls `GET /api/read/user/selects?collectionId=<id>` server-side to seed a viewer's persisted selects. It fires for **every authenticated viewer** regardless of membership (by design -- the frontend swallows failures and treats "no access" as empty selects). For a non-member, `UserSelectsService.requireCollectionAccess` correctly throws `org.springframework.security.access.AccessDeniedException`.

But that exception is thrown *inside* the controller method (after the security filter chain), so it's caught by the `@ControllerAdvice` catch-all `handleGeneric(Exception)` **before** Spring Security's `ExceptionTranslationFilter` can convert it -- yielding `log.error(..., e)` with a full stack trace and a 500, instead of a quiet 403.

## Fix
Add a dedicated `@ExceptionHandler(AccessDeniedException.class)` to `GlobalExceptionHandler` returning **403 Forbidden**, logged at `debug` with no stack trace (the denial is an expected authorization outcome on a per-render read, not a server error).

This is the same class of bug the repo already patched for `NoResourceFoundException` and `HttpMessageNotReadableException` -- the catch-all silently mis-reports client/auth errors as 500. It also (correctly) makes any `@PreAuthorize` method-security denial return 403 instead of 500.

## Verification
- New handler test `handleAccessDenied_returnsStatus403` asserts 403 + JSON body -- **13/13 pass** in `GlobalExceptionHandlerTest`.
- Full project `test-compile` clean; `spotless:apply` produced no changes.
- Confirmed the only other `AccessDeniedException` references are the service throw and its service-layer unit test (asserts the exception type, unaffected) -- nothing relied on the 500.

## Not covered here
The manual `localhost:3000/rumi-visit-2025` logged-in-non-member E2E from the handoff (needs backend + frontend + a live non-member session). The handler-level test deterministically proves the 403 / no-stack-trace behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)