### PR TITLE
fix(access): populate grant audit actor, 404 on missing role, FK on-d…

### DIFF
--- a/src/main/java/edens/zac/portfolio/backend/controller/admin/AdminRoleController.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/admin/AdminRoleController.java
@@ -8,6 +8,7 @@ import edens.zac.portfolio.backend.controller.admin.RoleRequests.RoleSummary;
 import edens.zac.portfolio.backend.controller.admin.RoleRequests.SetRoleGrantRequest;
 import edens.zac.portfolio.backend.dao.RoleRepository;
 import edens.zac.portfolio.backend.entity.RoleEntity;
+import edens.zac.portfolio.backend.model.AuthPrincipal;
 import edens.zac.portfolio.backend.types.RoleKind;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -15,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -58,7 +60,7 @@ public class AdminRoleController {
   @PostMapping
   public ResponseEntity<RoleSummary> createRole(@Valid @RequestBody CreateRoleRequest body) {
     RoleKind kind = body.kind() != null ? body.kind() : RoleKind.SHARED;
-    Long id = roleRepository.createRole(body.name(), kind, null);
+    Long id = roleRepository.createRole(body.name(), kind, currentUserId());
     return ResponseEntity.status(HttpStatus.CREATED).body(new RoleSummary(id, body.name(), kind));
   }
 
@@ -90,12 +92,13 @@ public class AdminRoleController {
    * Delete a role (cascades its memberships and grants).
    *
    * @param roleId the role id
-   * @return {@code 204 No Content}
+   * @return {@code 204 No Content}, or {@code 404} if no such role
    */
   @DeleteMapping("/{roleId}")
   public ResponseEntity<Void> deleteRole(@PathVariable Long roleId) {
-    roleRepository.deleteRole(roleId);
-    return ResponseEntity.noContent().build();
+    return roleRepository.deleteRole(roleId) > 0
+        ? ResponseEntity.noContent().build()
+        : ResponseEntity.notFound().build();
   }
 
   /**
@@ -112,7 +115,7 @@ public class AdminRoleController {
       @PathVariable Long roleId,
       @PathVariable Long collectionId,
       @Valid @RequestBody SetRoleGrantRequest body) {
-    roleRepository.setCollectionGrant(roleId, collectionId, body.level(), null);
+    roleRepository.setCollectionGrant(roleId, collectionId, body.level(), currentUserId());
     return ResponseEntity.noContent().build();
   }
 
@@ -139,7 +142,7 @@ public class AdminRoleController {
    */
   @PutMapping("/{roleId}/members/{userId}")
   public ResponseEntity<Void> addMember(@PathVariable Long roleId, @PathVariable Long userId) {
-    roleRepository.addMember(roleId, userId, null);
+    roleRepository.addMember(roleId, userId, currentUserId());
     return ResponseEntity.noContent().build();
   }
 
@@ -154,5 +157,11 @@ public class AdminRoleController {
   public ResponseEntity<Void> removeMember(@PathVariable Long roleId, @PathVariable Long userId) {
     roleRepository.removeMember(roleId, userId);
     return ResponseEntity.noContent().build();
+  }
+
+  /** The acting admin's user id for audit columns, or null in dev where the gate is open. */
+  private static Long currentUserId() {
+    var auth = SecurityContextHolder.getContext().getAuthentication();
+    return (auth != null && auth.getPrincipal() instanceof AuthPrincipal p) ? p.userId() : null;
   }
 }

--- a/src/main/java/edens/zac/portfolio/backend/controller/admin/AdminUserController.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/admin/AdminUserController.java
@@ -11,6 +11,7 @@ import edens.zac.portfolio.backend.controller.admin.UserRequests.UpdateUserReque
 import edens.zac.portfolio.backend.dao.AppUserRepository;
 import edens.zac.portfolio.backend.dao.RoleRepository;
 import edens.zac.portfolio.backend.entity.AppUserEntity;
+import edens.zac.portfolio.backend.model.AuthPrincipal;
 import edens.zac.portfolio.backend.model.CollectionModel;
 import edens.zac.portfolio.backend.services.UserInviteService;
 import edens.zac.portfolio.backend.services.UserMergeService;
@@ -25,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -257,7 +259,7 @@ public class AdminUserController {
    */
   @PutMapping("/{id}/roles/{roleId}")
   public ResponseEntity<Void> addUserToRole(@PathVariable Long id, @PathVariable Long roleId) {
-    roleRepository.addMember(roleId, id, null);
+    roleRepository.addMember(roleId, id, currentUserId());
     return ResponseEntity.noContent().build();
   }
 
@@ -335,5 +337,11 @@ public class AdminUserController {
   /** Build the public invite URL, tolerating a {@code frontendBaseUrl} that ends in a slash. */
   private String buildInviteUrl(String rawToken) {
     return frontendBaseUrl.replaceAll("/+$", "") + "/invite/" + rawToken;
+  }
+
+  /** The acting admin's user id for audit columns, or null in dev where the gate is open. */
+  private static Long currentUserId() {
+    var auth = SecurityContextHolder.getContext().getAuthentication();
+    return (auth != null && auth.getPrincipal() instanceof AuthPrincipal p) ? p.userId() : null;
   }
 }

--- a/src/main/java/edens/zac/portfolio/backend/dao/RoleRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/RoleRepository.java
@@ -69,8 +69,9 @@ public class RoleRepository extends BaseDao {
   }
 
   @Transactional
-  public void deleteRole(Long roleId) {
-    update("DELETE FROM role WHERE id = :id", createParameterSource().addValue("id", roleId));
+  public int deleteRole(Long roleId) {
+    return update(
+        "DELETE FROM role WHERE id = :id", createParameterSource().addValue("id", roleId));
   }
 
   // ---- Membership ----

--- a/src/main/resources/db/migration/V46__role_audit_fk_on_delete.sql
+++ b/src/main/resources/db/migration/V46__role_audit_fk_on_delete.sql
@@ -1,0 +1,19 @@
+-- V46: the audit FKs (role.created_by, role_member.added_by, role_collection.granted_by) are
+-- informational only. Recreate them as ON DELETE SET NULL so a hard-delete of a user (e.g. the
+-- identity merge in UserMergeService) never RESTRICT-fails on a stale actor reference; the row
+-- survives with a null actor. (The deferred DROP TABLE user_collection lands in a later migration.)
+BEGIN;
+
+ALTER TABLE role DROP CONSTRAINT role_created_by_fkey;
+ALTER TABLE role ADD CONSTRAINT role_created_by_fkey
+  FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL;
+
+ALTER TABLE role_member DROP CONSTRAINT role_member_added_by_fkey;
+ALTER TABLE role_member ADD CONSTRAINT role_member_added_by_fkey
+  FOREIGN KEY (added_by) REFERENCES users(id) ON DELETE SET NULL;
+
+ALTER TABLE role_collection DROP CONSTRAINT role_collection_granted_by_fkey;
+ALTER TABLE role_collection ADD CONSTRAINT role_collection_granted_by_fkey
+  FOREIGN KEY (granted_by) REFERENCES users(id) ON DELETE SET NULL;
+
+COMMIT;

--- a/src/test/java/edens/zac/portfolio/backend/controller/admin/AdminRoleControllerTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/admin/AdminRoleControllerTest.java
@@ -134,7 +134,14 @@ class AdminRoleControllerTest {
 
   @Test
   void deleteRoleReturns204() throws Exception {
+    when(roleRepository.deleteRole(7L)).thenReturn(1);
     mvc.perform(delete("/api/admin/roles/7")).andExpect(status().isNoContent());
     verify(roleRepository).deleteRole(7L);
+  }
+
+  @Test
+  void deleteRoleReturns404WhenMissing() throws Exception {
+    when(roleRepository.deleteRole(404L)).thenReturn(0);
+    mvc.perform(delete("/api/admin/roles/404")).andExpect(status().isNotFound());
   }
 }


### PR DESCRIPTION
…elete

Address low-severity findings from the RBAC security review:
- AdminRoleController/AdminUserController record the acting admin in the V45 audit columns (created_by/added_by/granted_by) instead of null.
- deleteRole returns 404 when the role does not exist (was a phantom 204).
- V46 recreates the three audit FKs as ON DELETE SET NULL so a user hard-delete (identity merge) never RESTRICT-fails on a stale actor.