### PR TITLE
feat(roles): list roles granting a collection (admin read endpoint)

### DIFF
--- a/src/main/java/edens/zac/portfolio/backend/controller/admin/CollectionAdminController.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/admin/CollectionAdminController.java
@@ -1,12 +1,16 @@
 package edens.zac.portfolio.backend.controller.admin;
 
+import edens.zac.portfolio.backend.controller.admin.RoleRequests.CollectionRoleGrantRow;
+import edens.zac.portfolio.backend.dao.RoleRepository;
 import edens.zac.portfolio.backend.model.CollectionRequests.GalleryAccessRequest;
 import edens.zac.portfolio.backend.model.CollectionRequests.GalleryAccessResponse;
 import edens.zac.portfolio.backend.services.CollectionService;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,7 +20,8 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * Admin endpoints for managing client galleries (password, recipient emails, future operations).
  *
- * <p>Delegates all business logic to {@link CollectionService}.
+ * <p>Delegates gallery-access logic to {@link CollectionService}; role reads go straight to {@link
+ * RoleRepository}, mirroring {@link AdminRoleController}.
  */
 @Slf4j
 @RequiredArgsConstructor
@@ -25,6 +30,21 @@ import org.springframework.web.bind.annotation.RestController;
 public class CollectionAdminController {
 
   private final CollectionService collectionService;
+  private final RoleRepository roleRepository;
+
+  /**
+   * List the roles granting this collection (the inverse of the role-detail view), for the
+   * collection-edit access panel. Bare array to match the sibling RBAC list endpoints.
+   *
+   * @param id the collection id
+   * @return the granting roles, SHARED before PERSONAL, then by name
+   */
+  @GetMapping("/{id}/roles")
+  public List<CollectionRoleGrantRow> collectionRoles(@PathVariable Long id) {
+    return roleRepository.rolesGrantingCollection(id).stream()
+        .map(g -> new CollectionRoleGrantRow(g.roleId(), g.name(), g.kind(), g.level()))
+        .toList();
+  }
 
   @PostMapping("/{id}/gallery-access")
   public ResponseEntity<GalleryAccessResponse> updateGalleryAccess(

--- a/src/main/java/edens/zac/portfolio/backend/controller/admin/RoleRequests.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/admin/RoleRequests.java
@@ -37,4 +37,8 @@ public final class RoleRequests {
 
   /** One role a user belongs to, for the reshaped user-detail view. */
   public record UserRoleRow(Long roleId, String name, RoleKind kind) {}
+
+  /** One role granting a collection, for the collection-edit access panel. */
+  public record CollectionRoleGrantRow(
+      Long roleId, String name, RoleKind kind, AccessLevel level) {}
 }

--- a/src/main/java/edens/zac/portfolio/backend/dao/RoleRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/RoleRepository.java
@@ -42,6 +42,9 @@ public class RoleRepository extends BaseDao {
   /** A member of a role, joined to their account, for the role-detail view. */
   public record RoleMember(Long userId, String email, String name) {}
 
+  /** One role granting a collection, for the collection-detail (inverse) view. */
+  public record CollectionRoleGrant(Long roleId, String name, RoleKind kind, AccessLevel level) {}
+
   // ---- Role CRUD ----
 
   @Transactional
@@ -166,6 +169,29 @@ public class RoleRepository extends BaseDao {
                 rs.getString("title"),
                 AccessLevel.valueOf(rs.getString("level"))),
         createParameterSource().addValue("roleId", roleId));
+  }
+
+  /**
+   * The inverse of {@link #grantsForRole}: every role granting a collection, with its level.
+   * Ordered SHARED before PERSONAL, then by name (matches {@link #findAll}).
+   */
+  @Transactional(readOnly = true)
+  public List<CollectionRoleGrant> rolesGrantingCollection(Long collectionId) {
+    return query(
+        """
+        SELECT rc.role_id, r.name, r.kind, rc.level
+          FROM role_collection rc
+          JOIN role r ON r.id = rc.role_id
+         WHERE rc.collection_id = :collectionId
+         ORDER BY r.kind DESC, r.name ASC
+        """,
+        (rs, n) ->
+            new CollectionRoleGrant(
+                rs.getLong("role_id"),
+                rs.getString("name"),
+                RoleKind.valueOf(rs.getString("kind")),
+                AccessLevel.valueOf(rs.getString("level"))),
+        createParameterSource().addValue("collectionId", collectionId));
   }
 
   // ---- Resolution (the seam) ----

--- a/src/test/java/edens/zac/portfolio/backend/controller/admin/CollectionAdminControllerTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/admin/CollectionAdminControllerTest.java
@@ -3,14 +3,20 @@ package edens.zac.portfolio.backend.controller.admin;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import edens.zac.portfolio.backend.config.GlobalExceptionHandler;
+import edens.zac.portfolio.backend.dao.RoleRepository;
+import edens.zac.portfolio.backend.dao.RoleRepository.CollectionRoleGrant;
 import edens.zac.portfolio.backend.model.CollectionRequests.GalleryAccessRequest;
 import edens.zac.portfolio.backend.model.CollectionRequests.GalleryAccessResponse;
 import edens.zac.portfolio.backend.services.CollectionService;
+import edens.zac.portfolio.backend.types.AccessLevel;
+import edens.zac.portfolio.backend.types.RoleKind;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -29,6 +35,8 @@ class CollectionAdminControllerTest {
   private MockMvc mockMvc;
 
   @Mock private CollectionService collectionService;
+
+  @Mock private RoleRepository roleRepository;
 
   @InjectMocks private CollectionAdminController controller;
 
@@ -140,6 +148,44 @@ class CollectionAdminControllerTest {
           .andExpect(jsonPath("$.emailsSent").value(false))
           .andExpect(jsonPath("$.password").doesNotExist())
           .andExpect(jsonPath("$.emails").isEmpty());
+    }
+  }
+
+  @Nested
+  class CollectionRoles {
+
+    @Test
+    void returnsGrantingRolesAsRows() throws Exception {
+      when(roleRepository.rolesGrantingCollection(42L))
+          .thenReturn(
+              List.of(
+                  new CollectionRoleGrant(
+                      7L, "family gallery", RoleKind.SHARED, AccessLevel.CLIENT),
+                  new CollectionRoleGrant(
+                      9L, "mara personal", RoleKind.PERSONAL, AccessLevel.GENERAL)));
+
+      mockMvc
+          .perform(get("/api/admin/collections/42/roles"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.length()").value(2))
+          .andExpect(jsonPath("$[0].roleId").value(7))
+          .andExpect(jsonPath("$[0].name").value("family gallery"))
+          .andExpect(jsonPath("$[0].kind").value("SHARED"))
+          .andExpect(jsonPath("$[0].level").value("CLIENT"))
+          .andExpect(jsonPath("$[1].roleId").value(9))
+          .andExpect(jsonPath("$[1].name").value("mara personal"))
+          .andExpect(jsonPath("$[1].kind").value("PERSONAL"))
+          .andExpect(jsonPath("$[1].level").value("GENERAL"));
+    }
+
+    @Test
+    void returnsEmptyArrayWhenNoRolesGrant() throws Exception {
+      when(roleRepository.rolesGrantingCollection(42L)).thenReturn(List.of());
+
+      mockMvc
+          .perform(get("/api/admin/collections/42/roles"))
+          .andExpect(status().isOk())
+          .andExpect(content().json("[]"));
     }
   }
 

--- a/src/test/java/edens/zac/portfolio/backend/dao/RoleRepositoryIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/dao/RoleRepositoryIntegrationTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
 import edens.zac.portfolio.backend.AbstractPostgresIntegrationTest;
+import edens.zac.portfolio.backend.dao.RoleRepository.CollectionRoleGrant;
 import edens.zac.portfolio.backend.dao.RoleRepository.EffectiveGrant;
 import edens.zac.portfolio.backend.dao.RoleRepository.RoleMember;
 import edens.zac.portfolio.backend.entity.RoleEntity;
@@ -102,6 +103,56 @@ class RoleRepositoryIntegrationTest extends AbstractPostgresIntegrationTest {
         .containsExactly(
             tuple(first, "nia-mfr@example.com", "Nia"),
             tuple(second, "owen-mfr@example.com", "Owen"));
+  }
+
+  @Test
+  void rolesGrantingCollectionOrdersSharedFirstThenName() {
+    long coll = seedCollection("role-inverse-order");
+    long personal = repo.createRole("aaa personal", RoleKind.PERSONAL, null);
+    long sharedBravo = repo.createRole("bravo crew", RoleKind.SHARED, null);
+    long sharedAlpha = repo.createRole("alpha crew", RoleKind.SHARED, null);
+    repo.setCollectionGrant(personal, coll, AccessLevel.CLIENT, null);
+    repo.setCollectionGrant(sharedBravo, coll, AccessLevel.GENERAL, null);
+    repo.setCollectionGrant(sharedAlpha, coll, AccessLevel.CLIENT, null);
+
+    List<CollectionRoleGrant> grants = repo.rolesGrantingCollection(coll);
+
+    assertThat(grants)
+        .extracting(
+            CollectionRoleGrant::roleId,
+            CollectionRoleGrant::name,
+            CollectionRoleGrant::kind,
+            CollectionRoleGrant::level)
+        .containsExactly(
+            tuple(sharedAlpha, "alpha crew", RoleKind.SHARED, AccessLevel.CLIENT),
+            tuple(sharedBravo, "bravo crew", RoleKind.SHARED, AccessLevel.GENERAL),
+            tuple(personal, "aaa personal", RoleKind.PERSONAL, AccessLevel.CLIENT));
+  }
+
+  @Test
+  void rolesGrantingCollectionEmptyWhenNoGrants() {
+    long coll = seedCollection("role-inverse-empty");
+    repo.createRole("ungranted role", RoleKind.SHARED, null);
+
+    assertThat(repo.rolesGrantingCollection(coll)).isEmpty();
+  }
+
+  @Test
+  void rolesGrantingCollectionReturnsBothRolesAndOnlyThatCollection() {
+    long coll = seedCollection("role-inverse-two");
+    long other = seedCollection("role-inverse-other");
+    long r1 = repo.createRole("family gallery", RoleKind.SHARED, null);
+    long r2 = repo.createRole("wedding party", RoleKind.SHARED, null);
+    long unrelated = repo.createRole("unrelated role", RoleKind.SHARED, null);
+    repo.setCollectionGrant(r1, coll, AccessLevel.GENERAL, null);
+    repo.setCollectionGrant(r2, coll, AccessLevel.CLIENT, null);
+    repo.setCollectionGrant(unrelated, other, AccessLevel.CLIENT, null);
+
+    List<CollectionRoleGrant> grants = repo.rolesGrantingCollection(coll);
+
+    assertThat(grants)
+        .extracting(CollectionRoleGrant::roleId, CollectionRoleGrant::level)
+        .containsExactly(tuple(r1, AccessLevel.GENERAL), tuple(r2, AccessLevel.CLIENT));
   }
 
   @Test


### PR DESCRIPTION
## Purpose

Third admin surface over the role graph: the **collection -> roles inverse view**. The role-detail page answers "what does this role grant?"; this endpoint answers "which roles grant this collection?", so the collection edit page can show and manage role access from the collection you are standing on. The frontend `CollectionRolesSection` follow-up lands in `edens.zac` once this route is live.

## What was added

- **`RoleRepository.rolesGrantingCollection(collectionId)`** + `CollectionRoleGrant` record — inverse of `grantsForRole`, same NamedParameterJdbcTemplate query + rowMapper style. Ordered `r.kind DESC, r.name ASC` (SHARED before PERSONAL, then name — matches `findAll`).
- **`RoleRequests.CollectionRoleGrantRow`** — `(roleId, name, kind, level)` DTO alongside the other role rows.
- **`GET /api/admin/collections/{id}/roles`** on `CollectionAdminController`, injecting `RoleRepository` directly (mirrors `AdminRoleController` — no service layer for roles). Same two-layer admin perimeter as every `/api/admin/**` route; no route collision with the `AdminController` collection PUT.

No Flyway migration; the resolution queries (`canView` / `isClient` / `memberCollectionIdsForUser` / `effectiveGrants`) and `CollectionAccessService` are untouched. All mutations keep reusing the existing `AdminRoleController` grant routes.

## Convention note (conscious call requested)

Backend convention prefers top-level JSON **objects**, but the sibling RBAC list endpoints (`AdminRoleController.listRoles`, `AdminUserController.userRoles`) already return bare arrays and the frontend helpers consume them that way. This endpoint intentionally returns a bare `List<CollectionRoleGrantRow>` to match its siblings — wrapping only this one would be the inconsistency. Flagged for a conscious call at review.

## Coupling note (waterfall retrofit)

Once the waterfall PR (materialized inherited grants with `role_collection.inherited_from_collection_id`, branch `feat/collection-waterfall-grants`) also merges, this endpoint gets a small retrofit to select the provenance column so the admin UI can badge inherited rows read-only and block independent removal at the child. This branch deliberately does not reference that column — it does not exist here.

## Test evidence

TDD: both test classes written first and confirmed red (missing `CollectionRoleGrant` symbol), then implementation brought them green.

- `RoleRepositoryIntegrationTest` (Testcontainers Postgres): ordering SHARED-first-then-name with correct levels; empty when no grants; two roles granting one collection returns both and excludes other collections' grants.
- `CollectionAdminControllerTest` (MockMvc standaloneSetup): `GET /{id}/roles` -> 200 with mapped rows; 200 `[]` when none.

```
mvn spotless:apply   OK
mvn checkstyle:check BUILD SUCCESS
mvn clean install    Tests run: 1053, Failures: 0, Errors: 0, Skipped: 1
                     BUILD SUCCESS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)