### PR TITLE
feat(roles): waterfall role grants from parent to child collections

### DIFF
--- a/src/main/java/edens/zac/portfolio/backend/controller/admin/AdminRoleController.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/admin/AdminRoleController.java
@@ -9,6 +9,7 @@ import edens.zac.portfolio.backend.controller.admin.RoleRequests.SetRoleGrantReq
 import edens.zac.portfolio.backend.dao.RoleRepository;
 import edens.zac.portfolio.backend.entity.RoleEntity;
 import edens.zac.portfolio.backend.model.AuthPrincipal;
+import edens.zac.portfolio.backend.services.RoleGrantPropagationService;
 import edens.zac.portfolio.backend.types.RoleKind;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -38,6 +39,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminRoleController {
 
   private final RoleRepository roleRepository;
+  private final RoleGrantPropagationService roleGrantPropagationService;
 
   /**
    * List all roles (SHARED before PERSONAL, then by name) for the admin role-management view.
@@ -103,7 +105,8 @@ public class AdminRoleController {
 
   /**
    * Grant a collection to a role at a level (GENERAL or CLIENT). Upserts: creates the grant if
-   * absent, promotes/demotes if present.
+   * absent, promotes/demotes if present. The grant waterfalls: it is also materialized onto every
+   * visible descendant collection as an inherited copy.
    *
    * @param roleId the role id
    * @param collectionId the collection id
@@ -115,12 +118,13 @@ public class AdminRoleController {
       @PathVariable Long roleId,
       @PathVariable Long collectionId,
       @Valid @RequestBody SetRoleGrantRequest body) {
-    roleRepository.setCollectionGrant(roleId, collectionId, body.level(), currentUserId());
+    roleGrantPropagationService.setGrant(roleId, collectionId, body.level(), currentUserId());
     return ResponseEntity.noContent().build();
   }
 
   /**
-   * Revoke a role's grant on a collection.
+   * Revoke a role's grant on a collection, along with the inherited copies it waterfalled onto
+   * descendants. Copies still inherited from a surviving ancestor grant are re-materialized.
    *
    * @param roleId the role id
    * @param collectionId the collection id
@@ -129,7 +133,7 @@ public class AdminRoleController {
   @DeleteMapping("/{roleId}/collections/{collectionId}")
   public ResponseEntity<Void> removeGrant(
       @PathVariable Long roleId, @PathVariable Long collectionId) {
-    roleRepository.removeCollectionGrant(roleId, collectionId);
+    roleGrantPropagationService.removeGrant(roleId, collectionId);
     return ResponseEntity.noContent().build();
   }
 

--- a/src/main/java/edens/zac/portfolio/backend/controller/admin/CollectionAdminController.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/admin/CollectionAdminController.java
@@ -42,7 +42,15 @@ public class CollectionAdminController {
   @GetMapping("/{id}/roles")
   public List<CollectionRoleGrantRow> collectionRoles(@PathVariable Long id) {
     return roleRepository.rolesGrantingCollection(id).stream()
-        .map(g -> new CollectionRoleGrantRow(g.roleId(), g.name(), g.kind(), g.level()))
+        .map(
+            g ->
+                new CollectionRoleGrantRow(
+                    g.roleId(),
+                    g.name(),
+                    g.kind(),
+                    g.level(),
+                    g.inheritedFromCollectionId(),
+                    g.inheritedFromCollectionTitle()))
         .toList();
   }
 

--- a/src/main/java/edens/zac/portfolio/backend/controller/admin/RoleRequests.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/admin/RoleRequests.java
@@ -38,7 +38,16 @@ public final class RoleRequests {
   /** One role a user belongs to, for the reshaped user-detail view. */
   public record UserRoleRow(Long roleId, String name, RoleKind kind) {}
 
-  /** One role granting a collection, for the collection-edit access panel. */
+  /**
+   * One role granting a collection, for the collection-edit access panel. The provenance pair is
+   * null for direct grants; inherited (waterfalled) rows carry the origin collection's id and title
+   * so the UI can badge them.
+   */
   public record CollectionRoleGrantRow(
-      Long roleId, String name, RoleKind kind, AccessLevel level) {}
+      Long roleId,
+      String name,
+      RoleKind kind,
+      AccessLevel level,
+      Long inheritedFromCollectionId,
+      String inheritedFromCollectionTitle) {}
 }

--- a/src/main/java/edens/zac/portfolio/backend/dao/CollectionRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/CollectionRepository.java
@@ -214,6 +214,29 @@ public class CollectionRepository extends BaseDao {
   }
 
   /**
+   * Ids of children linked under a parent through a VISIBLE membership row ({@code cc.visible =
+   * true}), regardless of the child collection's own {@code visibility}. Role-grant propagation
+   * follows only visible links (mirroring the V47 backfill gate); removal walks use the
+   * visibility-agnostic {@link #findAllReferencedCollectionsByParentId} instead so stale copies are
+   * always stripped.
+   */
+  @Transactional(readOnly = true)
+  public List<Long> findVisibleReferencedCollectionIdsByParentId(Long parentId) {
+    String sql =
+        """
+        SELECT cct.referenced_collection_id
+        FROM collection_content cc
+        JOIN content_collection cct ON cct.id = cc.content_id
+        WHERE cc.collection_id = :parentId
+          AND cc.visible = true
+          AND cct.referenced_collection_id IS NOT NULL
+        ORDER BY cc.order_index ASC
+        """;
+    MapSqlParameterSource params = createParameterSource().addValue("parentId", parentId);
+    return query(sql, (rs, n) -> rs.getLong("referenced_collection_id"), params);
+  }
+
+  /**
    * Inverse of {@link #findAllReferencedCollectionsByParentId}: given a child collection, find
    * every parent collection that references it. Walks child -> content_collection ->
    * collection_content -> parent. Admin-context query: filters neither {@code c.visibility} nor

--- a/src/main/java/edens/zac/portfolio/backend/dao/CollectionRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/CollectionRepository.java
@@ -237,6 +237,27 @@ public class CollectionRepository extends BaseDao {
   }
 
   /**
+   * Inverse of {@link #findVisibleReferencedCollectionIdsByParentId}: ids of parents linked to a
+   * child through a VISIBLE membership row. Used by grant re-materialization to find the ancestors
+   * whose grants can actually waterfall down to the child (a hidden link on the path blocks
+   * inheritance).
+   */
+  @Transactional(readOnly = true)
+  public List<Long> findVisibleParentCollectionIdsByChildId(Long childId) {
+    String sql =
+        """
+        SELECT cc.collection_id
+        FROM collection_content cc
+        JOIN content_collection cct ON cct.id = cc.content_id
+        WHERE cct.referenced_collection_id = :childId
+          AND cc.visible = true
+        ORDER BY cc.collection_id ASC
+        """;
+    MapSqlParameterSource params = createParameterSource().addValue("childId", childId);
+    return query(sql, (rs, n) -> rs.getLong("collection_id"), params);
+  }
+
+  /**
    * Inverse of {@link #findAllReferencedCollectionsByParentId}: given a child collection, find
    * every parent collection that references it. Walks child -> content_collection ->
    * collection_content -> parent. Admin-context query: filters neither {@code c.visibility} nor

--- a/src/main/java/edens/zac/portfolio/backend/dao/RoleRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/RoleRepository.java
@@ -42,8 +42,18 @@ public class RoleRepository extends BaseDao {
   /** A member of a role, joined to their account, for the role-detail view. */
   public record RoleMember(Long userId, String email, String name) {}
 
-  /** One role granting a collection, for the collection-detail (inverse) view. */
-  public record CollectionRoleGrant(Long roleId, String name, RoleKind kind, AccessLevel level) {}
+  /**
+   * One role granting a collection, for the collection-detail (inverse) view. The provenance pair
+   * is null for a direct grant; for an inherited copy it carries the origin collection's id and
+   * title so the admin UI can badge waterfalled rows.
+   */
+  public record CollectionRoleGrant(
+      Long roleId,
+      String name,
+      RoleKind kind,
+      AccessLevel level,
+      Long inheritedFromCollectionId,
+      String inheritedFromCollectionTitle) {}
 
   /**
    * A grant held on a collection: the role, the level, and its provenance. A null {@code
@@ -196,16 +206,20 @@ public class RoleRepository extends BaseDao {
   }
 
   /**
-   * The inverse of {@link #grantsForRole}: every role granting a collection, with its level.
-   * Ordered SHARED before PERSONAL, then by name (matches {@link #findAll}).
+   * The inverse of {@link #grantsForRole}: every role granting a collection, with its level and
+   * waterfall provenance (origin collection id + title, null for direct grants). Ordered SHARED
+   * before PERSONAL, then by name (matches {@link #findAll}).
    */
   @Transactional(readOnly = true)
   public List<CollectionRoleGrant> rolesGrantingCollection(Long collectionId) {
     return query(
         """
-        SELECT rc.role_id, r.name, r.kind, rc.level
+        SELECT rc.role_id, r.name, r.kind, rc.level,
+               rc.inherited_from_collection_id,
+               origin.title AS inherited_from_collection_title
           FROM role_collection rc
           JOIN role r ON r.id = rc.role_id
+          LEFT JOIN collection origin ON origin.id = rc.inherited_from_collection_id
          WHERE rc.collection_id = :collectionId
          ORDER BY r.kind DESC, r.name ASC
         """,
@@ -214,7 +228,9 @@ public class RoleRepository extends BaseDao {
                 rs.getLong("role_id"),
                 rs.getString("name"),
                 RoleKind.valueOf(rs.getString("kind")),
-                AccessLevel.valueOf(rs.getString("level"))),
+                AccessLevel.valueOf(rs.getString("level")),
+                getLong(rs, "inherited_from_collection_id"),
+                rs.getString("inherited_from_collection_title")),
         createParameterSource().addValue("collectionId", collectionId));
   }
 

--- a/src/main/java/edens/zac/portfolio/backend/dao/RoleRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/RoleRepository.java
@@ -161,7 +161,9 @@ public class RoleRepository extends BaseDao {
   /**
    * Upsert a DIRECT grant. Clearing {@code inherited_from_collection_id} on conflict converts an
    * inherited copy into a direct grant, so an explicit admin grant is never mistaken for (or later
-   * swept away with) waterfalled rows.
+   * swept away with) waterfalled rows. The audit pair is refreshed on conflict too: the row records
+   * who set the CURRENT level and when (an inherited copy carries a null actor, which must not
+   * survive its promotion to direct).
    */
   @Transactional
   public void setCollectionGrant(
@@ -171,7 +173,10 @@ public class RoleRepository extends BaseDao {
         INSERT INTO role_collection (role_id, collection_id, level, granted_by)
         VALUES (:roleId, :collectionId, :level, :grantedBy)
         ON CONFLICT (role_id, collection_id)
-          DO UPDATE SET level = EXCLUDED.level, inherited_from_collection_id = NULL
+          DO UPDATE SET level = EXCLUDED.level,
+                        granted_by = EXCLUDED.granted_by,
+                        granted_at = EXCLUDED.granted_at,
+                        inherited_from_collection_id = NULL
         """,
         createParameterSource()
             .addValue("roleId", roleId)

--- a/src/main/java/edens/zac/portfolio/backend/dao/RoleRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/RoleRepository.java
@@ -45,6 +45,24 @@ public class RoleRepository extends BaseDao {
   /** One role granting a collection, for the collection-detail (inverse) view. */
   public record CollectionRoleGrant(Long roleId, String name, RoleKind kind, AccessLevel level) {}
 
+  /**
+   * A grant held on a collection: the role, the level, and its provenance. A null {@code
+   * inheritedFromCollectionId} means the grant is direct; otherwise it is an inherited copy whose
+   * origin (the collection holding the direct grant) is that id.
+   */
+  public record CollectionGrant(Long roleId, AccessLevel level, Long inheritedFromCollectionId) {
+    public boolean direct() {
+      return inheritedFromCollectionId == null;
+    }
+  }
+
+  private static final RowMapper<CollectionGrant> COLLECTION_GRANT_ROW_MAPPER =
+      (rs, n) ->
+          new CollectionGrant(
+              rs.getLong("role_id"),
+              AccessLevel.valueOf(rs.getString("level")),
+              getLong(rs, "inherited_from_collection_id"));
+
   // ---- Role CRUD ----
 
   @Transactional
@@ -130,6 +148,11 @@ public class RoleRepository extends BaseDao {
 
   // ---- Collection grants on a role ----
 
+  /**
+   * Upsert a DIRECT grant. Clearing {@code inherited_from_collection_id} on conflict converts an
+   * inherited copy into a direct grant, so an explicit admin grant is never mistaken for (or later
+   * swept away with) waterfalled rows.
+   */
   @Transactional
   public void setCollectionGrant(
       Long roleId, Long collectionId, AccessLevel level, Long grantedBy) {
@@ -137,7 +160,8 @@ public class RoleRepository extends BaseDao {
         """
         INSERT INTO role_collection (role_id, collection_id, level, granted_by)
         VALUES (:roleId, :collectionId, :level, :grantedBy)
-        ON CONFLICT (role_id, collection_id) DO UPDATE SET level = EXCLUDED.level
+        ON CONFLICT (role_id, collection_id)
+          DO UPDATE SET level = EXCLUDED.level, inherited_from_collection_id = NULL
         """,
         createParameterSource()
             .addValue("roleId", roleId)
@@ -191,6 +215,92 @@ public class RoleRepository extends BaseDao {
                 rs.getString("name"),
                 RoleKind.valueOf(rs.getString("kind")),
                 AccessLevel.valueOf(rs.getString("level"))),
+        createParameterSource().addValue("collectionId", collectionId));
+  }
+
+  // ---- Waterfall provenance (inherited copies of direct grants) ----
+
+  /**
+   * Upsert an INHERITED copy of a direct grant held on {@code originCollectionId}. Never clobbers a
+   * direct row, and never downgrades: an existing inherited row is only rewritten when the incoming
+   * level is strictly higher (CLIENT over GENERAL), in which case the origin moves with it.
+   * Everything else is a no-op, keeping direct grants sticky.
+   */
+  @Transactional
+  public void insertInheritedGrant(
+      Long roleId, Long collectionId, AccessLevel level, Long originCollectionId) {
+    update(
+        """
+        INSERT INTO role_collection (role_id, collection_id, level, inherited_from_collection_id)
+        VALUES (:roleId, :collectionId, :level, :originId)
+        ON CONFLICT (role_id, collection_id) DO UPDATE
+           SET level = EXCLUDED.level,
+               inherited_from_collection_id = EXCLUDED.inherited_from_collection_id
+         WHERE role_collection.inherited_from_collection_id IS NOT NULL
+           AND role_collection.level = 'GENERAL'
+           AND EXCLUDED.level = 'CLIENT'
+        """,
+        createParameterSource()
+            .addValue("roleId", roleId)
+            .addValue("collectionId", collectionId)
+            .addValue("level", level.name())
+            .addValue("originId", originCollectionId));
+  }
+
+  /** Delete every inherited copy of the role's direct grant on the origin, tree-wide. */
+  @Transactional
+  public void removeInheritedGrantsByOrigin(Long roleId, Long originCollectionId) {
+    update(
+        """
+        DELETE FROM role_collection
+         WHERE role_id = :roleId AND inherited_from_collection_id = :originId
+        """,
+        createParameterSource()
+            .addValue("roleId", roleId)
+            .addValue("originId", originCollectionId));
+  }
+
+  /** Delete one collection's inherited copy for a specific origin (used by the unlink hook). */
+  @Transactional
+  public void removeInheritedGrantsForCollectionByOrigin(
+      Long roleId, Long collectionId, Long originCollectionId) {
+    update(
+        """
+        DELETE FROM role_collection
+         WHERE role_id = :roleId AND collection_id = :collectionId
+           AND inherited_from_collection_id = :originId
+        """,
+        createParameterSource()
+            .addValue("roleId", roleId)
+            .addValue("collectionId", collectionId)
+            .addValue("originId", originCollectionId));
+  }
+
+  /** The DIRECT grants held on a collection (provenance null), across all roles. */
+  @Transactional(readOnly = true)
+  public List<CollectionGrant> directGrantsForCollection(Long collectionId) {
+    return query(
+        """
+        SELECT role_id, level, inherited_from_collection_id
+          FROM role_collection
+         WHERE collection_id = :collectionId AND inherited_from_collection_id IS NULL
+         ORDER BY role_id ASC
+        """,
+        COLLECTION_GRANT_ROW_MAPPER,
+        createParameterSource().addValue("collectionId", collectionId));
+  }
+
+  /** Every grant held on a collection -- direct and inherited -- across all roles. */
+  @Transactional(readOnly = true)
+  public List<CollectionGrant> allGrantsForCollection(Long collectionId) {
+    return query(
+        """
+        SELECT role_id, level, inherited_from_collection_id
+          FROM role_collection
+         WHERE collection_id = :collectionId
+         ORDER BY role_id ASC
+        """,
+        COLLECTION_GRANT_ROW_MAPPER,
         createParameterSource().addValue("collectionId", collectionId));
   }
 

--- a/src/main/java/edens/zac/portfolio/backend/services/CollectionService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/CollectionService.java
@@ -76,6 +76,7 @@ public class CollectionService {
   private final TagViewResolver tagViewResolver;
   private final ClientGalleryAuthService clientGalleryAuthService;
   private final CollectionAccessService collectionAccessService;
+  private final RoleGrantPropagationService roleGrantPropagationService;
   private final Environment springEnv;
 
   private static final int DEFAULT_PAGE_SIZE = default_content_per_page;
@@ -409,6 +410,9 @@ public class CollectionService {
         childCollectionId,
         parentId,
         orderIndex);
+
+    // Waterfall: the new child inherits every grant the parent holds (origin preserved).
+    roleGrantPropagationService.onChildLinked(parentId, childCollectionId);
   }
 
   @Transactional(readOnly = true)
@@ -846,6 +850,16 @@ public class CollectionService {
             "Removed {} collection references from parent collection {}",
             contentIdsToRemove.size(),
             parentCollection.getId());
+
+        // Waterfall: each unlinked child subtree loses the grants it inherited through this
+        // parent (origins at/above it); grants with origins inside the subtree survive.
+        contentColEntities.stream()
+            .map(ContentCollectionEntity::getReferencedCollection)
+            .filter(Objects::nonNull)
+            .map(CollectionEntity::getId)
+            .forEach(
+                childId ->
+                    roleGrantPropagationService.onChildUnlinked(parentCollection.getId(), childId));
       } else {
         log.debug(
             "No matching content collections found to remove from collection {}",
@@ -902,6 +916,13 @@ public class CollectionService {
               childCollectionEntity.getId(),
               parentCollection.getId(),
               orderIndex);
+
+          // Waterfall: a visibly linked child inherits the parent's grants. Hidden links do not
+          // waterfall (mirrors the cc.visible gate used by propagation and the V47 backfill).
+          if (Boolean.TRUE.equals(newEntry.getVisible())) {
+            roleGrantPropagationService.onChildLinked(
+                parentCollection.getId(), childCollectionEntity.getId());
+          }
         } else {
           // Update existing entry
           if (childCollection.orderIndex() != null) {

--- a/src/main/java/edens/zac/portfolio/backend/services/RoleGrantPropagationService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/RoleGrantPropagationService.java
@@ -1,0 +1,163 @@
+package edens.zac.portfolio.backend.services;
+
+import edens.zac.portfolio.backend.dao.CollectionRepository;
+import edens.zac.portfolio.backend.dao.RoleRepository;
+import edens.zac.portfolio.backend.dao.RoleRepository.CollectionGrant;
+import edens.zac.portfolio.backend.entity.CollectionEntity;
+import edens.zac.portfolio.backend.types.AccessLevel;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Write-time waterfall of role grants down the collection tree (materialized propagation).
+ * Inherited grants are real {@code role_collection} rows carrying their ORIGIN (the collection
+ * holding the direct grant) in {@code inherited_from_collection_id}, so the resolution queries in
+ * {@link RoleRepository} stay flat and untouched. Propagation follows only visible parent-to-child
+ * links ({@code cc.visible = true}), matching the V47 backfill; removal walks are
+ * visibility-agnostic so stale copies are always stripped. Direct grants are sticky: propagation
+ * never clobbers or downgrades a direct row, and removing a parent grant leaves a child's own
+ * direct grant in place.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RoleGrantPropagationService {
+
+  private final RoleRepository roleRepository;
+  private final CollectionRepository collectionRepository;
+
+  /** Grant/raise hook: upsert the direct grant, then materialize it onto visible descendants. */
+  @Transactional
+  public void setGrant(Long roleId, Long collectionId, AccessLevel level, Long grantedBy) {
+    roleRepository.setCollectionGrant(roleId, collectionId, level, grantedBy);
+    propagateToVisibleSubtree(roleId, level, collectionId, collectionId);
+    log.info(
+        "Set {} grant for role {} on collection {} and waterfalled to descendants",
+        level,
+        roleId,
+        collectionId);
+  }
+
+  /**
+   * Removal hook: delete the grant and its tree-wide inherited copies, then re-materialize whatever
+   * the affected subtree still inherits from surviving ancestor grants.
+   */
+  @Transactional
+  public void removeGrant(Long roleId, Long collectionId) {
+    roleRepository.removeCollectionGrant(roleId, collectionId);
+    roleRepository.removeInheritedGrantsByOrigin(roleId, collectionId);
+    for (Long ancestorId : ancestorsOf(collectionId)) {
+      roleRepository.directGrantsForCollection(ancestorId).stream()
+          .filter(g -> g.roleId().equals(roleId))
+          .forEach(g -> propagateToVisibleSubtree(roleId, g.level(), ancestorId, ancestorId));
+    }
+    log.info(
+        "Removed grant for role {} on collection {} along with its inherited copies",
+        roleId,
+        collectionId);
+  }
+
+  /** Link hook: copy every grant the parent holds into the newly linked child's subtree. */
+  @Transactional
+  public void onChildLinked(Long parentId, Long childId) {
+    for (CollectionGrant grant : roleRepository.allGrantsForCollection(parentId)) {
+      Long originId = grant.direct() ? parentId : grant.inheritedFromCollectionId();
+      roleRepository.insertInheritedGrant(grant.roleId(), childId, grant.level(), originId);
+      propagateToVisibleSubtree(grant.roleId(), grant.level(), originId, childId);
+    }
+  }
+
+  /** Unlink hook: strip the child subtree's inherited copies originating at/above the parent. */
+  @Transactional
+  public void onChildUnlinked(Long parentId, Long childId) {
+    Set<Long> origins = ancestorsOf(parentId);
+    origins.add(parentId);
+    for (Long member : subtreeOf(childId)) {
+      for (CollectionGrant grant : roleRepository.allGrantsForCollection(member)) {
+        if (!grant.direct() && origins.contains(grant.inheritedFromCollectionId())) {
+          roleRepository.removeInheritedGrantsForCollectionByOrigin(
+              grant.roleId(), member, grant.inheritedFromCollectionId());
+        }
+      }
+    }
+  }
+
+  /**
+   * Insert inherited copies of the origin's direct grant on every collection reachable from {@code
+   * rootId} through visible links, cycle-guarded. The root itself is not written -- for a grant it
+   * already holds the direct row, and for a link the caller inserts the child's copy before
+   * descending.
+   */
+  private void propagateToVisibleSubtree(
+      Long roleId, AccessLevel level, Long originCollectionId, Long rootId) {
+    Set<Long> visited = new HashSet<>();
+    visited.add(rootId);
+    Deque<Long> pending =
+        new ArrayDeque<>(collectionRepository.findVisibleReferencedCollectionIdsByParentId(rootId));
+    while (!pending.isEmpty()) {
+      Long current = pending.poll();
+      if (!visited.add(current)) {
+        continue;
+      }
+      if (!current.equals(originCollectionId)) {
+        roleRepository.insertInheritedGrant(roleId, current, level, originCollectionId);
+      }
+      pending.addAll(collectionRepository.findVisibleReferencedCollectionIdsByParentId(current));
+    }
+  }
+
+  /** Every ancestor of the collection through the content graph (any depth), cycle-guarded. */
+  private Set<Long> ancestorsOf(Long collectionId) {
+    Set<Long> visited = new HashSet<>();
+    visited.add(collectionId);
+    Set<Long> ancestors = new LinkedHashSet<>();
+    Deque<Long> pending = new ArrayDeque<>(parentIdsOf(collectionId));
+    while (!pending.isEmpty()) {
+      Long current = pending.poll();
+      if (!visited.add(current)) {
+        continue;
+      }
+      ancestors.add(current);
+      pending.addAll(parentIdsOf(current));
+    }
+    return ancestors;
+  }
+
+  /**
+   * The collection plus every descendant, regardless of link visibility (removal must also reach
+   * copies under links that were later hidden), cycle-guarded.
+   */
+  private Set<Long> subtreeOf(Long rootId) {
+    Set<Long> visited = new LinkedHashSet<>();
+    visited.add(rootId);
+    Deque<Long> pending = new ArrayDeque<>(childIdsOf(rootId));
+    while (!pending.isEmpty()) {
+      Long current = pending.poll();
+      if (!visited.add(current)) {
+        continue;
+      }
+      pending.addAll(childIdsOf(current));
+    }
+    return visited;
+  }
+
+  private List<Long> parentIdsOf(Long collectionId) {
+    return collectionRepository.findAllParentCollectionsByChildId(collectionId).stream()
+        .map(CollectionEntity::getId)
+        .toList();
+  }
+
+  private List<Long> childIdsOf(Long collectionId) {
+    return collectionRepository.findAllReferencedCollectionsByParentId(collectionId).stream()
+        .map(CollectionEntity::getId)
+        .toList();
+  }
+}

--- a/src/main/java/edens/zac/portfolio/backend/services/RoleGrantPropagationService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/RoleGrantPropagationService.java
@@ -34,11 +34,19 @@ public class RoleGrantPropagationService {
   private final RoleRepository roleRepository;
   private final CollectionRepository collectionRepository;
 
-  /** Grant/raise hook: upsert the direct grant, then materialize it onto visible descendants. */
+  /**
+   * Grant/raise/demote hook: upsert the direct grant, then rebuild this origin's inherited copies
+   * at the new level. Stripping before re-propagating is what makes DEMOTION stick -- the
+   * inherited-grant upsert never downgrades, so stale CLIENT copies must be deleted first.
+   * Surviving ancestor grants are then re-materialized so a descendant also covered by a higher
+   * ancestor grant keeps its higher level.
+   */
   @Transactional
   public void setGrant(Long roleId, Long collectionId, AccessLevel level, Long grantedBy) {
     roleRepository.setCollectionGrant(roleId, collectionId, level, grantedBy);
+    roleRepository.removeInheritedGrantsByOrigin(roleId, collectionId);
     propagateToVisibleSubtree(roleId, level, collectionId, collectionId);
+    rematerializeSubtreeFromAncestors(roleId, collectionId);
     log.info(
         "Set {} grant for role {} on collection {} and waterfalled to descendants",
         level,
@@ -54,11 +62,7 @@ public class RoleGrantPropagationService {
   public void removeGrant(Long roleId, Long collectionId) {
     roleRepository.removeCollectionGrant(roleId, collectionId);
     roleRepository.removeInheritedGrantsByOrigin(roleId, collectionId);
-    for (Long ancestorId : ancestorsOf(collectionId)) {
-      roleRepository.directGrantsForCollection(ancestorId).stream()
-          .filter(g -> g.roleId().equals(roleId))
-          .forEach(g -> propagateToVisibleSubtree(roleId, g.level(), ancestorId, ancestorId));
-    }
+    rematerializeSubtreeFromAncestors(roleId, collectionId);
     log.info(
         "Removed grant for role {} on collection {} along with its inherited copies",
         roleId,
@@ -114,6 +118,28 @@ public class RoleGrantPropagationService {
     }
   }
 
+  /**
+   * Re-materialize, within {@code collectionId}'s subtree only, the inherited copies still due from
+   * surviving ancestor grants. Rows carrying a given origin exist only inside that origin's
+   * subtree, so after stripping origin = {@code collectionId} nothing OUTSIDE its subtree can need
+   * rewriting -- rooting the walk here instead of at each ancestor keeps the write set minimal.
+   * Only ancestors connected to the collection through an unbroken chain of visible links qualify:
+   * a hidden link on the way down blocks re-materialization exactly as it blocks forward
+   * propagation. The root itself is upserted too (a no-op right after {@code setGrant}, where it
+   * holds a fresh direct row; the re-inherited copy after {@code removeGrant}).
+   */
+  private void rematerializeSubtreeFromAncestors(Long roleId, Long collectionId) {
+    for (Long ancestorId : visiblyLinkedAncestorsOf(collectionId)) {
+      roleRepository.directGrantsForCollection(ancestorId).stream()
+          .filter(g -> g.roleId().equals(roleId))
+          .forEach(
+              g -> {
+                roleRepository.insertInheritedGrant(roleId, collectionId, g.level(), ancestorId);
+                propagateToVisibleSubtree(roleId, g.level(), ancestorId, collectionId);
+              });
+    }
+  }
+
   /** Every ancestor of the collection through the content graph (any depth), cycle-guarded. */
   private Set<Long> ancestorsOf(Long collectionId) {
     Set<Long> visited = new HashSet<>();
@@ -147,6 +173,29 @@ public class RoleGrantPropagationService {
       pending.addAll(childIdsOf(current));
     }
     return visited;
+  }
+
+  /**
+   * Ancestors reachable from the collection through an unbroken upward chain of VISIBLE links,
+   * cycle-guarded. Only these can waterfall grants down to it (single-parent trees; multi-parent
+   * inheritance is a declared non-goal).
+   */
+  private Set<Long> visiblyLinkedAncestorsOf(Long collectionId) {
+    Set<Long> visited = new HashSet<>();
+    visited.add(collectionId);
+    Set<Long> ancestors = new LinkedHashSet<>();
+    Deque<Long> pending =
+        new ArrayDeque<>(
+            collectionRepository.findVisibleParentCollectionIdsByChildId(collectionId));
+    while (!pending.isEmpty()) {
+      Long current = pending.poll();
+      if (!visited.add(current)) {
+        continue;
+      }
+      ancestors.add(current);
+      pending.addAll(collectionRepository.findVisibleParentCollectionIdsByChildId(current));
+    }
+    return ancestors;
   }
 
   private List<Long> parentIdsOf(Long collectionId) {

--- a/src/main/resources/db/migration/V47__role_collection_waterfall.sql
+++ b/src/main/resources/db/migration/V47__role_collection_waterfall.sql
@@ -1,0 +1,51 @@
+-- V47: waterfall role grants. Adds provenance to role_collection so a grant on a PARENT
+-- collection can be materialized onto every descendant as a real row:
+--   inherited_from_collection_id IS NULL -> direct grant (the unchanged meaning of every
+--                                           pre-V47 row; this migration leaves them all NULL);
+--   inherited_from_collection_id = X     -> inherited copy whose ORIGIN (the collection that
+--                                           holds the direct grant) is X. Storing the origin --
+--                                           not the immediate parent -- makes removal a single
+--                                           DELETE ... WHERE inherited_from_collection_id = X.
+-- The resolution queries (RoleRepository.canView/isClient/memberCollectionIdsForUser/
+-- effectiveGrants) are untouched by design: inherited grants are real rows, so reads stay flat.
+BEGIN;
+
+ALTER TABLE role_collection
+  ADD COLUMN inherited_from_collection_id BIGINT NULL
+    REFERENCES collection(id) ON DELETE CASCADE;
+CREATE INDEX idx_role_collection_inherited_from
+  ON role_collection(inherited_from_collection_id);
+
+-- One-time backfill: materialize every existing direct grant down its collection tree.
+-- The hierarchy is a content graph: parent -> collection_content (visible links only, matching
+-- runtime propagation) -> content_collection -> child collection. UNION (not UNION ALL) drops
+-- revisited rows, so accidental cycles terminate. When a descendant is reachable from origins
+-- at different levels, CLIENT wins; a descendant that already has its own direct grant for the
+-- role is left untouched (direct wins).
+WITH RECURSIVE descendant AS (
+  SELECT rc.role_id,
+         rc.collection_id AS origin_id,
+         rc.level,
+         cct.referenced_collection_id AS descendant_id
+    FROM role_collection rc
+    JOIN collection_content cc ON cc.collection_id = rc.collection_id AND cc.visible = true
+    JOIN content_collection cct ON cct.id = cc.content_id
+   WHERE rc.inherited_from_collection_id IS NULL
+     AND cct.referenced_collection_id IS NOT NULL
+  UNION
+  SELECT d.role_id, d.origin_id, d.level, cct.referenced_collection_id
+    FROM descendant d
+    JOIN collection_content cc ON cc.collection_id = d.descendant_id AND cc.visible = true
+    JOIN content_collection cct ON cct.id = cc.content_id
+   WHERE cct.referenced_collection_id IS NOT NULL
+)
+INSERT INTO role_collection (role_id, collection_id, level, inherited_from_collection_id)
+SELECT DISTINCT ON (d.role_id, d.descendant_id)
+       d.role_id, d.descendant_id, d.level, d.origin_id
+  FROM descendant d
+ WHERE NOT EXISTS (SELECT 1 FROM role_collection rc
+                    WHERE rc.role_id = d.role_id AND rc.collection_id = d.descendant_id)
+ ORDER BY d.role_id, d.descendant_id, (d.level = 'CLIENT') DESC
+ON CONFLICT (role_id, collection_id) DO NOTHING;
+
+COMMIT;

--- a/src/test/java/edens/zac/portfolio/backend/RoleWaterfallMigrationIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/RoleWaterfallMigrationIntegrationTest.java
@@ -1,0 +1,121 @@
+package edens.zac.portfolio.backend;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import edens.zac.portfolio.backend.dao.RoleRepository;
+import edens.zac.portfolio.backend.services.CollectionService;
+import edens.zac.portfolio.backend.types.AccessLevel;
+import edens.zac.portfolio.backend.types.RoleKind;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Verifies the V47 backfill: existing direct grants are materialized down the collection tree as
+ * inherited copies carrying their origin. Flyway already applied V47 to the (then empty) container
+ * schema, so this seeds a pre-waterfall state -- a tree plus direct-only {@code role_collection}
+ * rows written straight through the repository -- and re-runs the V47 backfill statement, mirroring
+ * how {@link RoleMigrationIntegrationTest} re-runs the V45 backfill.
+ */
+class RoleWaterfallMigrationIntegrationTest extends AbstractPostgresIntegrationTest {
+
+  /** The WITH RECURSIVE backfill from V47__role_collection_waterfall.sql, verbatim. */
+  private static final String V47_BACKFILL =
+      """
+      WITH RECURSIVE descendant AS (
+        SELECT rc.role_id,
+               rc.collection_id AS origin_id,
+               rc.level,
+               cct.referenced_collection_id AS descendant_id
+          FROM role_collection rc
+          JOIN collection_content cc ON cc.collection_id = rc.collection_id AND cc.visible = true
+          JOIN content_collection cct ON cct.id = cc.content_id
+         WHERE rc.inherited_from_collection_id IS NULL
+           AND cct.referenced_collection_id IS NOT NULL
+        UNION
+        SELECT d.role_id, d.origin_id, d.level, cct.referenced_collection_id
+          FROM descendant d
+          JOIN collection_content cc ON cc.collection_id = d.descendant_id AND cc.visible = true
+          JOIN content_collection cct ON cct.id = cc.content_id
+         WHERE cct.referenced_collection_id IS NOT NULL
+      )
+      INSERT INTO role_collection (role_id, collection_id, level, inherited_from_collection_id)
+      SELECT DISTINCT ON (d.role_id, d.descendant_id)
+             d.role_id, d.descendant_id, d.level, d.origin_id
+        FROM descendant d
+       WHERE NOT EXISTS (SELECT 1 FROM role_collection rc
+                          WHERE rc.role_id = d.role_id AND rc.collection_id = d.descendant_id)
+       ORDER BY d.role_id, d.descendant_id, (d.level = 'CLIENT') DESC
+      ON CONFLICT (role_id, collection_id) DO NOTHING
+      """;
+
+  @Autowired private JdbcTemplate jdbc;
+  @Autowired private RoleRepository roleRepository;
+  @Autowired private CollectionService collectionService;
+
+  private long seedUser(String name) {
+    jdbc.update(
+        "INSERT INTO users (name, webauthn_user_handle, status) VALUES (?, gen_random_uuid(), 'ACTIVE')",
+        name);
+    return jdbc.queryForObject("SELECT id FROM users WHERE name=?", Long.class, name);
+  }
+
+  private long seedCollection(String slug) {
+    jdbc.update(
+        "INSERT INTO collection (title, slug, type, visibility) VALUES (?, ?, 'CLIENT_GALLERY', 'UNLISTED')",
+        slug,
+        slug);
+    return jdbc.queryForObject("SELECT id FROM collection WHERE slug=?", Long.class, slug);
+  }
+
+  private Long inheritedFrom(long roleId, long collectionId) {
+    return jdbc.queryForObject(
+        "SELECT inherited_from_collection_id FROM role_collection"
+            + " WHERE role_id=? AND collection_id=?",
+        Long.class,
+        roleId,
+        collectionId);
+  }
+
+  @Test
+  void backfillMaterializesDirectGrantsDownVisibleTree() {
+    long user = seedUser("Backfill");
+    long parent = seedCollection("bf-pnwer");
+    long child = seedCollection("bf-pnwer-2025");
+    long grandchild = seedCollection("bf-pnwer-2025-day1");
+    long hidden = seedCollection("bf-pnwer-hidden");
+    long selfGranted = seedCollection("bf-pnwer-2026");
+    collectionService.linkCollectionToParent(parent, child);
+    collectionService.linkCollectionToParent(child, grandchild);
+    collectionService.linkCollectionToParent(parent, hidden);
+    collectionService.linkCollectionToParent(parent, selfGranted);
+    jdbc.update(
+        "UPDATE collection_content cc SET visible = false FROM content_collection cct"
+            + " WHERE cc.content_id = cct.id AND cc.collection_id = ?"
+            + " AND cct.referenced_collection_id = ?",
+        parent,
+        hidden);
+
+    // Pre-waterfall state: direct rows only, written straight through the repository (which does
+    // not propagate) -- the shape the table had the moment V47's ALTER ran in prod.
+    long roleId = roleRepository.createRole("role:bf-pnwer", RoleKind.SHARED, null);
+    roleRepository.addMember(roleId, user, null);
+    roleRepository.setCollectionGrant(roleId, parent, AccessLevel.CLIENT, null);
+    roleRepository.setCollectionGrant(roleId, selfGranted, AccessLevel.GENERAL, null);
+    assertThat(roleRepository.canView(user, child)).isFalse();
+
+    jdbc.execute(V47_BACKFILL);
+
+    // Visible descendants inherit CLIENT with the origin recorded.
+    assertThat(roleRepository.isClient(user, child)).isTrue();
+    assertThat(roleRepository.isClient(user, grandchild)).isTrue();
+    assertThat(inheritedFrom(roleId, child)).isEqualTo(parent);
+    assertThat(inheritedFrom(roleId, grandchild)).isEqualTo(parent);
+    // The hidden link blocks inheritance entirely.
+    assertThat(roleRepository.canView(user, hidden)).isFalse();
+    // A descendant with its own direct grant is left untouched (direct wins).
+    assertThat(roleRepository.canView(user, selfGranted)).isTrue();
+    assertThat(roleRepository.isClient(user, selfGranted)).isFalse();
+    assertThat(inheritedFrom(roleId, selfGranted)).isNull();
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/controller/admin/AdminRoleControllerTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/admin/AdminRoleControllerTest.java
@@ -17,6 +17,7 @@ import edens.zac.portfolio.backend.dao.RoleRepository;
 import edens.zac.portfolio.backend.dao.RoleRepository.RoleCollectionGrant;
 import edens.zac.portfolio.backend.dao.RoleRepository.RoleMember;
 import edens.zac.portfolio.backend.entity.RoleEntity;
+import edens.zac.portfolio.backend.services.RoleGrantPropagationService;
 import edens.zac.portfolio.backend.types.AccessLevel;
 import edens.zac.portfolio.backend.types.RoleKind;
 import java.util.List;
@@ -30,14 +31,17 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 class AdminRoleControllerTest {
 
   private RoleRepository roleRepository;
+  private RoleGrantPropagationService roleGrantPropagationService;
   private MockMvc mvc;
   private final ObjectMapper json = new ObjectMapper();
 
   @BeforeEach
   void setup() {
     roleRepository = Mockito.mock(RoleRepository.class);
+    roleGrantPropagationService = Mockito.mock(RoleGrantPropagationService.class);
     mvc =
-        MockMvcBuilders.standaloneSetup(new AdminRoleController(roleRepository))
+        MockMvcBuilders.standaloneSetup(
+                new AdminRoleController(roleRepository, roleGrantPropagationService))
             .setControllerAdvice(new GlobalExceptionHandler())
             .build();
   }
@@ -92,7 +96,7 @@ class AdminRoleControllerTest {
   }
 
   @Test
-  void setGrantReturns204AndUpserts() throws Exception {
+  void setGrantReturns204AndUpsertsWithPropagation() throws Exception {
     mvc.perform(
             put("/api/admin/roles/7/collections/9")
                 .contentType("application/json")
@@ -100,7 +104,7 @@ class AdminRoleControllerTest {
                     json.writeValueAsString(
                         new RoleRequests.SetRoleGrantRequest(AccessLevel.CLIENT))))
         .andExpect(status().isNoContent());
-    verify(roleRepository).setCollectionGrant(7L, 9L, AccessLevel.CLIENT, null);
+    verify(roleGrantPropagationService).setGrant(7L, 9L, AccessLevel.CLIENT, null);
   }
 
   @Test
@@ -115,9 +119,9 @@ class AdminRoleControllerTest {
   }
 
   @Test
-  void removeGrantReturns204() throws Exception {
+  void removeGrantReturns204WithPropagation() throws Exception {
     mvc.perform(delete("/api/admin/roles/7/collections/9")).andExpect(status().isNoContent());
-    verify(roleRepository).removeCollectionGrant(7L, 9L);
+    verify(roleGrantPropagationService).removeGrant(7L, 9L);
   }
 
   @Test

--- a/src/test/java/edens/zac/portfolio/backend/controller/admin/CollectionAdminControllerTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/admin/CollectionAdminControllerTest.java
@@ -1,5 +1,6 @@
 package edens.zac.portfolio.backend.controller.admin;
 
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -160,9 +161,9 @@ class CollectionAdminControllerTest {
           .thenReturn(
               List.of(
                   new CollectionRoleGrant(
-                      7L, "family gallery", RoleKind.SHARED, AccessLevel.CLIENT),
+                      7L, "family gallery", RoleKind.SHARED, AccessLevel.CLIENT, null, null),
                   new CollectionRoleGrant(
-                      9L, "mara personal", RoleKind.PERSONAL, AccessLevel.GENERAL)));
+                      9L, "mara personal", RoleKind.PERSONAL, AccessLevel.GENERAL, null, null)));
 
       mockMvc
           .perform(get("/api/admin/collections/42/roles"))
@@ -172,10 +173,30 @@ class CollectionAdminControllerTest {
           .andExpect(jsonPath("$[0].name").value("family gallery"))
           .andExpect(jsonPath("$[0].kind").value("SHARED"))
           .andExpect(jsonPath("$[0].level").value("CLIENT"))
+          .andExpect(jsonPath("$[0].inheritedFromCollectionId").value(nullValue()))
+          .andExpect(jsonPath("$[0].inheritedFromCollectionTitle").value(nullValue()))
           .andExpect(jsonPath("$[1].roleId").value(9))
           .andExpect(jsonPath("$[1].name").value("mara personal"))
           .andExpect(jsonPath("$[1].kind").value("PERSONAL"))
           .andExpect(jsonPath("$[1].level").value("GENERAL"));
+    }
+
+    @Test
+    void returnsInheritanceProvenanceForWaterfalledRows() throws Exception {
+      when(roleRepository.rolesGrantingCollection(43L))
+          .thenReturn(
+              List.of(
+                  new CollectionRoleGrant(
+                      7L, "pnwer crew", RoleKind.SHARED, AccessLevel.CLIENT, 12L, "PNWER Parent")));
+
+      mockMvc
+          .perform(get("/api/admin/collections/43/roles"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.length()").value(1))
+          .andExpect(jsonPath("$[0].roleId").value(7))
+          .andExpect(jsonPath("$[0].level").value("CLIENT"))
+          .andExpect(jsonPath("$[0].inheritedFromCollectionId").value(12))
+          .andExpect(jsonPath("$[0].inheritedFromCollectionTitle").value("PNWER Parent"));
     }
 
     @Test

--- a/src/test/java/edens/zac/portfolio/backend/dao/RoleRepositoryIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/dao/RoleRepositoryIntegrationTest.java
@@ -181,6 +181,21 @@ class RoleRepositoryIntegrationTest extends AbstractPostgresIntegrationTest {
               assertThat(g.inheritedFromCollectionId()).isEqualTo(origin);
               assertThat(g.inheritedFromCollectionTitle()).isEqualTo("role-inverse-origin");
             });
+
+    // Converting the inherited copy to a direct grant records the acting admin, not the
+    // inherited row's null actor.
+    long actor = seedUser("Provenance Admin");
+    repo.setCollectionGrant(roleId, child, AccessLevel.CLIENT, actor);
+    assertThat(
+            jdbc.queryForObject(
+                "SELECT granted_by FROM role_collection WHERE role_id=? AND collection_id=?",
+                Long.class,
+                roleId,
+                child))
+        .isEqualTo(actor);
+    assertThat(repo.rolesGrantingCollection(child))
+        .singleElement()
+        .satisfies(g -> assertThat(g.inheritedFromCollectionId()).isNull());
   }
 
   @Test

--- a/src/test/java/edens/zac/portfolio/backend/dao/RoleRepositoryIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/dao/RoleRepositoryIntegrationTest.java
@@ -153,6 +153,34 @@ class RoleRepositoryIntegrationTest extends AbstractPostgresIntegrationTest {
     assertThat(grants)
         .extracting(CollectionRoleGrant::roleId, CollectionRoleGrant::level)
         .containsExactly(tuple(r1, AccessLevel.GENERAL), tuple(r2, AccessLevel.CLIENT));
+    // Direct grants carry no waterfall provenance.
+    assertThat(grants)
+        .allSatisfy(
+            g -> {
+              assertThat(g.inheritedFromCollectionId()).isNull();
+              assertThat(g.inheritedFromCollectionTitle()).isNull();
+            });
+  }
+
+  @Test
+  void rolesGrantingCollectionExposesInheritanceProvenance() {
+    long origin = seedCollection("role-inverse-origin");
+    long child = seedCollection("role-inverse-inherited");
+    long roleId = repo.createRole("waterfall crew", RoleKind.SHARED, null);
+    repo.setCollectionGrant(roleId, origin, AccessLevel.CLIENT, null);
+    repo.insertInheritedGrant(roleId, child, AccessLevel.CLIENT, origin);
+
+    List<CollectionRoleGrant> grants = repo.rolesGrantingCollection(child);
+
+    assertThat(grants)
+        .singleElement()
+        .satisfies(
+            g -> {
+              assertThat(g.roleId()).isEqualTo(roleId);
+              assertThat(g.level()).isEqualTo(AccessLevel.CLIENT);
+              assertThat(g.inheritedFromCollectionId()).isEqualTo(origin);
+              assertThat(g.inheritedFromCollectionTitle()).isEqualTo("role-inverse-origin");
+            });
   }
 
   @Test

--- a/src/test/java/edens/zac/portfolio/backend/services/CollectionServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/CollectionServiceTest.java
@@ -71,6 +71,7 @@ class CollectionServiceTest {
   @Mock private TagViewResolver tagViewResolver;
   @Mock private ClientGalleryAuthService clientGalleryAuthService;
   @Mock private CollectionAccessService collectionAccessService;
+  @Mock private RoleGrantPropagationService roleGrantPropagationService;
 
   @Mock
   private edens.zac.portfolio.backend.dao.CollectionSiblingRepository collectionSiblingRepository;

--- a/src/test/java/edens/zac/portfolio/backend/services/RoleGrantPropagationServiceIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/RoleGrantPropagationServiceIntegrationTest.java
@@ -272,6 +272,34 @@ class RoleGrantPropagationServiceIntegrationTest extends AbstractPostgresIntegra
   }
 
   @Test
+  void demotingParentGrantLowersInheritedCopiesButDirectChildGrantSurvives() {
+    long user = seedUser("Wf-Demote");
+    long parent = seedCollection("wf-dm-parent");
+    long child = seedCollection("wf-dm-child");
+    long grandchild = seedCollection("wf-dm-grandchild");
+    long directChild = seedCollection("wf-dm-direct");
+    collectionService.linkCollectionToParent(parent, child);
+    collectionService.linkCollectionToParent(child, grandchild);
+    collectionService.linkCollectionToParent(parent, directChild);
+    long roleId = seedMemberRole("role:wf-dm", user);
+    propagation.setGrant(roleId, parent, AccessLevel.CLIENT, null);
+    propagation.setGrant(roleId, directChild, AccessLevel.CLIENT, null);
+    assertThat(roleRepository.isClient(user, grandchild)).isTrue();
+
+    propagation.setGrant(roleId, parent, AccessLevel.GENERAL, null);
+
+    // Inherited copies follow the demotion through the real resolution path.
+    assertThat(roleRepository.canView(user, child)).isTrue();
+    assertThat(roleRepository.isClient(user, child)).isFalse();
+    assertThat(roleRepository.canView(user, grandchild)).isTrue();
+    assertThat(roleRepository.isClient(user, grandchild)).isFalse();
+    assertThat(inheritedFrom(roleId, child)).isEqualTo(parent);
+    // A child's own direct CLIENT grant is sticky through the demotion.
+    assertThat(roleRepository.isClient(user, directChild)).isTrue();
+    assertThat(inheritedFrom(roleId, directChild)).isNull();
+  }
+
+  @Test
   void removingDirectChildGrantRematerializesInheritedCopy() {
     long user = seedUser("Wf-Sticky");
     long parent = seedCollection("wf-st-parent");

--- a/src/test/java/edens/zac/portfolio/backend/services/RoleGrantPropagationServiceIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/RoleGrantPropagationServiceIntegrationTest.java
@@ -1,0 +1,313 @@
+package edens.zac.portfolio.backend.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import edens.zac.portfolio.backend.AbstractPostgresIntegrationTest;
+import edens.zac.portfolio.backend.dao.RoleRepository;
+import edens.zac.portfolio.backend.model.CollectionRequests;
+import edens.zac.portfolio.backend.model.Records;
+import edens.zac.portfolio.backend.types.AccessLevel;
+import edens.zac.portfolio.backend.types.RoleKind;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Waterfall role grants (V47): a grant on a parent collection is materialized onto every visible
+ * descendant as an inherited {@code role_collection} row, and the untouched resolution queries
+ * ({@code canView}/{@code isClient}/{@code memberCollectionIdsForUser}) already see them. Covers
+ * the four sync hooks (grant, remove, link, unlink), the direct-wins-and-is-sticky conflict rule,
+ * CLIENT-beats-GENERAL upgrades, re-materialization from surviving ancestors, and the {@code
+ * cc.visible = false} gate.
+ */
+class RoleGrantPropagationServiceIntegrationTest extends AbstractPostgresIntegrationTest {
+
+  @Autowired private RoleGrantPropagationService propagation;
+  @Autowired private RoleRepository roleRepository;
+  @Autowired private CollectionService collectionService;
+  @Autowired private JdbcTemplate jdbc;
+
+  private long seedUser(String name) {
+    jdbc.update(
+        "INSERT INTO users (name, webauthn_user_handle, status) VALUES (?, gen_random_uuid(), 'ACTIVE')",
+        name);
+    return jdbc.queryForObject("SELECT id FROM users WHERE name=?", Long.class, name);
+  }
+
+  private long seedCollection(String slug) {
+    jdbc.update(
+        "INSERT INTO collection (title, slug, type, visibility) VALUES (?, ?, 'CLIENT_GALLERY', 'UNLISTED')",
+        slug,
+        slug);
+    return jdbc.queryForObject("SELECT id FROM collection WHERE slug=?", Long.class, slug);
+  }
+
+  private long seedMemberRole(String roleName, long userId) {
+    long roleId = roleRepository.createRole(roleName, RoleKind.SHARED, null);
+    roleRepository.addMember(roleId, userId, null);
+    return roleId;
+  }
+
+  /** Hide the parent-to-child membership link ({@code cc.visible = false}). */
+  private void hideLink(long parentId, long childId) {
+    jdbc.update(
+        "UPDATE collection_content cc SET visible = false FROM content_collection cct"
+            + " WHERE cc.content_id = cct.id AND cc.collection_id = ?"
+            + " AND cct.referenced_collection_id = ?",
+        parentId,
+        childId);
+  }
+
+  private int grantRowCount(long roleId, long collectionId) {
+    return jdbc.queryForObject(
+        "SELECT count(*) FROM role_collection WHERE role_id=? AND collection_id=?",
+        Integer.class,
+        roleId,
+        collectionId);
+  }
+
+  private Long inheritedFrom(long roleId, long collectionId) {
+    return jdbc.queryForObject(
+        "SELECT inherited_from_collection_id FROM role_collection"
+            + " WHERE role_id=? AND collection_id=?",
+        Long.class,
+        roleId,
+        collectionId);
+  }
+
+  /** An update DTO that only removes the given child collections from the parent. */
+  private static CollectionRequests.Update removeChildrenUpdate(
+      long parentId, List<Long> childIds) {
+    return new CollectionRequests.Update(
+        parentId,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        new CollectionRequests.CollectionUpdate(null, null, childIds),
+        null);
+  }
+
+  /** An update DTO that only adds the given child collection to the parent. */
+  private static CollectionRequests.Update addChildUpdate(
+      long parentId, long childId, Boolean visible) {
+    Records.ChildCollection child =
+        new Records.ChildCollection(childId, null, null, null, visible, null);
+    return new CollectionRequests.Update(
+        parentId,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        new CollectionRequests.CollectionUpdate(null, List.of(child), null),
+        null);
+  }
+
+  @Test
+  void grantOnParentWaterfallsToEveryDescendant() {
+    long user = seedUser("Wf-Parent");
+    long parent = seedCollection("wf-pnwer");
+    long child1 = seedCollection("wf-pnwer-2025");
+    long child2 = seedCollection("wf-pnwer-2026");
+    long grandchild = seedCollection("wf-pnwer-2025-day1");
+    collectionService.linkCollectionToParent(parent, child1);
+    collectionService.linkCollectionToParent(parent, child2);
+    collectionService.linkCollectionToParent(child1, grandchild);
+    long roleId = seedMemberRole("role:wf-pnwer", user);
+
+    propagation.setGrant(roleId, parent, AccessLevel.CLIENT, null);
+
+    for (long coll : new long[] {parent, child1, child2, grandchild}) {
+      assertThat(roleRepository.canView(user, coll)).isTrue();
+      assertThat(roleRepository.isClient(user, coll)).isTrue();
+    }
+    assertThat(roleRepository.memberCollectionIdsForUser(user))
+        .containsExactlyInAnyOrder(parent, child1, child2, grandchild);
+    // Provenance: descendants carry the ORIGIN (the parent), the parent row is direct.
+    assertThat(inheritedFrom(roleId, parent)).isNull();
+    assertThat(inheritedFrom(roleId, child1)).isEqualTo(parent);
+    assertThat(inheritedFrom(roleId, child2)).isEqualTo(parent);
+    assertThat(inheritedFrom(roleId, grandchild)).isEqualTo(parent);
+  }
+
+  @Test
+  void childLinkedAfterGrantInheritsWithItsSubtree() {
+    long user = seedUser("Wf-Link");
+    long parent = seedCollection("wf-link-parent");
+    long child = seedCollection("wf-link-child");
+    long grandchild = seedCollection("wf-link-grandchild");
+    collectionService.linkCollectionToParent(child, grandchild);
+    long roleId = seedMemberRole("role:wf-link", user);
+    propagation.setGrant(roleId, parent, AccessLevel.CLIENT, null);
+    assertThat(roleRepository.canView(user, child)).isFalse();
+
+    collectionService.linkCollectionToParent(parent, child);
+
+    assertThat(roleRepository.isClient(user, child)).isTrue();
+    assertThat(roleRepository.isClient(user, grandchild)).isTrue();
+    assertThat(inheritedFrom(roleId, child)).isEqualTo(parent);
+    assertThat(inheritedFrom(roleId, grandchild)).isEqualTo(parent);
+  }
+
+  @Test
+  void childAddedThroughCollectionUpdateFlowInherits() {
+    long user = seedUser("Wf-UpdateAdd");
+    long parent = seedCollection("wf-upd-parent");
+    long child = seedCollection("wf-upd-child");
+    long roleId = seedMemberRole("role:wf-upd", user);
+    propagation.setGrant(roleId, parent, AccessLevel.CLIENT, null);
+
+    collectionService.updateContent(parent, addChildUpdate(parent, child, null));
+
+    assertThat(roleRepository.isClient(user, child)).isTrue();
+    assertThat(inheritedFrom(roleId, child)).isEqualTo(parent);
+  }
+
+  @Test
+  void childAddedHiddenThroughCollectionUpdateFlowDoesNotInherit() {
+    long user = seedUser("Wf-UpdateHidden");
+    long parent = seedCollection("wf-updh-parent");
+    long child = seedCollection("wf-updh-child");
+    long roleId = seedMemberRole("role:wf-updh", user);
+    propagation.setGrant(roleId, parent, AccessLevel.CLIENT, null);
+
+    collectionService.updateContent(parent, addChildUpdate(parent, child, false));
+
+    assertThat(roleRepository.canView(user, child)).isFalse();
+    assertThat(grantRowCount(roleId, child)).isZero();
+  }
+
+  @Test
+  void removingParentGrantStripsInheritedButDirectChildGrantSurvives() {
+    long user = seedUser("Wf-Remove");
+    long parent = seedCollection("wf-rm-parent");
+    long keeper = seedCollection("wf-rm-keeper");
+    long loser = seedCollection("wf-rm-loser");
+    collectionService.linkCollectionToParent(parent, keeper);
+    collectionService.linkCollectionToParent(parent, loser);
+    long roleId = seedMemberRole("role:wf-rm", user);
+    propagation.setGrant(roleId, parent, AccessLevel.GENERAL, null);
+    // Direct grant on one child: converts its inherited copy into a sticky direct row.
+    propagation.setGrant(roleId, keeper, AccessLevel.CLIENT, null);
+
+    propagation.removeGrant(roleId, parent);
+
+    assertThat(roleRepository.canView(user, parent)).isFalse();
+    assertThat(roleRepository.canView(user, loser)).isFalse();
+    assertThat(roleRepository.isClient(user, keeper)).isTrue();
+    assertThat(inheritedFrom(roleId, keeper)).isNull();
+  }
+
+  @Test
+  void unlinkingChildStripsOnlyItsSubtree() {
+    long user = seedUser("Wf-Unlink");
+    long parent = seedCollection("wf-ul-parent");
+    long unlinked = seedCollection("wf-ul-child");
+    long grandchild = seedCollection("wf-ul-grandchild");
+    long sibling = seedCollection("wf-ul-sibling");
+    collectionService.linkCollectionToParent(parent, unlinked);
+    collectionService.linkCollectionToParent(unlinked, grandchild);
+    collectionService.linkCollectionToParent(parent, sibling);
+    long roleId = seedMemberRole("role:wf-ul", user);
+    propagation.setGrant(roleId, parent, AccessLevel.CLIENT, null);
+    assertThat(roleRepository.isClient(user, grandchild)).isTrue();
+
+    collectionService.updateContent(parent, removeChildrenUpdate(parent, List.of(unlinked)));
+
+    assertThat(roleRepository.canView(user, unlinked)).isFalse();
+    assertThat(roleRepository.canView(user, grandchild)).isFalse();
+    assertThat(roleRepository.isClient(user, sibling)).isTrue();
+    assertThat(roleRepository.isClient(user, parent)).isTrue();
+  }
+
+  @Test
+  void clientBeatsGeneralAcrossOriginsAndRemovalRematerializesFromAncestor() {
+    long user = seedUser("Wf-Level");
+    long grandparent = seedCollection("wf-lvl-grandparent");
+    long parent = seedCollection("wf-lvl-parent");
+    long child = seedCollection("wf-lvl-child");
+    collectionService.linkCollectionToParent(grandparent, parent);
+    collectionService.linkCollectionToParent(parent, child);
+    long roleId = seedMemberRole("role:wf-lvl", user);
+
+    propagation.setGrant(roleId, grandparent, AccessLevel.GENERAL, null);
+    assertThat(roleRepository.canView(user, child)).isTrue();
+    assertThat(roleRepository.isClient(user, child)).isFalse();
+
+    // CLIENT on the middle collection upgrades the child's inherited copy (new origin: parent).
+    propagation.setGrant(roleId, parent, AccessLevel.CLIENT, null);
+    assertThat(roleRepository.isClient(user, child)).isTrue();
+    assertThat(inheritedFrom(roleId, child)).isEqualTo(parent);
+
+    // Removing the CLIENT grant re-materializes GENERAL from the surviving grandparent grant.
+    propagation.removeGrant(roleId, parent);
+    assertThat(roleRepository.canView(user, parent)).isTrue();
+    assertThat(roleRepository.isClient(user, parent)).isFalse();
+    assertThat(roleRepository.canView(user, child)).isTrue();
+    assertThat(roleRepository.isClient(user, child)).isFalse();
+    assertThat(inheritedFrom(roleId, child)).isEqualTo(grandparent);
+  }
+
+  @Test
+  void removingDirectChildGrantRematerializesInheritedCopy() {
+    long user = seedUser("Wf-Sticky");
+    long parent = seedCollection("wf-st-parent");
+    long child = seedCollection("wf-st-child");
+    collectionService.linkCollectionToParent(parent, child);
+    long roleId = seedMemberRole("role:wf-st", user);
+    propagation.setGrant(roleId, parent, AccessLevel.GENERAL, null);
+    propagation.setGrant(roleId, child, AccessLevel.CLIENT, null);
+    assertThat(roleRepository.isClient(user, child)).isTrue();
+
+    propagation.removeGrant(roleId, child);
+
+    assertThat(roleRepository.canView(user, child)).isTrue();
+    assertThat(roleRepository.isClient(user, child)).isFalse();
+    assertThat(inheritedFrom(roleId, child)).isEqualTo(parent);
+  }
+
+  @Test
+  void hiddenLinkBlocksInheritanceForChildAndItsSubtree() {
+    long user = seedUser("Wf-Hidden");
+    long parent = seedCollection("wf-hd-parent");
+    long visible = seedCollection("wf-hd-visible");
+    long hidden = seedCollection("wf-hd-hidden");
+    long hiddenChild = seedCollection("wf-hd-hidden-child");
+    collectionService.linkCollectionToParent(parent, visible);
+    collectionService.linkCollectionToParent(parent, hidden);
+    collectionService.linkCollectionToParent(hidden, hiddenChild);
+    hideLink(parent, hidden);
+    long roleId = seedMemberRole("role:wf-hd", user);
+
+    propagation.setGrant(roleId, parent, AccessLevel.CLIENT, null);
+
+    assertThat(roleRepository.isClient(user, visible)).isTrue();
+    assertThat(roleRepository.canView(user, hidden)).isFalse();
+    assertThat(roleRepository.canView(user, hiddenChild)).isFalse();
+    assertThat(grantRowCount(roleId, hidden)).isZero();
+    assertThat(grantRowCount(roleId, hiddenChild)).isZero();
+  }
+}


### PR DESCRIPTION
## Problem

A SHARED role (e.g. `role:pnwer`) granted the PNWER parent collection must reach every child
collection (pnwer 2018..2026), including children added in the future. Today resolution is
strictly per-`collection_id` -- a parent grant does not waterfall.

## Design (spec 2026-07-17, Part 1)

**Materialized write-time propagation.** Inherited grants are real `role_collection` rows, so the
read path stays flat. V47 adds `inherited_from_collection_id BIGINT NULL REFERENCES collection(id)
ON DELETE CASCADE` (+ index):

- `NULL` -> direct grant (unchanged meaning of every pre-V47 row)
- `= X` -> inherited copy whose ORIGIN (the collection holding the direct grant) is `X`, making
  removal a single `DELETE ... WHERE inherited_from_collection_id = X`

**Resolution queries untouched -- please verify the zero-diff.** `RoleRepository.canView` /
`isClient` / `memberCollectionIdsForUser` / `effectiveGrants` and `CollectionAccessService` have no
diff on this branch (`git diff main -- .../RoleRepository.java` shows only additive methods; the
`CollectionAccessService` diff is empty). That is the entire point of the materialized approach.

## Conflict rule (spec 4.4)

- **Direct wins and is sticky**: propagation never clobbers or downgrades a direct row.
- Inherited-onto-inherited keeps the higher level (CLIENT beats GENERAL); on upgrade the origin
  moves with the level.
- **Demotion propagates** (review fix): demoting a grant (CLIENT -> GENERAL) strips that origin's
  inherited copies and re-propagates at the new level, then re-materializes whatever the subtree
  still inherits from surviving ancestor grants -- so descendants follow the demotion, a
  descendant covered by a higher ancestor grant keeps its higher level, and a child's own direct
  grant stays sticky through it.
- Removing a direct grant the collection still inherits re-materializes the inherited copy from
  the surviving ancestor origin.
- An explicit admin grant on a collection that currently holds an inherited copy converts it to a
  direct row (`setCollectionGrant` clears provenance on conflict and, per review, refreshes
  `granted_by`/`granted_at` so the promotion records the acting admin instead of keeping the
  inherited row's null actor).

### Sticky rule -- needs your explicit confirmation, Zac

Adopted as written from the spec, but it was flagged as unconfirmed: **when a role's grant on the
parent is removed, a child's own direct grant survives** (an admin who deliberately granted
`pnwer 2024` directly keeps that grant even after the PNWER-wide grant is revoked). The
alternative -- child direct grants are removed together with the parent's grant -- was NOT chosen.
If you want the alternative, say so and the removal hook gets a small change.

## The four hooks (all inside existing @Transactional writes)

1. **Grant/raise** (`AdminRoleController.setGrant` -> `RoleGrantPropagationService.setGrant`):
   upsert direct row, propagate to all visible descendants (origin = this collection).
2. **Remove** (`AdminRoleController.removeGrant` -> `removeGrant`): delete row +
   `removeInheritedGrantsByOrigin`, then re-materialize anything still inherited from a surviving
   ancestor grant.
3. **Link child** (`CollectionService.linkCollectionToParent`, and the collection-update
   `newValue` add path, which creates links without going through `linkCollectionToParent`): copy
   every grant the parent holds into the child subtree, preserving each grant's origin. Hidden
   (`visible=false`) adds do not waterfall.
4. **Unlink child** (verified to exist: `CollectionService.handleCollectionToCollectionUpdates`
   step 1 `remove`, reached via `updateContent` and the inverse `parents.remove` path): strip
   inherited copies in the child subtree whose origin is at/above the removed parent. Grants
   originating inside the subtree survive.

## Backfill (same V47 migration)

One-time `WITH RECURSIVE` walk over `collection_content`/`content_collection`, gated on
`cc.visible = true`, inserting inherited copies for every descendant lacking a direct grant for
that role (`ON CONFLICT DO NOTHING`; CLIENT preferred when reachable from origins at different
levels; `UNION` recursion terminates on cycles).

## Visibility consistency

The backfill gates on `cc.visible = true`, so runtime propagation honors the same gate: a new
targeted repo method `CollectionRepository.findVisibleReferencedCollectionIdsByParentId` (filters
only the membership `cc.visible` flag, NOT the child's own `visibility` -- UNLISTED client
galleries still inherit). The existing visibility-agnostic
`findAllReferencedCollectionsByParentId` is reused unchanged for removal walks so stale copies are
always stripped, and the LISTED-filtered helper (known bug) is not used anywhere.

Known limitation (out of Part 1 scope, follow-up candidate): toggling an existing link's
`visible` flag does not re-sync grants; only grant/remove/link/unlink do.

## Tests

- `RoleGrantPropagationServiceIntegrationTest` (9 tests): parent grant reaches every descendant
  (canView/isClient/memberCollectionIdsForUser + provenance rows); child linked after the grant
  inherits with its subtree (both link paths); hidden link blocks inheritance; removing the parent
  grant strips inherited rows while a child's direct grant survives; unlink strips only that
  child's subtree; CLIENT beats GENERAL across origins; removal re-materializes from surviving
  ancestors (both directions).
- `RoleWaterfallMigrationIntegrationTest`: seeds a pre-waterfall state and re-runs the V47
  backfill statement verbatim (same pattern as `RoleMigrationIntegrationTest` for V45).
- `AdminRoleControllerTest` updated for the rerouted grant endpoints.

## Provenance retrofit (B/C reconciliation)

`feat/collection-roles-endpoint` (#126) merged first, so this PR (rebased onto it) now also
carries the planned retrofit: `GET /api/admin/collections/{id}/roles` exposes
`inheritedFromCollectionId` and `inheritedFromCollectionTitle` on each row (both `null` for
direct grants; inherited rows carry the origin collection's id and title via a `LEFT JOIN
collection` in `rolesGrantingCollection`). Pinned contract -- the companion admin UI (badge +
lock inherited rows) is being built against exactly these JSON fields on `edens.zac` branch
`collection-roles-inherited-badge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
