### PR TITLE
perf(collections): fix home-read N+1 and cold metadata rebuild latency

### DIFF
--- a/src/main/java/edens/zac/portfolio/backend/services/CollectionProcessingUtil.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/CollectionProcessingUtil.java
@@ -10,6 +10,7 @@ import edens.zac.portfolio.backend.dao.PersonRepository;
 import edens.zac.portfolio.backend.dao.TagRepository;
 import edens.zac.portfolio.backend.entity.CollectionContentEntity;
 import edens.zac.portfolio.backend.entity.CollectionEntity;
+import edens.zac.portfolio.backend.entity.ContentCollectionEntity;
 import edens.zac.portfolio.backend.entity.ContentEntity;
 import edens.zac.portfolio.backend.entity.ContentImageEntity;
 import edens.zac.portfolio.backend.entity.ContentPersonEntity;
@@ -239,18 +240,52 @@ public class CollectionProcessingUtil {
       contentMap = new HashMap<>();
     }
 
-    // Batch-load tags, people, and locations for all IMAGE content to avoid N+1 queries
+    // Batch-load referenced collections and their cover images for any child-collection tile
+    // blocks, so a parent/home collection with N tiles stays at a constant query count instead of
+    // firing findById + findImageById (+ per-image metadata) for every tile.
+    List<Long> referencedCollectionIds =
+        contentMap.values().stream()
+            .filter(ContentCollectionEntity.class::isInstance)
+            .map(c -> ((ContentCollectionEntity) c).getReferencedCollection())
+            .filter(Objects::nonNull)
+            .map(CollectionEntity::getId)
+            .filter(Objects::nonNull)
+            .distinct()
+            .toList();
+    Map<Long, CollectionEntity> referencedCollectionsById =
+        referencedCollectionIds.isEmpty()
+            ? Map.of()
+            : collectionRepository.findByIds(referencedCollectionIds).stream()
+                .collect(Collectors.toMap(CollectionEntity::getId, c -> c));
+    List<Long> coverImageIds =
+        referencedCollectionsById.values().stream()
+            .map(CollectionEntity::getCoverImageId)
+            .filter(Objects::nonNull)
+            .distinct()
+            .toList();
+    Map<Long, ContentImageEntity> coverImagesById =
+        coverImageIds.isEmpty()
+            ? Map.of()
+            : contentRepository.findImagesByIds(coverImageIds).stream()
+                .collect(Collectors.toMap(ContentImageEntity::getId, img -> img));
+
+    // Batch-load tags, people, and locations for all IMAGE content AND all tile cover images in
+    // three queries total, to avoid N+1 queries.
     List<Long> imageContentIds =
         contentMap.values().stream()
             .filter(c -> c.getContentType() == ContentType.IMAGE)
             .map(ContentEntity::getId)
             .toList();
+    List<Long> metadataContentIds = new ArrayList<>(imageContentIds);
+    coverImageIds.stream()
+        .filter(id -> !metadataContentIds.contains(id))
+        .forEach(metadataContentIds::add);
     Map<Long, List<TagEntity>> tagsByContentId =
-        tagRepository.findTagsByContentIds(imageContentIds);
+        tagRepository.findTagsByContentIds(metadataContentIds);
     Map<Long, List<ContentPersonEntity>> peopleByContentId =
-        personRepository.findPeopleByContentIds(imageContentIds);
+        personRepository.findPeopleByContentIds(metadataContentIds);
     Map<Long, List<LocationEntity>> locationsByContentId =
-        locationRepository.findLocationsByContentIds(imageContentIds);
+        locationRepository.findLocationsByContentIds(metadataContentIds);
 
     // Convert join table entries to content models with collection-specific metadata
     List<ContentModel> contents =
@@ -277,7 +312,19 @@ public class CollectionProcessingUtil {
                         peopleByContentId,
                         locationsByContentId);
                   }
-                  // For other content types, use the standard conversion
+                  // For child-collection tiles, use batch-loaded referenced collections + cover
+                  // images to avoid per-tile N+1 queries.
+                  if (content instanceof ContentCollectionEntity collectionContent) {
+                    return contentModelConverter.buildCollectionModelWithBatchData(
+                        collectionContent,
+                        cc,
+                        referencedCollectionsById,
+                        coverImagesById,
+                        tagsByContentId,
+                        peopleByContentId,
+                        locationsByContentId);
+                  }
+                  // For other content types (TEXT, GIF), use the standard conversion
                   return contentModelConverter.convertBulkLoadedContentToModel(content, cc);
                 })
             .filter(Objects::nonNull)

--- a/src/main/java/edens/zac/portfolio/backend/services/CollectionService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/CollectionService.java
@@ -44,6 +44,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.core.env.Environment;
@@ -78,6 +80,13 @@ public class CollectionService {
   private final CollectionAccessService collectionAccessService;
   private final RoleGrantPropagationService roleGrantPropagationService;
   private final Environment springEnv;
+  private final CacheManager cacheManager;
+
+  // Self-reference through the Spring proxy. Required so internal calls to the @Cacheable
+  // getGeneralMetadata() are intercepted by the caching aspect; a direct this.getGeneralMetadata()
+  // is self-invoked and silently bypasses the cache. ObjectProvider is resolved lazily, so this
+  // does not create a circular-dependency failure at startup.
+  private final ObjectProvider<CollectionService> selfProvider;
 
   private static final int DEFAULT_PAGE_SIZE = default_content_per_page;
   private static final String HOME_SLUG = "home";
@@ -487,10 +496,6 @@ public class CollectionService {
   }
 
   @Transactional
-  @CacheEvict(
-      value = "generalMetadata",
-      allEntries = true,
-      condition = "#updateDTO != null && (#updateDTO.title != null || #updateDTO.slug != null)")
   public CollectionModel updateContent(Long id, CollectionRequests.Update updateDTO) {
     log.debug("Updating collection with ID: {}", id);
 
@@ -500,6 +505,14 @@ public class CollectionService {
             .findById(id)
             .orElseThrow(
                 () -> new ResourceNotFoundException("Collection not found with ID: " + id));
+
+    // Capture identity fields before mutation. The shared generalMetadata cache embeds the
+    // collection id/title/slug list, so it only needs invalidating when one of those actually
+    // changes. The previous blanket @CacheEvict fired on every save that merely included a title
+    // or slug in its payload (which the manage page always does), forcing a cold rebuild of all
+    // tags/people/locations metadata mid-save.
+    final String previousTitle = entity.getTitle();
+    final String previousSlug = entity.getSlug();
 
     // Update basic properties via utility helper
     collectionProcessingUtil.applyBasicUpdates(entity, updateDTO);
@@ -532,25 +545,53 @@ public class CollectionService {
     // Save updated entity
     CollectionEntity savedEntity = collectionRepository.save(entity);
 
+    // Only invalidate the shared metadata cache when the identity fields it embeds changed.
+    // applyBasicUpdates already mutated the managed entity, so compare against it directly.
+    if (!Objects.equals(previousTitle, entity.getTitle())
+        || !Objects.equals(previousSlug, entity.getSlug())) {
+      evictGeneralMetadataCache();
+    }
+
     // Return lightweight model without loading all content to avoid N+1 queries
     // Frontend can refetch full content if needed
     return collectionProcessingUtil.convertToBasicModel(savedEntity);
   }
 
+  /**
+   * Manually evict the shared {@code generalMetadata} cache. Used from methods that update it via
+   * self-invocation, where Spring's proxy-based {@link CacheEvict} cannot intercept.
+   */
+  private void evictGeneralMetadataCache() {
+    var cache = cacheManager.getCache("generalMetadata");
+    if (cache != null) {
+      cache.clear();
+      log.debug("Evicted generalMetadata cache after collection identity change");
+    }
+  }
+
   @Transactional
-  @CacheEvict(
-      value = "generalMetadata",
-      allEntries = true,
-      condition = "#updateDTO != null && (#updateDTO.title != null || #updateDTO.slug != null)")
   public CollectionRequests.UpdateResponse updateContentWithMetadata(
       Long id, CollectionRequests.Update updateDTO) {
     log.debug("Updating collection with ID: {} (with metadata response)", id);
 
-    // Perform the update
+    // Perform the update (handles its own conditional metadata-cache invalidation)
+    long writeStart = System.nanoTime();
     CollectionModel updatedCollection = updateContent(id, updateDTO);
+    long writeEnd = System.nanoTime();
 
     // Get the full update response with metadata using the new slug
-    return getUpdateCollectionData(updatedCollection.getSlug());
+    CollectionRequests.UpdateResponse response =
+        getUpdateCollectionData(updatedCollection.getSlug());
+    long refetchEnd = System.nanoTime();
+
+    log.info(
+        "updateContentWithMetadata timing [collection {}]: write={}ms refetch={}ms total={}ms",
+        id,
+        (writeEnd - writeStart) / 1_000_000,
+        (refetchEnd - writeEnd) / 1_000_000,
+        (refetchEnd - writeStart) / 1_000_000);
+
+    return response;
   }
 
   /**
@@ -670,14 +711,25 @@ public class CollectionService {
   public CollectionRequests.UpdateResponse getUpdateCollectionData(String slug) {
     log.debug("Getting update collection data for slug: {}", slug);
 
-    // Get the collection
+    // Get the collection (loads the full, unpaginated content list)
+    long contentStart = System.nanoTime();
     CollectionModel collection =
         findBySlug(slug)
             .orElseThrow(
                 () -> new ResourceNotFoundException("Collection not found with slug: " + slug));
+    long contentEnd = System.nanoTime();
 
-    // Get all general metadata using helper method
-    final GeneralMetadataDTO metadata = getGeneralMetadata();
+    // Get all general metadata. Routed through the Spring proxy (selfProvider) so the @Cacheable
+    // on getGeneralMetadata is honored -- a direct this.getGeneralMetadata() is self-invoked and
+    // bypasses the cache, running every metadata query on each request.
+    final GeneralMetadataDTO metadata = selfProvider.getObject().getGeneralMetadata();
+    long metadataEnd = System.nanoTime();
+
+    log.info(
+        "getUpdateCollectionData timing [slug {}]: contentLoad={}ms metadata={}ms",
+        slug,
+        (contentEnd - contentStart) / 1_000_000,
+        (metadataEnd - contentEnd) / 1_000_000);
 
     // For parent-type collections, aggregate images from child collections
     List<ContentModels.Image> childCollectionImages = null;

--- a/src/main/java/edens/zac/portfolio/backend/services/ContentModelConverter.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/ContentModelConverter.java
@@ -492,6 +492,76 @@ class ContentModelConverter {
       }
     }
 
+    return buildCollectionRecord(contentEntity, referencedCollection, joinEntry, coverImage);
+  }
+
+  /**
+   * Batch-aware variant of {@link #convertCollectionToModel}. Resolves the referenced collection
+   * and its cover image (including the cover image's tags/people/locations) from pre-fetched maps
+   * rather than issuing per-tile queries. Used by the paginated collection read path so a
+   * parent/home collection with N child-collection tiles stays at a constant query count instead of
+   * an N+1.
+   *
+   * @param contentEntity The collection-reference content block to convert
+   * @param joinEntry The join table entry with collection-specific metadata (orderIndex, visible)
+   * @param referencedCollectionsById Pre-loaded referenced collections keyed by id
+   * @param coverImagesById Pre-loaded cover image entities keyed by id
+   * @param tagsByContentId Pre-loaded tags grouped by content id (covers cover-image ids)
+   * @param peopleByContentId Pre-loaded people grouped by content id (covers cover-image ids)
+   * @param locationsByContentId Pre-loaded locations grouped by content id (covers cover-image ids)
+   * @return The corresponding collection content model
+   */
+  public ContentModels.Collection buildCollectionModelWithBatchData(
+      ContentCollectionEntity contentEntity,
+      CollectionContentEntity joinEntry,
+      Map<Long, CollectionEntity> referencedCollectionsById,
+      Map<Long, ContentImageEntity> coverImagesById,
+      Map<Long, List<TagEntity>> tagsByContentId,
+      Map<Long, List<ContentPersonEntity>> peopleByContentId,
+      Map<Long, List<LocationEntity>> locationsByContentId) {
+    if (contentEntity == null) {
+      return null;
+    }
+
+    CollectionEntity referencedCollection = contentEntity.getReferencedCollection();
+    if (referencedCollection == null) {
+      log.error("ContentCollectionEntity {} has null referencedCollection", contentEntity.getId());
+      return null;
+    }
+
+    Long referencedCollectionId = referencedCollection.getId();
+    if (referencedCollectionId != null) {
+      referencedCollection =
+          referencedCollectionsById.getOrDefault(referencedCollectionId, referencedCollection);
+    }
+
+    ContentModels.Image coverImage = null;
+    Long coverImageId = referencedCollection.getCoverImageId();
+    if (coverImageId != null) {
+      ContentImageEntity coverImageEntity = coverImagesById.get(coverImageId);
+      if (coverImageEntity != null) {
+        coverImage =
+            buildImageModelWithBatchData(
+                coverImageEntity,
+                null,
+                null,
+                tagsByContentId,
+                peopleByContentId,
+                locationsByContentId);
+      }
+    }
+
+    return buildCollectionRecord(contentEntity, referencedCollection, joinEntry, coverImage);
+  }
+
+  /**
+   * Assemble the {@link ContentModels.Collection} record shared by the singular and batch paths.
+   */
+  private ContentModels.Collection buildCollectionRecord(
+      ContentCollectionEntity contentEntity,
+      CollectionEntity referencedCollection,
+      CollectionContentEntity joinEntry,
+      ContentModels.Image coverImage) {
     return new ContentModels.Collection(
         contentEntity.getId(),
         contentEntity.getContentType(),

--- a/src/test/java/edens/zac/portfolio/backend/services/CollectionServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/CollectionServiceTest.java
@@ -8,6 +8,9 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -47,6 +50,9 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -77,6 +83,8 @@ class CollectionServiceTest {
   private edens.zac.portfolio.backend.dao.CollectionSiblingRepository collectionSiblingRepository;
 
   @Mock private org.springframework.core.env.Environment springEnv;
+  @Mock private CacheManager cacheManager;
+  @Mock private ObjectProvider<CollectionService> selfProvider;
 
   @InjectMocks private CollectionService service;
 
@@ -104,6 +112,10 @@ class CollectionServiceTest {
             .type(CollectionType.PORTFOLIO)
             .visibility(CollectionVisibility.LISTED)
             .build();
+
+    // Route the metadata proxy call back to the service under test. Lenient because not every
+    // test exercises the getGeneralMetadata path.
+    lenient().when(selfProvider.getObject()).thenReturn(service);
   }
 
   @Nested
@@ -360,6 +372,105 @@ class CollectionServiceTest {
       service.updateContentWithMetadata(collectionId, updateDTO);
 
       verify(collectionProcessingUtil).applyBasicUpdates(testCollection, updateDTO);
+    }
+
+    @Test
+    void updateContentWithMetadata_identityUnchanged_doesNotEvictMetadataCache() {
+      Long collectionId = 1L;
+      // Description-only update: title and slug are null, so identity does not change and the
+      // shared generalMetadata cache must be left intact (this is the hot-path optimization).
+      CollectionRequests.Update updateDTO =
+          new CollectionRequests.Update(
+              collectionId,
+              null,
+              null,
+              null,
+              "New desc",
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null);
+
+      CollectionModel model =
+          CollectionModel.builder().id(1L).title("Test Collection").slug("test-collection").build();
+
+      when(collectionRepository.findById(collectionId)).thenReturn(Optional.of(testCollection));
+      when(collectionRepository.countContentByCollectionId(collectionId)).thenReturn(0L);
+      when(collectionRepository.save(any(CollectionEntity.class))).thenReturn(testCollection);
+      when(collectionProcessingUtil.convertToBasicModel(any(CollectionEntity.class)))
+          .thenReturn(model);
+      when(collectionProcessingUtil.convertToFullModel(any(CollectionEntity.class)))
+          .thenReturn(model);
+      when(collectionRepository.findBySlug("test-collection"))
+          .thenReturn(Optional.of(testCollection));
+      stubEmptyMetadata();
+
+      service.updateContentWithMetadata(collectionId, updateDTO);
+
+      verify(cacheManager, never()).getCache(anyString());
+    }
+
+    @Test
+    void updateContentWithMetadata_titleOrSlugChanged_evictsMetadataCache() {
+      Long collectionId = 1L;
+      CollectionRequests.Update updateDTO =
+          new CollectionRequests.Update(
+              collectionId,
+              null,
+              "New Title",
+              "new-slug",
+              "New desc",
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null);
+
+      CollectionModel model =
+          CollectionModel.builder().id(1L).title("New Title").slug("new-slug").build();
+      Cache metadataCache = mock(Cache.class);
+
+      // applyBasicUpdates is mocked, so make it actually mutate identity to simulate a rename.
+      doAnswer(
+              invocation -> {
+                testCollection.setTitle("New Title");
+                testCollection.setSlug("new-slug");
+                return null;
+              })
+          .when(collectionProcessingUtil)
+          .applyBasicUpdates(eq(testCollection), any(CollectionRequests.Update.class));
+
+      when(cacheManager.getCache("generalMetadata")).thenReturn(metadataCache);
+      when(collectionRepository.findById(collectionId)).thenReturn(Optional.of(testCollection));
+      when(collectionRepository.countContentByCollectionId(collectionId)).thenReturn(0L);
+      when(collectionRepository.save(any(CollectionEntity.class))).thenReturn(testCollection);
+      when(collectionProcessingUtil.convertToBasicModel(any(CollectionEntity.class)))
+          .thenReturn(model);
+      when(collectionProcessingUtil.convertToFullModel(any(CollectionEntity.class)))
+          .thenReturn(model);
+      when(collectionRepository.findBySlug("new-slug")).thenReturn(Optional.of(testCollection));
+      stubEmptyMetadata();
+
+      service.updateContentWithMetadata(collectionId, updateDTO);
+
+      verify(metadataCache).clear();
     }
   }
 

--- a/src/test/java/edens/zac/portfolio/backend/services/CollectionTileCoverImageBatchTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/CollectionTileCoverImageBatchTest.java
@@ -1,0 +1,175 @@
+package edens.zac.portfolio.backend.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import edens.zac.portfolio.backend.dao.CollectionPeopleRepository;
+import edens.zac.portfolio.backend.dao.CollectionRepository;
+import edens.zac.portfolio.backend.dao.CollectionSiblingRepository;
+import edens.zac.portfolio.backend.dao.ContentRepository;
+import edens.zac.portfolio.backend.dao.LocationRepository;
+import edens.zac.portfolio.backend.dao.PersonRepository;
+import edens.zac.portfolio.backend.dao.TagRepository;
+import edens.zac.portfolio.backend.entity.CollectionContentEntity;
+import edens.zac.portfolio.backend.entity.CollectionEntity;
+import edens.zac.portfolio.backend.entity.ContentCollectionEntity;
+import edens.zac.portfolio.backend.entity.ContentEntity;
+import edens.zac.portfolio.backend.entity.ContentImageEntity;
+import edens.zac.portfolio.backend.model.CollectionModel;
+import edens.zac.portfolio.backend.model.ContentModel;
+import edens.zac.portfolio.backend.model.ContentModels;
+import edens.zac.portfolio.backend.types.CollectionType;
+import edens.zac.portfolio.backend.types.ContentType;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Regression guard for the home / parent read path: a collection that contains child-collection
+ * tiles must batch-load the tiles' referenced collections and cover images, NOT issue per-tile
+ * queries. The per-tile path (findById + findImageById + per-image tags/people/locations) turned
+ * the home read into a ~30-query N+1 that cost ~7s over the remote-DB tunnel.
+ *
+ * <p>Wires a real {@link ContentModelConverter} into a real {@link CollectionProcessingUtil} so the
+ * query pattern of the actual read path is exercised end to end.
+ */
+@ExtendWith(MockitoExtension.class)
+class CollectionTileCoverImageBatchTest {
+
+  @Mock private CollectionRepository collectionRepository;
+  @Mock private CollectionPeopleRepository collectionPeopleRepository;
+  @Mock private CollectionSiblingRepository collectionSiblingRepository;
+  @Mock private ContentRepository contentRepository;
+  @Mock private ContentMutationUtil contentMutationUtil;
+  @Mock private LocationRepository locationRepository;
+  @Mock private TagRepository tagRepository;
+  @Mock private PersonRepository personRepository;
+
+  private CollectionProcessingUtil util;
+
+  @BeforeEach
+  void setUp() {
+    ContentModelConverter converter =
+        new ContentModelConverter(
+            contentRepository,
+            collectionRepository,
+            tagRepository,
+            personRepository,
+            locationRepository);
+    util =
+        new CollectionProcessingUtil(
+            collectionRepository,
+            collectionPeopleRepository,
+            collectionSiblingRepository,
+            contentRepository,
+            converter,
+            contentMutationUtil,
+            locationRepository,
+            tagRepository,
+            personRepository);
+  }
+
+  private ContentCollectionEntity tile(long contentId, long referencedCollectionId) {
+    CollectionEntity ref = new CollectionEntity();
+    ref.setId(referencedCollectionId);
+    return ContentCollectionEntity.builder()
+        .id(contentId)
+        .contentType(ContentType.COLLECTION)
+        .referencedCollection(ref)
+        .build();
+  }
+
+  private CollectionContentEntity join(long contentId, int orderIndex) {
+    return CollectionContentEntity.builder()
+        .id(contentId)
+        .collectionId(34L)
+        .contentId(contentId)
+        .orderIndex(orderIndex)
+        .visible(true)
+        .build();
+  }
+
+  @Test
+  void convertToModel_homeWithChildTiles_batchesCoverImagesWithoutPerTileQueries() {
+    CollectionEntity home = new CollectionEntity();
+    home.setId(34L);
+    home.setType(CollectionType.HOME);
+    home.setTitle("Home");
+    home.setSlug("home");
+
+    // Three child-collection tiles: content 101/102/103 -> collections 201/202/203.
+    List<CollectionContentEntity> joins = List.of(join(101L, 0), join(102L, 1), join(103L, 2));
+    List<ContentEntity> tiles = List.of(tile(101L, 201L), tile(102L, 202L), tile(103L, 203L));
+    when(contentRepository.findAllByIds(List.of(101L, 102L, 103L))).thenReturn(tiles);
+
+    // Referenced collections, each with a cover image (301/302/303).
+    CollectionEntity c201 =
+        CollectionEntity.builder()
+            .id(201L)
+            .title("Film")
+            .slug("film")
+            .type(CollectionType.PORTFOLIO)
+            .coverImageId(301L)
+            .build();
+    CollectionEntity c202 =
+        CollectionEntity.builder()
+            .id(202L)
+            .title("Adventure")
+            .slug("adventure")
+            .type(CollectionType.PORTFOLIO)
+            .coverImageId(302L)
+            .build();
+    CollectionEntity c203 =
+        CollectionEntity.builder()
+            .id(203L)
+            .title("Travel")
+            .slug("travel")
+            .type(CollectionType.PORTFOLIO)
+            .coverImageId(303L)
+            .build();
+    lenient()
+        .when(collectionRepository.findByIds(List.of(201L, 202L, 203L)))
+        .thenReturn(List.of(c201, c202, c203));
+
+    ContentImageEntity cover301 = ContentImageEntity.builder().id(301L).build();
+    ContentImageEntity cover302 = ContentImageEntity.builder().id(302L).build();
+    ContentImageEntity cover303 = ContentImageEntity.builder().id(303L).build();
+    lenient()
+        .when(contentRepository.findImagesByIds(List.of(301L, 302L, 303L)))
+        .thenReturn(List.of(cover301, cover302, cover303));
+
+    // Metadata batch loads must never be per-tile; return empty regardless of the id list.
+    lenient().when(tagRepository.findTagsByContentIds(anyList())).thenReturn(Map.of());
+    lenient().when(personRepository.findPeopleByContentIds(anyList())).thenReturn(Map.of());
+    lenient().when(locationRepository.findLocationsByContentIds(anyList())).thenReturn(Map.of());
+
+    CollectionModel model = util.convertToModel(home, joins, 0, 30, 3);
+
+    // Correctness: three tiles, titles + cover images resolved from the referenced collections.
+    assertThat(model.getContent()).hasSize(3);
+    ContentModel first = model.getContent().get(0);
+    assertThat(first).isInstanceOf(ContentModels.Collection.class);
+    ContentModels.Collection firstTile = (ContentModels.Collection) first;
+    assertThat(firstTile.title()).isEqualTo("Film");
+    assertThat(firstTile.referencedCollectionId()).isEqualTo(201L);
+    assertThat(firstTile.coverImage()).isNotNull();
+    assertThat(firstTile.coverImage().id()).isEqualTo(301L);
+
+    // The whole point: no per-tile lookups.
+    verify(collectionRepository, never()).findById(anyLong());
+    verify(contentRepository, never()).findImageById(anyLong());
+
+    // Batch lookups instead: one referenced-collection load, one cover-image load.
+    verify(collectionRepository).findByIds(List.of(201L, 202L, 203L));
+    verify(contentRepository).findImagesByIds(List.of(301L, 302L, 303L));
+  }
+}


### PR DESCRIPTION
## Summary

Two collection-latency fixes on this branch. The headline one (this session) removes an N+1 that made the homepage take ~19s on hard refresh.

### 1. Home-read N+1 on child-collection cover images (`4571da2`)

**Symptom:** `GET /api/read/collections/home` took ~7.5s (consistent, warm) for a 6-tile / 7.8KB response — the dominant chunk of a ~19s homepage hard-refresh.

**Root cause (confirmed via JVM thread dumps):** the paginated read rendered each child-collection tile's cover image through the *singular* converter path (`convertCollectionToModel` -> `convertImageToModel`), firing `findById` + `findImageById` + three per-image metadata queries **per tile**. 6 tiles => ~30 sequential queries; over the dev remote-DB SSH tunnel (~136ms/query measured) that stacked to ~7.5s. The 2026-04 read-perf pass batched the image-grid path but missed this collection-tile cover-image path.

**Fix:** in `CollectionProcessingUtil.convertToModel`, batch-load referenced collections (`findByIds`) and their cover images (`findImagesByIds`) once, fold the cover-image ids into the existing tags/people/locations batch (no extra queries), and route `COLLECTION` blocks through a new `ContentModelConverter.buildCollectionModelWithBatchData`. Per-tile queries collapse to **+2 constant queries**; response output is unchanged. `convertToFullModel` (the `findBySlug` path) benefits too.

**Test:** `CollectionTileCoverImageBatchTest` wires a real `ContentModelConverter` into a real `CollectionProcessingUtil` and asserts **no** per-tile `findById`/`findImageById` and a single batched `findByIds`/`findImagesByIds` (verified RED before the fix, GREEN after).

### 2. Cold metadata rebuild on every collection save (`41cc5d4`)

Stops the cold metadata rebuild that ran on every collection save; resolves image-visibility via roles and trims related dead code/tests.

## Verification

- Full suite: **1069 tests, 0 failures, 0 errors** (Testcontainers; confirmed passing independent of the dev DB tunnel).
- `spotless:apply` clean, `checkstyle:check` 0 violations.

## Manual review notes

- The wall-clock re-time (`~7.5s` -> sub-second on `GET /api/read/collections/home`) still needs a container rebuild in an env that has the shell secrets (`SPRING_PROFILES_ACTIVE`, `AWS_*`, `POSTGRES_PASSWORD`): `docker compose up -d --build backend`.
- The remaining ~11s of the 19s homepage load is frontend (`edens-zac`: `force-dynamic` home + Next dev compile + cover-image optimization) — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)