### PR TITLE
feat(collections): add isClient/isBlog as storage truth, with dual-compat type mapping

### DIFF
--- a/src/main/java/edens/zac/portfolio/backend/controller/admin/AdminController.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/admin/AdminController.java
@@ -378,13 +378,20 @@ class AdminController {
     return ResponseEntity.ok(Map.of("deletedId", deletedId));
   }
 
-  /** Create a new collection and upload images to it in one request. */
+  /**
+   * Create a new collection and upload images to it in one request. During the dual-compat window
+   * the legacy {@code type} param is optional and the {@code isClient}/{@code isBlog} booleans are
+   * accepted (booleans win; neither type nor booleans lands on MISC -- see {@code
+   * CollectionTypeCompat}).
+   */
   @PostMapping(
       value = "/content/images/create-collection",
       consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
   public ResponseEntity<ImageUploadResult> createCollectionWithImages(
       @RequestParam("title") String title,
-      @RequestParam("type") String type,
+      @RequestParam(value = "type", required = false) String type,
+      @RequestParam(value = "isClient", required = false) Boolean isClient,
+      @RequestParam(value = "isBlog", required = false) Boolean isBlog,
       @RequestParam(value = "description", required = false) String description,
       @RequestParam(value = "locationIds", required = false) List<Long> locationIds,
       @RequestParam(value = "locationNames", required = false) List<String> locationNames,
@@ -398,11 +405,18 @@ class AdminController {
           "No files provided. Use 'files' part with one or more images.");
     }
 
-    CollectionType collectionType = CollectionType.forValue(type);
+    CollectionType collectionType = type != null ? CollectionType.forValue(type) : null;
 
     CollectionRequests.Create createRequest =
         new CollectionRequests.Create(
-            collectionType, title, description, locationIds, locationNames, collectionDate);
+            collectionType,
+            title,
+            description,
+            locationIds,
+            locationNames,
+            collectionDate,
+            isClient,
+            isBlog);
 
     Map<String, String> rawFilePathMap = parseRawFilePaths(rawFilePaths);
     ImageUploadResult result =

--- a/src/main/java/edens/zac/portfolio/backend/dao/CollectionRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/CollectionRepository.java
@@ -39,7 +39,7 @@ public class CollectionRepository extends BaseDao {
 
   private static final String SELECT_COLLECTION =
       """
-      SELECT id, type, title, slug, description, collection_date, collection_end_date,
+      SELECT id, type, is_client, is_blog, title, slug, description, collection_date, collection_end_date,
              visibility, display_mode, cover_image_id, content_per_page, total_content,
              rows_wide, gallery_password, recipient_emails, rating, created_at, updated_at
       FROM collection
@@ -50,6 +50,8 @@ public class CollectionRepository extends BaseDao {
         CollectionEntity entity = new CollectionEntity();
         entity.setId(rs.getLong("id"));
         entity.setType(CollectionType.valueOf(rs.getString("type")));
+        entity.setClient(rs.getBoolean("is_client"));
+        entity.setBlog(rs.getBoolean("is_blog"));
         entity.setTitle(rs.getString("title"));
         entity.setSlug(rs.getString("slug"));
         entity.setDescription(rs.getString("description"));
@@ -120,49 +122,30 @@ public class CollectionRepository extends BaseDao {
     return queryForObject(sql, COLLECTION_ROW_MAPPER, params);
   }
 
+  /** Find LISTED blog collections ({@code is_blog = true}), rating-first then newest. */
   @Transactional(readOnly = true)
-  public List<CollectionEntity> findByTypeAndListedOrdered(CollectionType type) {
+  public List<CollectionEntity> findListedBlogsOrdered() {
     String sql =
         SELECT_COLLECTION
-            + " WHERE type = :type AND visibility = 'LISTED' "
+            + " WHERE is_blog = true AND visibility = 'LISTED' "
             + "ORDER BY rating DESC NULLS LAST, collection_date DESC NULLS LAST";
-    MapSqlParameterSource params = createParameterSource().addValue("type", type.name());
-    return query(sql, COLLECTION_ROW_MAPPER, params);
+    return query(sql, COLLECTION_ROW_MAPPER);
   }
 
   /**
-   * Find collections of a given type on an exact collection_date, oldest first. Used by the
-   * tag-first ingest flow to get-or-create the per-day BLOG collection keyed on {@code (type=BLOG,
-   * collection_date=day)}. Ordering by {@code created_at ASC} means callers can take the first
-   * result as the canonical (oldest) collection when duplicates unexpectedly exist.
+   * Find blog collections ({@code is_blog = true}) on an exact collection_date, oldest first. Used
+   * by the tag-first ingest flow to get-or-create the per-day blog collection keyed on {@code
+   * (is_blog=true, collection_date=day)}. Ordering by {@code created_at ASC} means callers can take
+   * the first result as the canonical (oldest) collection when duplicates unexpectedly exist.
    */
   @Transactional(readOnly = true)
-  public List<CollectionEntity> findByTypeAndCollectionDate(
-      CollectionType type, LocalDate collectionDate) {
+  public List<CollectionEntity> findBlogsByCollectionDate(LocalDate collectionDate) {
     String sql =
         SELECT_COLLECTION
-            + " WHERE type = :type AND collection_date = :collectionDate "
+            + " WHERE is_blog = true AND collection_date = :collectionDate "
             + "ORDER BY created_at ASC";
     MapSqlParameterSource params =
-        createParameterSource()
-            .addValue("type", type.name())
-            .addValue("collectionDate", collectionDate);
-    return query(sql, COLLECTION_ROW_MAPPER, params);
-  }
-
-  @Transactional(readOnly = true)
-  public List<CollectionEntity> findByTypeOrderByCollectionDateDesc(
-      CollectionType type, int limit, int offset) {
-    String sql =
-        SELECT_COLLECTION
-            + " WHERE type = :type AND visibility = 'LISTED' "
-            + "ORDER BY rating DESC NULLS LAST, collection_date DESC NULLS LAST "
-            + "LIMIT :limit OFFSET :offset";
-    MapSqlParameterSource params =
-        createParameterSource()
-            .addValue("type", type.name())
-            .addValue("limit", limit)
-            .addValue("offset", offset);
+        createParameterSource().addValue("collectionDate", collectionDate);
     return query(sql, COLLECTION_ROW_MAPPER, params);
   }
 
@@ -175,7 +158,7 @@ public class CollectionRepository extends BaseDao {
   public List<CollectionEntity> findReferencedCollectionsByParentId(Long parentId) {
     String sql =
         """
-        SELECT c.id, c.type, c.title, c.slug, c.description, c.collection_date, c.collection_end_date,
+        SELECT c.id, c.type, c.is_client, c.is_blog, c.title, c.slug, c.description, c.collection_date, c.collection_end_date,
                c.visibility, c.display_mode, c.cover_image_id, c.content_per_page, c.total_content,
                c.rows_wide, c.gallery_password, c.recipient_emails, c.rating, c.created_at, c.updated_at
         FROM collection c
@@ -200,7 +183,7 @@ public class CollectionRepository extends BaseDao {
   public List<CollectionEntity> findAllReferencedCollectionsByParentId(Long parentId) {
     String sql =
         """
-        SELECT c.id, c.type, c.title, c.slug, c.description, c.collection_date, c.collection_end_date,
+        SELECT c.id, c.type, c.is_client, c.is_blog, c.title, c.slug, c.description, c.collection_date, c.collection_end_date,
                c.visibility, c.display_mode, c.cover_image_id, c.content_per_page, c.total_content,
                c.rows_wide, c.gallery_password, c.recipient_emails, c.rating, c.created_at, c.updated_at
         FROM collection c
@@ -269,7 +252,7 @@ public class CollectionRepository extends BaseDao {
   public List<CollectionEntity> findAllParentCollectionsByChildId(Long childId) {
     String sql =
         """
-        SELECT c.id, c.type, c.title, c.slug, c.description, c.collection_date, c.collection_end_date,
+        SELECT c.id, c.type, c.is_client, c.is_blog, c.title, c.slug, c.description, c.collection_date, c.collection_end_date,
                c.visibility, c.display_mode, c.cover_image_id, c.content_per_page, c.total_content,
                c.rows_wide, c.gallery_password, c.recipient_emails, c.rating, c.created_at, c.updated_at
         FROM collection c
@@ -293,19 +276,11 @@ public class CollectionRepository extends BaseDao {
   }
 
   @Transactional(readOnly = true)
-  public long countByType(CollectionType type) {
-    String sql = "SELECT COUNT(*) FROM collection WHERE type = :type AND visibility = 'LISTED'";
-    MapSqlParameterSource params = createParameterSource().addValue("type", type.name());
-    Long count = namedParameterJdbcTemplate.queryForObject(sql, params, Long.class);
-    return count != null ? count : 0L;
-  }
-
-  @Transactional(readOnly = true)
   public List<CollectionEntity> findListedByLocationName(
       String locationName, int limit, int offset) {
     String sql =
         """
-        SELECT c.id, c.type, c.title, c.slug, c.description, c.collection_date, c.collection_end_date,
+        SELECT c.id, c.type, c.is_client, c.is_blog, c.title, c.slug, c.description, c.collection_date, c.collection_end_date,
                c.visibility, c.display_mode, c.cover_image_id, c.content_per_page, c.total_content,
                c.rows_wide, c.gallery_password, c.recipient_emails, c.rating, c.created_at, c.updated_at
         FROM collection c
@@ -376,32 +351,30 @@ public class CollectionRepository extends BaseDao {
   }
 
   /**
-   * Find collections whose visibility is in the supplied set, optionally filtered by type, ordered
-   * by rating then collection_date. Used by synthetic-slug list views (env-aware visibility scope:
-   * dev includes all, prod includes only LISTED).
+   * Find client-gallery collections ({@code is_client = true}) whose visibility is in the supplied
+   * set, ordered by rating then collection_date. Includes empty collections — used by admin-cover
+   * candidate selection where content is irrelevant.
    */
   @Transactional(readOnly = true)
-  public List<CollectionEntity> findOrderedByVisibilityIn(
-      List<CollectionVisibility> allowed, CollectionType typeFilter) {
-    StringBuilder sql =
-        new StringBuilder(SELECT_COLLECTION).append(" WHERE visibility IN (:visibilities) ");
+  public List<CollectionEntity> findClientGalleriesByVisibilityIn(
+      List<CollectionVisibility> allowed) {
+    String sql =
+        SELECT_COLLECTION
+            + " WHERE visibility IN (:visibilities) AND is_client = true "
+            + "ORDER BY rating DESC NULLS LAST, collection_date DESC NULLS LAST";
     MapSqlParameterSource params =
         createParameterSource()
             .addValue("visibilities", allowed.stream().map(CollectionVisibility::name).toList());
-    if (typeFilter != null) {
-      sql.append(" AND type = :type ");
-      params.addValue("type", typeFilter.name());
-    }
-    sql.append(" ORDER BY rating DESC NULLS LAST, collection_date DESC NULLS LAST");
-    return query(sql.toString(), COLLECTION_ROW_MAPPER, params);
+    return query(sql, COLLECTION_ROW_MAPPER, params);
   }
 
   /**
-   * Same as {@link #findOrderedByVisibilityIn} but additionally drops collections that have zero
-   * non-soft-removed entries in {@code collection_content}. Used by synthetic-list endpoints (e.g.
-   * {@code /all-collections}, {@code /all-blogs}) so the listing never renders empty tiles.
-   * Admin-only flows that need empty collections (e.g. cover-image picking) should keep using
-   * {@link #findOrderedByVisibilityIn}.
+   * Find collections whose visibility is in the supplied set, optionally filtered by legacy type,
+   * dropping collections that have zero non-soft-removed entries in {@code collection_content}.
+   * Used by synthetic-list endpoints (e.g. {@code /all-collections}, {@code /all-blogs}) so the
+   * listing never renders empty tiles. Admin-only flows that need empty collections (e.g.
+   * cover-image picking) should use {@link #findClientGalleriesByVisibilityIn}. The type filter
+   * remains legacy-keyed for the synthetic-slug catalog, which a later task prunes.
    */
   @Transactional(readOnly = true)
   public List<CollectionEntity> findNonEmptyOrderedByVisibilityIn(
@@ -488,13 +461,14 @@ public class CollectionRepository extends BaseDao {
   }
 
   /**
-   * Find every CLIENT_GALLERY plus every PARENT that has at least one CLIENT_GALLERY child, all
-   * within the supplied visibility set, ordered by rating then collection_date. The PARENT branch
-   * walks the same join chain as {@link #findReferencedCollectionsByParentId} (parent ->
+   * Find every client gallery ({@code is_client = true}) plus every collection that has at least
+   * one visible client-gallery child (a "derived parent" — no parent-side type filter), all within
+   * the supplied visibility set, ordered by rating then collection_date. The parent branch walks
+   * the same join chain as {@link #findReferencedCollectionsByParentId} (parent ->
    * collection_content -> content_collection -> child) and applies the same visibility scope to the
-   * child rows so PARENTs whose only matching child is HIDDEN do not appear. Used by the
-   * "all-client-galleries" synthetic listing where PARENT-of-galleries (e.g. wedding wrappers)
-   * should appear alongside standalone CLIENT_GALLERYs.
+   * child rows so parents whose only matching child is HIDDEN do not appear. Used by the
+   * "all-client-galleries" synthetic listing where parents-of-galleries (e.g. wedding wrappers)
+   * should appear alongside standalone client galleries.
    */
   @Transactional(readOnly = true)
   public List<CollectionEntity> findClientGalleriesAndQualifyingParents(
@@ -504,18 +478,15 @@ public class CollectionRepository extends BaseDao {
             + """
              WHERE visibility IN (:visibilities)
                AND (
-                 type = 'CLIENT_GALLERY'
-                 OR (
-                   type = 'PARENT'
-                   AND id IN (
-                     SELECT cc.collection_id
-                     FROM collection_content cc
-                     JOIN content_collection cct ON cct.id = cc.content_id
-                     JOIN collection child ON child.id = cct.referenced_collection_id
-                     WHERE child.type = 'CLIENT_GALLERY'
-                       AND child.visibility IN (:visibilities)
-                       AND cc.visible = true
-                   )
+                 is_client = true
+                 OR id IN (
+                   SELECT cc.collection_id
+                   FROM collection_content cc
+                   JOIN content_collection cct ON cct.id = cc.content_id
+                   JOIN collection child ON child.id = cct.referenced_collection_id
+                   WHERE child.is_client = true
+                     AND child.visibility IN (:visibilities)
+                     AND cc.visible = true
                  )
                )
              ORDER BY rating DESC NULLS LAST, collection_date DESC NULLS LAST
@@ -542,7 +513,8 @@ public class CollectionRepository extends BaseDao {
 
   @Transactional(readOnly = true)
   public List<Records.CollectionList> findIdTitleSlugAndType() {
-    String sql = "SELECT id, title, slug, type FROM collection ORDER BY title ASC";
+    String sql =
+        "SELECT id, title, slug, type, is_client, is_blog FROM collection ORDER BY title ASC";
     return jdbcTemplate.query(
         sql,
         (rs, rowNum) ->
@@ -550,7 +522,11 @@ public class CollectionRepository extends BaseDao {
                 rs.getLong("id"),
                 rs.getString("title"),
                 rs.getString("slug"),
-                CollectionType.valueOf(rs.getString("type"))));
+                CollectionType.valueOf(rs.getString("type")),
+                null,
+                null,
+                rs.getBoolean("is_client"),
+                rs.getBoolean("is_blog")));
   }
 
   /**
@@ -563,10 +539,10 @@ public class CollectionRepository extends BaseDao {
     if (entity.getId() == null) {
       String sql =
           """
-          INSERT INTO collection (type, title, slug, description, collection_date, collection_end_date,
+          INSERT INTO collection (type, is_client, is_blog, title, slug, description, collection_date, collection_end_date,
                                  visibility, display_mode, cover_image_id, content_per_page, total_content,
                                  rows_wide, gallery_password, rating, created_at, updated_at)
-          VALUES (:type, :title, :slug, :description, :collectionDate, :collectionEndDate,
+          VALUES (:type, :isClient, :isBlog, :title, :slug, :description, :collectionDate, :collectionEndDate,
                   :visibility, :displayMode, :coverImageId, :contentPerPage, :totalContent,
                   :rowsWide, :galleryPassword, :rating, :createdAt, :updatedAt)
           """;
@@ -574,6 +550,8 @@ public class CollectionRepository extends BaseDao {
       MapSqlParameterSource params =
           createParameterSource()
               .addValue("type", entity.getType().name())
+              .addValue("isClient", entity.isClient())
+              .addValue("isBlog", entity.isBlog())
               .addValue("title", entity.getTitle())
               .addValue("slug", entity.getSlug())
               .addValue("description", entity.getDescription())
@@ -605,7 +583,7 @@ public class CollectionRepository extends BaseDao {
       String sql =
           """
           UPDATE collection
-          SET type = :type, title = :title, slug = :slug, description = :description,
+          SET type = :type, is_client = :isClient, is_blog = :isBlog, title = :title, slug = :slug, description = :description,
               collection_date = :collectionDate, collection_end_date = :collectionEndDate,
               visibility = :visibility, display_mode = :displayMode,
               cover_image_id = :coverImageId, content_per_page = :contentPerPage, total_content = :totalContent,
@@ -617,6 +595,8 @@ public class CollectionRepository extends BaseDao {
           createParameterSource()
               .addValue("id", entity.getId())
               .addValue("type", entity.getType().name())
+              .addValue("isClient", entity.isClient())
+              .addValue("isBlog", entity.isBlog())
               .addValue("title", entity.getTitle())
               .addValue("slug", entity.getSlug())
               .addValue("description", entity.getDescription())

--- a/src/main/java/edens/zac/portfolio/backend/dao/CollectionSiblingRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/CollectionSiblingRepository.java
@@ -21,12 +21,15 @@ public class CollectionSiblingRepository extends BaseDao {
   private static final RowMapper<Records.SiblingRow> SIBLING_ROW_MAPPER =
       (rs, rowNum) -> {
         long coverImageId = rs.getLong("cover_image_id");
+        Long coverImageIdOrNull = rs.wasNull() ? null : coverImageId;
         return new Records.SiblingRow(
             rs.getLong("id"),
             rs.getString("name"),
             rs.getString("slug"),
             CollectionType.valueOf(rs.getString("type")),
-            rs.wasNull() ? null : coverImageId);
+            coverImageIdOrNull,
+            rs.getBoolean("is_client"),
+            rs.getBoolean("is_blog"));
       };
 
   public CollectionSiblingRepository(JdbcTemplate jdbcTemplate) {
@@ -66,7 +69,7 @@ public class CollectionSiblingRepository extends BaseDao {
   @Transactional(readOnly = true)
   public List<Records.SiblingRow> findSiblings(Long collectionId, boolean listedOnly) {
     String sql =
-        "SELECT c.id, c.title AS name, c.slug, c.type, c.cover_image_id "
+        "SELECT c.id, c.title AS name, c.slug, c.type, c.cover_image_id, c.is_client, c.is_blog "
             + "FROM collection_sibling cs "
             + "JOIN collection c ON c.id = cs.sibling_collection_id "
             + "WHERE cs.collection_id = :id "

--- a/src/main/java/edens/zac/portfolio/backend/dao/TagRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/TagRepository.java
@@ -49,6 +49,8 @@ public class TagRepository extends BaseDao {
         CollectionEntity entity = new CollectionEntity();
         entity.setId(rs.getLong("id"));
         entity.setType(CollectionType.valueOf(rs.getString("type")));
+        entity.setClient(rs.getBoolean("is_client"));
+        entity.setBlog(rs.getBoolean("is_blog"));
         entity.setTitle(rs.getString("title"));
         entity.setSlug(rs.getString("slug"));
         entity.setDescription(rs.getString("description"));
@@ -330,7 +332,7 @@ public class TagRepository extends BaseDao {
     }
     String sql =
         """
-        SELECT c.id, c.type, c.title, c.slug, c.description, c.collection_date,
+        SELECT c.id, c.type, c.is_client, c.is_blog, c.title, c.slug, c.description, c.collection_date,
                c.visibility, c.display_mode, c.cover_image_id, c.content_per_page, c.total_content,
                c.rows_wide, c.gallery_password, c.recipient_emails, c.rating, c.created_at, c.updated_at
         FROM collection c

--- a/src/main/java/edens/zac/portfolio/backend/entity/CollectionEntity.java
+++ b/src/main/java/edens/zac/portfolio/backend/entity/CollectionEntity.java
@@ -26,6 +26,18 @@ public class CollectionEntity {
   /** Column: type (VARCHAR, NOT NULL) - enum: BLOG, CLIENT_GALLERY, PORTFOLIO, MISC */
   @NotNull private CollectionType type;
 
+  /**
+   * Column: is_client (BOOLEAN, NOT NULL, default false) - storage truth for what {@code
+   * type=CLIENT_GALLERY} means; kept in sync with {@code type} during the dual-compat window.
+   */
+  private boolean isClient;
+
+  /**
+   * Column: is_blog (BOOLEAN, NOT NULL, default false) - storage truth for what {@code type=BLOG}
+   * means; kept in sync with {@code type} during the dual-compat window.
+   */
+  private boolean isBlog;
+
   /** Column: title (VARCHAR(100), NOT NULL) */
   @NotBlank @Size(min = 3, max = 100) private String title;
 

--- a/src/main/java/edens/zac/portfolio/backend/model/CollectionModel.java
+++ b/src/main/java/edens/zac/portfolio/backend/model/CollectionModel.java
@@ -1,6 +1,7 @@
 package edens.zac.portfolio.backend.model;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import edens.zac.portfolio.backend.config.DefaultValues;
 import edens.zac.portfolio.backend.types.CollectionType;
 import edens.zac.portfolio.backend.types.CollectionVisibility;
@@ -30,7 +31,22 @@ public class CollectionModel {
 
   private Long id;
 
+  /**
+   * Legacy type field, still emitted and accepted during the dual-compat window. The booleans below
+   * are the source of truth; a later release drops this field.
+   */
   private CollectionType type;
+
+  /**
+   * True when this collection is a client gallery. Serializes as exactly {@code "isClient"} (the
+   * explicit JsonProperty guards against the Lombok/Jackson boolean-getter rename trap).
+   */
+  @JsonProperty("isClient")
+  private Boolean isClient;
+
+  /** True when this collection is a blog. Serializes as exactly {@code "isBlog"}. */
+  @JsonProperty("isBlog")
+  private Boolean isBlog;
 
   @Size(min = 3, max = 100, message = "Title must be between 3 and 100 characters") private String title;
 

--- a/src/main/java/edens/zac/portfolio/backend/model/CollectionRequests.java
+++ b/src/main/java/edens/zac/portfolio/backend/model/CollectionRequests.java
@@ -62,10 +62,14 @@ public final class CollectionRequests {
       /** Legacy collection type; the booleans win when both are present (dual-compat window). */
       CollectionType type,
       /**
-       * Set/clear the client-gallery flag. Null leaves it untouched (unless {@code type} is set).
+       * Set/clear the client-gallery flag. Null leaves it untouched (unless {@code type} is set,
+       * which then derives it). Setting it true clears {@code isBlog}.
        */
       @JsonProperty("isClient") Boolean isClient,
-      /** Set/clear the blog flag. Null leaves it untouched (unless {@code type} is set). */
+      /**
+       * Set/clear the blog flag. Null leaves it untouched (unless {@code type} is set, which then
+       * derives it). Setting it true clears {@code isClient}.
+       */
       @JsonProperty("isBlog") Boolean isBlog,
       /** Collection title */
       @Size(min = 3, max = 100, message = "Title must be between 3 and 100 characters") String title,

--- a/src/main/java/edens/zac/portfolio/backend/model/CollectionRequests.java
+++ b/src/main/java/edens/zac/portfolio/backend/model/CollectionRequests.java
@@ -1,6 +1,7 @@
 package edens.zac.portfolio.backend.model;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import edens.zac.portfolio.backend.types.CollectionType;
 import edens.zac.portfolio.backend.types.CollectionVisibility;
@@ -18,20 +19,35 @@ public final class CollectionRequests {
   private CollectionRequests() {} // Prevent instantiation
 
   /**
-   * Request for creating a new ContentCollection. Type and title are required; all other fields are
-   * optional and will use defaults if not provided.
+   * Request for creating a new ContentCollection. Title is required; all other fields are optional
+   * and use defaults if not provided. During the dual-compat window the legacy {@code type} is
+   * optional (new frontends send only the booleans + title; a create with neither type nor booleans
+   * lands on MISC). {@code isClient}/{@code isBlog} win over {@code type} when provided.
    */
   public record Create(
-      @NotNull(message = "Type is required") CollectionType type,
+      CollectionType type,
       @NotNull(message = "Title is required") @Size(min = 3, max = 100, message = "Title must be between 3 and 100 characters") String title,
       @Size(max = 500, message = "Description cannot exceed 500 characters") String description,
       List<Long> locationIds,
       List<String> locationNames,
-      @JsonFormat(pattern = "yyyy-MM-dd") LocalDate collectionDate) {
+      @JsonFormat(pattern = "yyyy-MM-dd") LocalDate collectionDate,
+      @JsonProperty("isClient") Boolean isClient,
+      @JsonProperty("isBlog") Boolean isBlog) {
+
+    /** Backwards-compatible constructor for callers predating the client/blog booleans. */
+    public Create(
+        CollectionType type,
+        String title,
+        String description,
+        List<Long> locationIds,
+        List<String> locationNames,
+        LocalDate collectionDate) {
+      this(type, title, description, locationIds, locationNames, collectionDate, null, null);
+    }
 
     /** Backwards-compatible constructor for callers that only provide type and title. */
     public Create(CollectionType type, String title) {
-      this(type, title, null, null, null, null);
+      this(type, title, null, null, null, null, null, null);
     }
   }
 
@@ -43,8 +59,14 @@ public final class CollectionRequests {
   public record Update(
       /** The ID of the collection to update (required) */
       @NotNull(message = "Collection ID is required for updates") Long id,
-      /** Collection type */
+      /** Legacy collection type; the booleans win when both are present (dual-compat window). */
       CollectionType type,
+      /**
+       * Set/clear the client-gallery flag. Null leaves it untouched (unless {@code type} is set).
+       */
+      @JsonProperty("isClient") Boolean isClient,
+      /** Set/clear the blog flag. Null leaves it untouched (unless {@code type} is set). */
+      @JsonProperty("isBlog") Boolean isBlog,
       /** Collection title */
       @Size(min = 3, max = 100, message = "Title must be between 3 and 100 characters") String title,
       /** Collection slug */
@@ -130,6 +152,8 @@ public final class CollectionRequests {
       this(
           id,
           type,
+          null,
+          null,
           title,
           slug,
           description,

--- a/src/main/java/edens/zac/portfolio/backend/model/ContentModels.java
+++ b/src/main/java/edens/zac/portfolio/backend/model/ContentModels.java
@@ -1,6 +1,7 @@
 package edens.zac.portfolio.backend.model;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import edens.zac.portfolio.backend.types.CollectionType;
 import edens.zac.portfolio.backend.types.ContentType;
 import edens.zac.portfolio.backend.types.FilmFormat;
@@ -240,6 +241,8 @@ public final class ContentModels {
       Long referencedCollectionId,
       String slug,
       CollectionType collectionType,
+      @JsonProperty("isClient") Boolean isClient,
+      @JsonProperty("isBlog") Boolean isBlog,
       ContentModels.Image coverImage,
       @JsonFormat(pattern = "yyyy-MM-dd") LocalDate collectionDate,
       @JsonFormat(pattern = "yyyy-MM-dd") LocalDate collectionEndDate,
@@ -267,6 +270,8 @@ public final class ContentModels {
           c.getId(),
           c.getSlug(),
           c.getType(),
+          c.getIsClient(),
+          c.getIsBlog(),
           c.getCoverImage(),
           c.getCollectionDate(),
           c.getCollectionEndDate(),
@@ -288,6 +293,8 @@ public final class ContentModels {
           referencedCollectionId,
           slug,
           collectionType,
+          isClient,
+          isBlog,
           coverImage,
           collectionDate,
           collectionEndDate,
@@ -313,6 +320,8 @@ public final class ContentModels {
           referencedCollectionId,
           slug,
           collectionType,
+          isClient,
+          isBlog,
           coverImage,
           collectionDate,
           collectionEndDate,

--- a/src/main/java/edens/zac/portfolio/backend/model/Records.java
+++ b/src/main/java/edens/zac/portfolio/backend/model/Records.java
@@ -1,5 +1,6 @@
 package edens.zac.portfolio.backend.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import edens.zac.portfolio.backend.types.CollectionType;
 import java.time.LocalDate;
 
@@ -76,19 +77,32 @@ public final class Records {
       String slug,
       CollectionType type,
       LocalDate collectionDate,
-      String coverImageUrl) {
+      String coverImageUrl,
+      @JsonProperty("isClient") Boolean isClient,
+      @JsonProperty("isBlog") Boolean isBlog) {
+
+    /** Backwards-compatible constructor for callers that omit the client/blog flags. */
+    public CollectionList(
+        Long id,
+        String name,
+        String slug,
+        CollectionType type,
+        LocalDate collectionDate,
+        String coverImageUrl) {
+      this(id, name, slug, type, collectionDate, coverImageUrl, null, null);
+    }
 
     /** Backwards-compatible constructor for callers that omit the cover image URL. */
     public CollectionList(
         Long id, String name, String slug, CollectionType type, LocalDate collectionDate) {
-      this(id, name, slug, type, collectionDate, null);
+      this(id, name, slug, type, collectionDate, null, null, null);
     }
 
     /**
      * Backwards-compatible constructor for callers that omit the collection date and cover image.
      */
     public CollectionList(Long id, String name, String slug, CollectionType type) {
-      this(id, name, slug, type, null, null);
+      this(id, name, slug, type, null, null, null, null);
     }
   }
 
@@ -99,7 +113,19 @@ public final class Records {
    * serialized to API responses directly.
    */
   public record SiblingRow(
-      Long id, String name, String slug, CollectionType type, Long coverImageId) {}
+      Long id,
+      String name,
+      String slug,
+      CollectionType type,
+      Long coverImageId,
+      boolean isClient,
+      boolean isBlog) {
+
+    /** Backwards-compatible constructor for callers that omit the client/blog flags. */
+    public SiblingRow(Long id, String name, String slug, CollectionType type, Long coverImageId) {
+      this(id, name, slug, type, coverImageId, false, false);
+    }
+  }
 
   /**
    * DTO for admin hub tile configuration. coverImageUrl and dimensions are null when no image is

--- a/src/main/java/edens/zac/portfolio/backend/model/SaveAsCollectionRequest.java
+++ b/src/main/java/edens/zac/portfolio/backend/model/SaveAsCollectionRequest.java
@@ -1,5 +1,6 @@
 package edens.zac.portfolio.backend.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import edens.zac.portfolio.backend.types.CollectionType;
 import edens.zac.portfolio.backend.types.CollectionVisibility;
 
@@ -7,12 +8,26 @@ import edens.zac.portfolio.backend.types.CollectionVisibility;
  * Request body for promoting a tag-view into a real collection. All fields are optional; the
  * service defaults type to PORTFOLIO and visibility to UNLISTED.
  *
+ * <p>During the dual-compat window the new {@code isClient}/{@code isBlog} booleans are accepted
+ * alongside the legacy {@code type}; the booleans win when provided (see {@code
+ * CollectionTypeCompat}). {@code isClient && isBlog} is rejected as a 400 on create.
+ *
  * <p>{@code includeHidden} widens the member snapshot to also copy HIDDEN / password-gated members.
  * It defaults to false so a promote never silently copies dev-only or password-protected content
  * into a new collection; an admin must explicitly opt in.
  */
 public record SaveAsCollectionRequest(
-    CollectionType type, CollectionVisibility visibility, Boolean includeHidden) {
+    CollectionType type,
+    CollectionVisibility visibility,
+    Boolean includeHidden,
+    @JsonProperty("isClient") Boolean isClient,
+    @JsonProperty("isBlog") Boolean isBlog) {
+
+  /** Backwards-compatible constructor for callers predating the client/blog booleans. */
+  public SaveAsCollectionRequest(
+      CollectionType type, CollectionVisibility visibility, Boolean includeHidden) {
+    this(type, visibility, includeHidden, null, null);
+  }
 
   /** True only when the caller explicitly opted into copying HIDDEN / password-gated members. */
   public boolean includeHiddenMembers() {

--- a/src/main/java/edens/zac/portfolio/backend/services/AdminHomeService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/AdminHomeService.java
@@ -6,7 +6,6 @@ import edens.zac.portfolio.backend.dao.ContentRepository;
 import edens.zac.portfolio.backend.model.CollectionModel;
 import edens.zac.portfolio.backend.model.ContentModels;
 import edens.zac.portfolio.backend.model.Records;
-import edens.zac.portfolio.backend.types.CollectionType;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -79,11 +78,9 @@ public class AdminHomeService {
         yield url != null ? urlOnlyCoverImage(url) : null;
       }
       case "blogs" ->
-          randomCoverImageFromCollections(
-              collectionService.findVisibleByTypeOrderByDate(CollectionType.BLOG));
+          randomCoverImageFromCollections(collectionService.findVisibleBlogsOrderedByDate());
       case "client-galleries" ->
-          randomCoverImageFromCollections(
-              collectionService.findByTypeForAdminCovers(CollectionType.CLIENT_GALLERY));
+          randomCoverImageFromCollections(collectionService.findClientGalleriesForAdminCovers());
       default -> null;
     };
   }

--- a/src/main/java/edens/zac/portfolio/backend/services/CollectionProcessingUtil.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/CollectionProcessingUtil.java
@@ -626,8 +626,10 @@ public class CollectionProcessingUtil {
     if (updateDTO.description() != null) {
       entity.setDescription(updateDTO.description());
     }
-    // Dual-compat type/flag handling: the booleans win when present; a legacy type-only request
-    // derives the booleans; a request with neither leaves type and flags untouched.
+    // Dual-compat type/flag handling: an explicit boolean wins; a null boolean is left
+    // untouched (inherited from the effective type, so partial updates never silently demote);
+    // a legacy type-only request derives the booleans; a request with neither leaves type and
+    // flags untouched.
     if (updateDTO.isClient() != null || updateDTO.isBlog() != null || updateDTO.type() != null) {
       CollectionTypeCompat.Resolved resolved =
           CollectionTypeCompat.resolve(

--- a/src/main/java/edens/zac/portfolio/backend/services/CollectionProcessingUtil.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/CollectionProcessingUtil.java
@@ -568,7 +568,10 @@ public class CollectionProcessingUtil {
     entity.setDescription(request.description() != null ? request.description() : "");
     entity.setCollectionDate(
         request.collectionDate() != null ? request.collectionDate() : LocalDate.now());
-    entity.setVisibility(CollectionVisibility.HIDDEN);
+    // Privacy-first default: new collections are UNLISTED (reachable by direct slug, absent
+    // from public listings) until an admin explicitly lists them. The Create request carries
+    // no visibility field, so every create lands here regardless of type.
+    entity.setVisibility(CollectionVisibility.UNLISTED);
     entity.setTotalContent(0);
     if (request.type().isParentType()) {
       // Parent-type collections don't use pagination or row layout
@@ -581,7 +584,7 @@ public class CollectionProcessingUtil {
       entity.setDisplayMode(
           request.type() == CollectionType.BLOG ? DisplayMode.CHRONOLOGICAL : DisplayMode.ORDERED);
     }
-    // Apply type-specific defaults (may adjust visibility etc.)
+    // Apply type-specific defaults (pagination sizing)
     return applyTypeSpecificDefaults(entity);
   }
 
@@ -870,7 +873,9 @@ public class CollectionProcessingUtil {
   // =============================================================================
 
   /**
-   * Update entity with type-specific defaults.
+   * Update entity with type-specific defaults (pagination sizing). Visibility is intentionally NOT
+   * touched here: new collections default to UNLISTED in {@link #toEntity} regardless of type
+   * (privacy-first), and updates only change visibility when explicitly requested.
    *
    * @param entity The entity to update
    * @return The updated entity
@@ -885,15 +890,6 @@ public class CollectionProcessingUtil {
       if (entity.getContentPerPage() == null || entity.getContentPerPage() <= 0) {
         entity.setContentPerPage(DefaultValues.default_content_per_page);
       }
-    }
-
-    // Set type-specific visibility defaults (only when entity still at HIDDEN default)
-    if (entity.getVisibility() == CollectionVisibility.HIDDEN) {
-      // Client galleries are private (UNLISTED) by default; everything else surfaces as LISTED.
-      entity.setVisibility(
-          entity.getType() == CollectionType.CLIENT_GALLERY
-              ? CollectionVisibility.UNLISTED
-              : CollectionVisibility.LISTED);
     }
 
     return entity;

--- a/src/main/java/edens/zac/portfolio/backend/services/CollectionProcessingUtil.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/CollectionProcessingUtil.java
@@ -21,7 +21,6 @@ import edens.zac.portfolio.backend.model.CollectionRequests;
 import edens.zac.portfolio.backend.model.ContentModel;
 import edens.zac.portfolio.backend.model.ContentModels;
 import edens.zac.portfolio.backend.model.Records;
-import edens.zac.portfolio.backend.types.CollectionType;
 import edens.zac.portfolio.backend.types.CollectionVisibility;
 import edens.zac.portfolio.backend.types.ContentType;
 import edens.zac.portfolio.backend.types.DisplayMode;
@@ -145,6 +144,8 @@ public class CollectionProcessingUtil {
     CollectionModel model = new CollectionModel();
     model.setId(entity.getId());
     model.setType(entity.getType());
+    model.setIsClient(entity.isClient());
+    model.setIsBlog(entity.isBlog());
     model.setTitle(entity.getTitle());
     model.setSlug(entity.getSlug());
     model.setDescription(entity.getDescription());
@@ -185,10 +186,11 @@ public class CollectionProcessingUtil {
 
     model.setCreatedAt(entity.getCreatedAt());
     model.setUpdatedAt(entity.getUpdatedAt());
+    // D10: chronological is the universal fallback when no display mode is stored; ORDERED is a
+    // per-collection opt-in (explicit displayMode in a request is always respected and persisted).
     DisplayMode mode = entity.getDisplayMode();
     if (mode == null) {
-      mode =
-          entity.getType() == CollectionType.BLOG ? DisplayMode.CHRONOLOGICAL : DisplayMode.ORDERED;
+      mode = DisplayMode.CHRONOLOGICAL;
     }
     model.setDisplayMode(mode);
     model.setContentCount(entity.getTotalContent());
@@ -503,7 +505,14 @@ public class CollectionProcessingUtil {
                           ? coverImageUrlsById.get(row.coverImageId())
                           : null;
                   return new Records.CollectionList(
-                      row.id(), row.name(), row.slug(), row.type(), null, coverImageUrl);
+                      row.id(),
+                      row.name(),
+                      row.slug(),
+                      row.type(),
+                      null,
+                      coverImageUrl,
+                      row.isClient(),
+                      row.isBlog());
                 })
             .toList();
 
@@ -552,15 +561,21 @@ public class CollectionProcessingUtil {
   // =============================================================================
 
   /**
-   * Create a CollectionEntity from a Create request. Required fields: type, title. Optional fields:
-   * description, locationId/locationName, collectionDate — use defaults when not provided.
+   * Create a CollectionEntity from a Create request. Required field: title. Optional fields: type,
+   * isClient/isBlog, description, locationId/locationName, collectionDate — use defaults when not
+   * provided. The booleans win over the legacy type when both are present; a create with neither
+   * lands on MISC (see {@link CollectionTypeCompat#resolve}).
    */
   public CollectionEntity toEntity(CollectionRequests.Create request, int defaultPageSize) {
     if (request == null) {
       throw new IllegalArgumentException("Create request cannot be null");
     }
     CollectionEntity entity = new CollectionEntity();
-    entity.setType(request.type());
+    CollectionTypeCompat.Resolved resolved =
+        CollectionTypeCompat.resolve(request.isClient(), request.isBlog(), request.type(), null);
+    entity.setType(resolved.type());
+    entity.setClient(resolved.isClient());
+    entity.setBlog(resolved.isBlog());
     entity.setTitle(request.title());
     String baseSlug = generateSlug(request.title());
     String uniqueSlug = validateAndEnsureUniqueSlug(baseSlug, null);
@@ -573,17 +588,16 @@ public class CollectionProcessingUtil {
     // no visibility field, so every create lands here regardless of type.
     entity.setVisibility(CollectionVisibility.UNLISTED);
     entity.setTotalContent(0);
-    if (request.type().isParentType()) {
+    if (resolved.type().isParentType()) {
       // Parent-type collections don't use pagination or row layout
       entity.setContentPerPage(null);
       entity.setRowsWide(null);
-      entity.setDisplayMode(DisplayMode.ORDERED);
     } else {
       entity.setContentPerPage(defaultPageSize);
-      // Set default displayMode based on type
-      entity.setDisplayMode(
-          request.type() == CollectionType.BLOG ? DisplayMode.CHRONOLOGICAL : DisplayMode.ORDERED);
     }
+    // D10: every new collection defaults to CHRONOLOGICAL regardless of type; ORDERED is an
+    // explicit opt-in via a later update request (Create carries no displayMode field).
+    entity.setDisplayMode(DisplayMode.CHRONOLOGICAL);
     // Apply type-specific defaults (pagination sizing)
     return applyTypeSpecificDefaults(entity);
   }
@@ -612,8 +626,15 @@ public class CollectionProcessingUtil {
     if (updateDTO.description() != null) {
       entity.setDescription(updateDTO.description());
     }
-    if (updateDTO.type() != null) {
-      entity.setType(updateDTO.type());
+    // Dual-compat type/flag handling: the booleans win when present; a legacy type-only request
+    // derives the booleans; a request with neither leaves type and flags untouched.
+    if (updateDTO.isClient() != null || updateDTO.isBlog() != null || updateDTO.type() != null) {
+      CollectionTypeCompat.Resolved resolved =
+          CollectionTypeCompat.resolve(
+              updateDTO.isClient(), updateDTO.isBlog(), updateDTO.type(), entity.getType());
+      entity.setType(resolved.type());
+      entity.setClient(resolved.isClient());
+      entity.setBlog(resolved.isBlog());
     }
     // Handle location update using prev/new/remove pattern (many-to-many)
     if (updateDTO.locations() != null) {

--- a/src/main/java/edens/zac/portfolio/backend/services/CollectionService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/CollectionService.java
@@ -157,49 +157,29 @@ public class CollectionService {
     return model;
   }
 
-  @Transactional(readOnly = true)
-  public Page<CollectionModel> findByType(CollectionType type, Pageable pageable) {
-    log.debug("Finding collections by type: {}", type);
-
-    // Get total count
-    long totalElements = collectionRepository.countByType(type);
-
-    // Get paginated collections directly from DB
-    int page = pageable.getPageNumber();
-    int size = pageable.getPageSize();
-    List<CollectionEntity> paginatedCollections =
-        collectionRepository.findByTypeOrderByCollectionDateDesc(type, size, page * size);
-
-    // Convert to models using batch loading
-    List<CollectionModel> models =
-        collectionProcessingUtil.batchConvertToBasicModels(paginatedCollections);
-
-    return new PageImpl<>(models, pageable, totalElements);
-  }
-
   /**
-   * Find LISTED collections of a given type, ordered by rating then collection_date. Used by
-   * AdminHomeService to pick cover images for type-specific admin home tiles.
+   * Find LISTED blog collections ({@code is_blog = true}), ordered by rating then collection_date.
+   * Used by AdminHomeService to pick cover images for the blogs admin home tile.
    */
   @Transactional(readOnly = true)
-  public List<CollectionModel> findVisibleByTypeOrderByDate(CollectionType type) {
-    log.debug("Finding visible collections by type ordered by date: {}", type);
-    List<CollectionEntity> collections = collectionRepository.findByTypeAndListedOrdered(type);
+  public List<CollectionModel> findVisibleBlogsOrderedByDate() {
+    log.debug("Finding visible blog collections ordered by date");
+    List<CollectionEntity> collections = collectionRepository.findListedBlogsOrdered();
     return collectionProcessingUtil.batchConvertToBasicModels(collections);
   }
 
   /**
-   * Find non-HIDDEN collections of a given type (LISTED + UNLISTED) for admin-only contexts where
-   * UNLISTED is acceptable to surface. Used by {@link AdminHomeService} to pick cover images for
-   * tiles like {@code client-galleries}, where the typical visibility is UNLISTED — the regular
-   * "visible" lookup would return no candidates and the tile would render with no cover.
+   * Find non-HIDDEN client galleries ({@code is_client = true}, LISTED + UNLISTED) for admin-only
+   * contexts where UNLISTED is acceptable to surface. Used by {@link AdminHomeService} to pick
+   * cover images for the {@code client-galleries} tile, where the typical visibility is UNLISTED —
+   * a LISTED-only lookup would return no candidates and the tile would render with no cover.
    */
   @Transactional(readOnly = true)
-  public List<CollectionModel> findByTypeForAdminCovers(CollectionType type) {
-    log.debug("Finding admin-cover candidates by type: {}", type);
+  public List<CollectionModel> findClientGalleriesForAdminCovers() {
+    log.debug("Finding admin-cover candidates for client galleries");
     List<CollectionEntity> collections =
-        collectionRepository.findOrderedByVisibilityIn(
-            List.of(CollectionVisibility.LISTED, CollectionVisibility.UNLISTED), type);
+        collectionRepository.findClientGalleriesByVisibilityIn(
+            List.of(CollectionVisibility.LISTED, CollectionVisibility.UNLISTED));
     return collectionProcessingUtil.batchConvertToBasicModels(collections);
   }
 
@@ -765,7 +745,14 @@ public class CollectionService {
             .map(
                 p ->
                     new Records.CollectionList(
-                        p.getId(), p.getTitle(), p.getSlug(), p.getType(), p.getCollectionDate()))
+                        p.getId(),
+                        p.getTitle(),
+                        p.getSlug(),
+                        p.getType(),
+                        p.getCollectionDate(),
+                        null,
+                        p.isClient(),
+                        p.isBlog()))
             .toList());
 
     return new CollectionRequests.UpdateResponse(collection, metadata, childCollectionImages);

--- a/src/main/java/edens/zac/portfolio/backend/services/CollectionTypeCompat.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/CollectionTypeCompat.java
@@ -11,15 +11,20 @@ import edens.zac.portfolio.backend.types.CollectionType;
  * <p>Resolution rules:
  *
  * <ul>
- *   <li>Request provides booleans (either field non-null) -&gt; booleans win. {@code isClient}
- *       derives {@code CLIENT_GALLERY}, {@code isBlog} derives {@code BLOG}; neither true -&gt; if
- *       the effective base type is {@code CLIENT_GALLERY}/{@code BLOG} (or absent) it becomes
- *       {@code MISC}, otherwise the base type is preserved.
+ *   <li>An explicit {@code true} flag wins over everything: {@code isClient} derives {@code
+ *       CLIENT_GALLERY}, {@code isBlog} derives {@code BLOG}, and the other flag is cleared (mutual
+ *       exclusion).
+ *   <li>A {@code null} flag means "leave it untouched": it inherits its value from the effective
+ *       base type (the requested legacy type when present, else the current type). Partial updates
+ *       therefore never silently demote a client gallery or blog.
+ *   <li>Only an explicit {@code false} clears a flag. When neither flag ends up true, a base type
+ *       of {@code CLIENT_GALLERY}/{@code BLOG} (or absent) folds to {@code MISC}, otherwise the
+ *       base type is preserved.
  *   <li>Request provides only a legacy type -&gt; booleans are derived from it ({@code
  *       CLIENT_GALLERY} -&gt; client, {@code BLOG} -&gt; blog, everything else false/false).
- *   <li>Request provides neither -&gt; the current type is preserved (create without type -&gt;
- *       {@code MISC}).
- *   <li>{@code isClient && isBlog} is a nonsense combination and is rejected with {@link
+ *   <li>Request provides neither flags nor type -&gt; the current type is preserved (create without
+ *       type -&gt; {@code MISC}).
+ *   <li>Explicit {@code isClient && isBlog} is a nonsense combination and is rejected with {@link
  *       IllegalArgumentException} (400 via GlobalExceptionHandler).
  * </ul>
  */
@@ -47,21 +52,32 @@ public final class CollectionTypeCompat {
       CollectionType currentType) {
     boolean flagsProvided = isClientRequested != null || isBlogRequested != null;
     if (flagsProvided) {
-      boolean client = Boolean.TRUE.equals(isClientRequested);
-      boolean blog = Boolean.TRUE.equals(isBlogRequested);
-      if (client && blog) {
+      if (Boolean.TRUE.equals(isClientRequested) && Boolean.TRUE.equals(isBlogRequested)) {
         throw new IllegalArgumentException(
             "isClient and isBlog are mutually exclusive; a collection cannot be both");
       }
+      // An explicit true is a category change: it wins over the legacy type and clears the
+      // other flag (mutual exclusion), whether that flag was absent or explicitly false.
+      if (Boolean.TRUE.equals(isClientRequested)) {
+        return new Resolved(CollectionType.CLIENT_GALLERY, true, false);
+      }
+      if (Boolean.TRUE.equals(isBlogRequested)) {
+        return new Resolved(CollectionType.BLOG, false, true);
+      }
+      // Remaining flags are explicit false (clear) or null (leave untouched). A null flag
+      // inherits its value from the effective base type so a partial update like
+      // {"isBlog": false} never silently demotes a client gallery.
+      CollectionType base = requestedType != null ? requestedType : currentType;
+      boolean client = isClientRequested == null && base != null && deriveIsClient(base);
+      boolean blog = isBlogRequested == null && base != null && deriveIsBlog(base);
       if (client) {
         return new Resolved(CollectionType.CLIENT_GALLERY, true, false);
       }
       if (blog) {
         return new Resolved(CollectionType.BLOG, false, true);
       }
-      // Neither flag set: preserve the effective base type unless it encoded client/blog,
-      // which the booleans just disclaimed -- that folds to MISC.
-      CollectionType base = requestedType != null ? requestedType : currentType;
+      // Neither flag survives: preserve the base type unless it encoded client/blog, which
+      // was just explicitly disclaimed -- that folds to MISC.
       if (base == null || base == CollectionType.CLIENT_GALLERY || base == CollectionType.BLOG) {
         base = CollectionType.MISC;
       }

--- a/src/main/java/edens/zac/portfolio/backend/services/CollectionTypeCompat.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/CollectionTypeCompat.java
@@ -4,7 +4,7 @@ import edens.zac.portfolio.backend.types.CollectionType;
 
 /**
  * Dual-compat mapping between the new {@code isClient}/{@code isBlog} booleans and the legacy
- * {@link CollectionType} column during the V49 transition window. The booleans are the storage
+ * {@link CollectionType} column during the V50 transition window. The booleans are the storage
  * truth; the legacy {@code type} column (and API field) is kept in sync on every write so old
  * frontends keep working until the type column is dropped in a later release.
  *

--- a/src/main/java/edens/zac/portfolio/backend/services/CollectionTypeCompat.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/CollectionTypeCompat.java
@@ -1,0 +1,88 @@
+package edens.zac.portfolio.backend.services;
+
+import edens.zac.portfolio.backend.types.CollectionType;
+
+/**
+ * Dual-compat mapping between the new {@code isClient}/{@code isBlog} booleans and the legacy
+ * {@link CollectionType} column during the V49 transition window. The booleans are the storage
+ * truth; the legacy {@code type} column (and API field) is kept in sync on every write so old
+ * frontends keep working until the type column is dropped in a later release.
+ *
+ * <p>Resolution rules:
+ *
+ * <ul>
+ *   <li>Request provides booleans (either field non-null) -&gt; booleans win. {@code isClient}
+ *       derives {@code CLIENT_GALLERY}, {@code isBlog} derives {@code BLOG}; neither true -&gt; if
+ *       the effective base type is {@code CLIENT_GALLERY}/{@code BLOG} (or absent) it becomes
+ *       {@code MISC}, otherwise the base type is preserved.
+ *   <li>Request provides only a legacy type -&gt; booleans are derived from it ({@code
+ *       CLIENT_GALLERY} -&gt; client, {@code BLOG} -&gt; blog, everything else false/false).
+ *   <li>Request provides neither -&gt; the current type is preserved (create without type -&gt;
+ *       {@code MISC}).
+ *   <li>{@code isClient && isBlog} is a nonsense combination and is rejected with {@link
+ *       IllegalArgumentException} (400 via GlobalExceptionHandler).
+ * </ul>
+ */
+public final class CollectionTypeCompat {
+
+  private CollectionTypeCompat() {} // Prevent instantiation
+
+  /** The resolved legacy type plus the boolean flags, always mutually consistent. */
+  public record Resolved(CollectionType type, boolean isClient, boolean isBlog) {}
+
+  /**
+   * Resolve the stored type + flags from a create/update request.
+   *
+   * @param isClientRequested the request's isClient field (null when not provided)
+   * @param isBlogRequested the request's isBlog field (null when not provided)
+   * @param requestedType the request's legacy type field (null when not provided)
+   * @param currentType the entity's current type (null on create)
+   * @return the consistent (type, isClient, isBlog) triple to store
+   * @throws IllegalArgumentException when both booleans are true (rejected as 400)
+   */
+  public static Resolved resolve(
+      Boolean isClientRequested,
+      Boolean isBlogRequested,
+      CollectionType requestedType,
+      CollectionType currentType) {
+    boolean flagsProvided = isClientRequested != null || isBlogRequested != null;
+    if (flagsProvided) {
+      boolean client = Boolean.TRUE.equals(isClientRequested);
+      boolean blog = Boolean.TRUE.equals(isBlogRequested);
+      if (client && blog) {
+        throw new IllegalArgumentException(
+            "isClient and isBlog are mutually exclusive; a collection cannot be both");
+      }
+      if (client) {
+        return new Resolved(CollectionType.CLIENT_GALLERY, true, false);
+      }
+      if (blog) {
+        return new Resolved(CollectionType.BLOG, false, true);
+      }
+      // Neither flag set: preserve the effective base type unless it encoded client/blog,
+      // which the booleans just disclaimed -- that folds to MISC.
+      CollectionType base = requestedType != null ? requestedType : currentType;
+      if (base == null || base == CollectionType.CLIENT_GALLERY || base == CollectionType.BLOG) {
+        base = CollectionType.MISC;
+      }
+      return new Resolved(base, false, false);
+    }
+
+    // Legacy path: no booleans in the request. Type field (or current type) drives the flags.
+    CollectionType type = requestedType != null ? requestedType : currentType;
+    if (type == null) {
+      type = CollectionType.MISC;
+    }
+    return new Resolved(type, deriveIsClient(type), deriveIsBlog(type));
+  }
+
+  /** True when the legacy type encodes a client gallery. */
+  public static boolean deriveIsClient(CollectionType type) {
+    return type == CollectionType.CLIENT_GALLERY;
+  }
+
+  /** True when the legacy type encodes a blog. */
+  public static boolean deriveIsBlog(CollectionType type) {
+    return type == CollectionType.BLOG;
+  }
+}

--- a/src/main/java/edens/zac/portfolio/backend/services/ContentModelConverter.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/ContentModelConverter.java
@@ -576,6 +576,8 @@ class ContentModelConverter {
         referencedCollection.getId(),
         referencedCollection.getSlug(),
         referencedCollection.getType(),
+        referencedCollection.isClient(),
+        referencedCollection.isBlog(),
         coverImage,
         referencedCollection.getCollectionDate(),
         referencedCollection.getCollectionEndDate(),

--- a/src/main/java/edens/zac/portfolio/backend/services/ImageUploadPipelineService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/ImageUploadPipelineService.java
@@ -554,14 +554,14 @@ public class ImageUploadPipelineService {
   }
 
   /**
-   * Get-or-create the BLOG collection for a capture day, keyed on {@code (type=BLOG,
+   * Get-or-create the blog collection for a capture day, keyed on {@code (is_blog=true,
    * collectionDate=day)}. If exactly one exists, reuse it; if multiple exist (should not happen),
-   * use the oldest and log a warning; otherwise create a new BLOG whose title/slug derive from the
-   * ISO date.
+   * use the oldest and log a warning; otherwise create a new blog whose title/slug derive from the
+   * ISO date. Creation still writes the legacy {@code type=BLOG} for dual-compat (the mapping layer
+   * derives {@code is_blog=true} from it).
    */
   private Long getOrCreateBlogForDay(LocalDate day) {
-    List<CollectionEntity> existing =
-        collectionRepository.findByTypeAndCollectionDate(CollectionType.BLOG, day);
+    List<CollectionEntity> existing = collectionRepository.findBlogsByCollectionDate(day);
     if (!existing.isEmpty()) {
       if (existing.size() > 1) {
         log.warn(

--- a/src/main/java/edens/zac/portfolio/backend/services/SyntheticCollectionResolver.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/SyntheticCollectionResolver.java
@@ -113,6 +113,8 @@ public class SyntheticCollectionResolver {
         .slug(slug)
         .title(spec.title())
         .type(CollectionType.PARENT)
+        .isClient(false)
+        .isBlog(false)
         .visibility(CollectionVisibility.LISTED)
         .content(content)
         .contentCount(content.size())

--- a/src/main/java/edens/zac/portfolio/backend/services/TagService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/TagService.java
@@ -65,9 +65,21 @@ public class TagService {
             ? request.visibility()
             : CollectionVisibility.UNLISTED;
 
-    // Create the collection, then take over the tag's slug and requested visibility.
+    // Create the collection, then take over the tag's slug and requested visibility. The
+    // isClient/isBlog booleans pass through to the create path, where CollectionTypeCompat
+    // resolves them against the (defaulted) legacy type: booleans win when provided, and the
+    // PORTFOLIO default is preserved when neither flag is true.
     CollectionRequests.UpdateResponse created =
-        collectionService.createCollection(new CollectionRequests.Create(type, tag.getTagName()));
+        collectionService.createCollection(
+            new CollectionRequests.Create(
+                type,
+                tag.getTagName(),
+                null,
+                null,
+                null,
+                null,
+                request != null ? request.isClient() : null,
+                request != null ? request.isBlog() : null));
     Long newCollectionId = created.collection().getId();
 
     CollectionEntity newCollection =

--- a/src/main/java/edens/zac/portfolio/backend/services/TagViewResolver.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/TagViewResolver.java
@@ -98,6 +98,8 @@ public class TagViewResolver {
             .slug(tag.getSlug())
             .title(tag.getTagName())
             .type(CollectionType.PARENT)
+            .isClient(false)
+            .isBlog(false)
             .derived(true)
             .visibility(CollectionVisibility.LISTED)
             .coverImage(representativeCover(memberCollections, memberImages))

--- a/src/main/java/edens/zac/portfolio/backend/services/UserPageAssembler.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/UserPageAssembler.java
@@ -93,6 +93,8 @@ public class UserPageAssembler {
         .title(title)
         .description(description)
         .type(CollectionType.PARENT)
+        .isClient(false)
+        .isBlog(false)
         .visibility(CollectionVisibility.UNLISTED)
         .coverImage(cover)
         .content(body)

--- a/src/main/resources/db/migration/V49__collection_client_blog_flags.sql
+++ b/src/main/resources/db/migration/V49__collection_client_blog_flags.sql
@@ -1,0 +1,47 @@
+-- V49: introduce is_client / is_blog booleans as the storage truth for what
+-- CollectionType.CLIENT_GALLERY / BLOG mean today.
+--
+-- Dual-compat window: the legacy `type` column is NOT dropped or altered here. The
+-- application keeps `type` and the new booleans in sync on every write; a later
+-- cleanup migration drops `type` after both deploys (BE then FE) verify.
+
+ALTER TABLE collection ADD COLUMN is_client BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE collection ADD COLUMN is_blog BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Backfill from the legacy type column.
+UPDATE collection
+SET is_client = (type = 'CLIENT_GALLERY'),
+    is_blog   = (type = 'BLOG');
+
+-- Label-tag backfill: ART_GALLERY / PORTFOLIO grouping must survive the eventual
+-- type drop, so each such collection gets a label tag. MISC gets nothing (untagged
+-- IS its meaning); PARENT/HOME get nothing (the graph/slug carry them).
+--
+-- Idempotent + collision-safe: tag inserts are guarded on slug existence (tag.slug
+-- has a unique index, idx_tag_slug from V8) with ON CONFLICT DO NOTHING as a final
+-- guard against any concurrent/unique-name collision; join-table inserts rely on
+-- the (collection_id, tag_id) primary key of collection_tags.
+
+INSERT INTO tag (tag_name, slug, created_at)
+SELECT 'Art Gallery', 'art-gallery', NOW()
+WHERE NOT EXISTS (SELECT 1 FROM tag WHERE slug = 'art-gallery')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO tag (tag_name, slug, created_at)
+SELECT 'Portfolio', 'portfolio', NOW()
+WHERE NOT EXISTS (SELECT 1 FROM tag WHERE slug = 'portfolio')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO collection_tags (collection_id, tag_id)
+SELECT c.id, t.id
+FROM collection c
+JOIN tag t ON t.slug = 'art-gallery'
+WHERE c.type = 'ART_GALLERY'
+ON CONFLICT (collection_id, tag_id) DO NOTHING;
+
+INSERT INTO collection_tags (collection_id, tag_id)
+SELECT c.id, t.id
+FROM collection c
+JOIN tag t ON t.slug = 'portfolio'
+WHERE c.type = 'PORTFOLIO'
+ON CONFLICT (collection_id, tag_id) DO NOTHING;

--- a/src/main/resources/db/migration/V50__collection_client_blog_flags.sql
+++ b/src/main/resources/db/migration/V50__collection_client_blog_flags.sql
@@ -1,4 +1,4 @@
--- V49: introduce is_client / is_blog booleans as the storage truth for what
+-- V50: introduce is_client / is_blog booleans as the storage truth for what
 -- CollectionType.CLIENT_GALLERY / BLOG mean today.
 --
 -- Dual-compat window: the legacy `type` column is NOT dropped or altered here. The

--- a/src/test/java/edens/zac/portfolio/backend/controller/admin/ContentControllerDevTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/admin/ContentControllerDevTest.java
@@ -1,5 +1,6 @@
 package edens.zac.portfolio.backend.controller.admin;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -23,6 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -366,6 +368,40 @@ class ContentControllerDevTest {
 
     verify(imageUploadPipelineService)
         .createCollectionWithImages(any(CollectionRequests.Create.class), anyList(), anyMap());
+  }
+
+  @Test
+  @DisplayName(
+      "POST /content/images/create-collection should accept booleans without legacy type param")
+  void createCollectionWithImages_typeOmitted_acceptsClientBlogBooleans() throws Exception {
+    // Arrange
+    MockMultipartFile file =
+        new MockMultipartFile("files", "photo.jpg", MediaType.IMAGE_JPEG_VALUE, "img".getBytes());
+
+    ImageUploadResult uploadResult = new ImageUploadResult(43L, testImages, List.of(), List.of());
+
+    when(imageUploadPipelineService.createCollectionWithImages(
+            any(CollectionRequests.Create.class), anyList(), anyMap()))
+        .thenReturn(uploadResult);
+
+    // Act & Assert: new FE sends only title + booleans (no legacy type param).
+    mockMvc
+        .perform(
+            multipart("/api/admin/content/images/create-collection")
+                .file(file)
+                .param("title", "Smith Wedding")
+                .param("isClient", "true")
+                .param("isBlog", "false"))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.collectionId", is(43)));
+
+    ArgumentCaptor<CollectionRequests.Create> createCaptor =
+        ArgumentCaptor.forClass(CollectionRequests.Create.class);
+    verify(imageUploadPipelineService)
+        .createCollectionWithImages(createCaptor.capture(), anyList(), anyMap());
+    assertThat(createCaptor.getValue().type()).isNull();
+    assertThat(createCaptor.getValue().isClient()).isTrue();
+    assertThat(createCaptor.getValue().isBlog()).isFalse();
   }
 
   // ============== POST /api/admin/content/images/{collectionId}/from-disk ==============

--- a/src/test/java/edens/zac/portfolio/backend/dao/CollectionFlagRepositoryIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/dao/CollectionFlagRepositoryIntegrationTest.java
@@ -16,10 +16,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 /**
- * Integration coverage for the V49 is_client / is_blog boolean predicates. Runs the real V49
+ * Integration coverage for the V50 is_client / is_blog boolean predicates. Runs the real V50
  * migration on Testcontainers Postgres. Verifies: the boolean-keyed repository queries key on the
  * flags (NOT the legacy type column), the derived parent-of-galleries query (no parent-side type
- * filter), the blog-by-date get-or-create key, save round-tripping of the flags, and the V49
+ * filter), the blog-by-date get-or-create key, save round-tripping of the flags, and the V50
  * label-tag seeds.
  */
 class CollectionFlagRepositoryIntegrationTest extends AbstractPostgresIntegrationTest {
@@ -66,7 +66,7 @@ class CollectionFlagRepositoryIntegrationTest extends AbstractPostgresIntegratio
 
   @Test
   void migrationSeedsLabelTags() {
-    // V49 idempotently ensures the art-gallery and portfolio label tags exist so grouping
+    // V50 idempotently ensures the art-gallery and portfolio label tags exist so grouping
     // survives the eventual type-column drop.
     List<String> slugs =
         jdbc.queryForList(

--- a/src/test/java/edens/zac/portfolio/backend/dao/CollectionFlagRepositoryIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/dao/CollectionFlagRepositoryIntegrationTest.java
@@ -1,0 +1,362 @@
+package edens.zac.portfolio.backend.dao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import edens.zac.portfolio.backend.AbstractPostgresIntegrationTest;
+import edens.zac.portfolio.backend.entity.CollectionContentEntity;
+import edens.zac.portfolio.backend.entity.CollectionEntity;
+import edens.zac.portfolio.backend.entity.ContentCollectionEntity;
+import edens.zac.portfolio.backend.types.CollectionType;
+import edens.zac.portfolio.backend.types.CollectionVisibility;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Integration coverage for the V49 is_client / is_blog boolean predicates. Runs the real V49
+ * migration on Testcontainers Postgres. Verifies: the boolean-keyed repository queries key on the
+ * flags (NOT the legacy type column), the derived parent-of-galleries query (no parent-side type
+ * filter), the blog-by-date get-or-create key, save round-tripping of the flags, and the V49
+ * label-tag seeds.
+ */
+class CollectionFlagRepositoryIntegrationTest extends AbstractPostgresIntegrationTest {
+
+  @Autowired private CollectionRepository collectionRepository;
+  @Autowired private ContentRepository contentRepository;
+  @Autowired private JdbcTemplate jdbc;
+
+  private CollectionEntity saveCollection(
+      String slug,
+      CollectionType type,
+      boolean isClient,
+      boolean isBlog,
+      CollectionVisibility visibility,
+      LocalDate date) {
+    return collectionRepository.save(
+        CollectionEntity.builder()
+            .type(type)
+            .isClient(isClient)
+            .isBlog(isBlog)
+            .title("Flag " + slug)
+            .slug(slug)
+            .collectionDate(date)
+            .visibility(visibility)
+            .totalContent(0)
+            .build());
+  }
+
+  /** Link child under parent through the content_collection join chain. */
+  private void linkChild(Long parentId, Long childId, boolean visible) {
+    CollectionEntity childRef =
+        collectionRepository.findById(childId).orElseThrow(IllegalStateException::new);
+    ContentCollectionEntity contentRef =
+        contentRepository.saveCollectionContent(
+            ContentCollectionEntity.builder().referencedCollection(childRef).build());
+    collectionRepository.saveContent(
+        CollectionContentEntity.builder()
+            .collectionId(parentId)
+            .contentId(contentRef.getId())
+            .orderIndex(0)
+            .visible(visible)
+            .build());
+  }
+
+  @Test
+  void migrationSeedsLabelTags() {
+    // V49 idempotently ensures the art-gallery and portfolio label tags exist so grouping
+    // survives the eventual type-column drop.
+    List<String> slugs =
+        jdbc.queryForList(
+            "SELECT slug FROM tag WHERE slug IN ('art-gallery', 'portfolio') ORDER BY slug",
+            String.class);
+    assertThat(slugs).containsExactly("art-gallery", "portfolio");
+  }
+
+  @Test
+  void saveRoundTripsFlags() {
+    CollectionEntity saved =
+        saveCollection(
+            "flag-roundtrip",
+            CollectionType.CLIENT_GALLERY,
+            true,
+            false,
+            CollectionVisibility.LISTED,
+            LocalDate.of(2026, 1, 5));
+
+    CollectionEntity reloaded = collectionRepository.findById(saved.getId()).orElseThrow();
+
+    assertThat(reloaded.isClient()).isTrue();
+    assertThat(reloaded.isBlog()).isFalse();
+    assertThat(reloaded.getType()).isEqualTo(CollectionType.CLIENT_GALLERY);
+  }
+
+  @Test
+  void findListedBlogsOrdered_keysOnIsBlogNotType() {
+    CollectionEntity blogFlagged =
+        saveCollection(
+            "flag-blog-flagged",
+            CollectionType.BLOG,
+            false,
+            true,
+            CollectionVisibility.LISTED,
+            LocalDate.of(2026, 2, 1));
+    // Boolean is the truth: a MISC-typed row with is_blog=true must be returned...
+    CollectionEntity miscButBlog =
+        saveCollection(
+            "flag-misc-but-blog",
+            CollectionType.MISC,
+            false,
+            true,
+            CollectionVisibility.LISTED,
+            LocalDate.of(2026, 2, 2));
+    // ...and a BLOG-typed row with is_blog=false must NOT be.
+    CollectionEntity blogTypeNoFlag =
+        saveCollection(
+            "flag-blog-type-no-flag",
+            CollectionType.BLOG,
+            false,
+            false,
+            CollectionVisibility.LISTED,
+            LocalDate.of(2026, 2, 3));
+    CollectionEntity unlistedBlog =
+        saveCollection(
+            "flag-unlisted-blog",
+            CollectionType.BLOG,
+            false,
+            true,
+            CollectionVisibility.UNLISTED,
+            LocalDate.of(2026, 2, 4));
+
+    List<Long> ids =
+        collectionRepository.findListedBlogsOrdered().stream()
+            .map(CollectionEntity::getId)
+            .toList();
+
+    assertThat(ids).contains(blogFlagged.getId(), miscButBlog.getId());
+    assertThat(ids).doesNotContain(blogTypeNoFlag.getId(), unlistedBlog.getId());
+  }
+
+  @Test
+  void findBlogsByCollectionDate_keysOnIsBlogAndReturnsOldestFirst() {
+    LocalDate day = LocalDate.of(2026, 3, 15);
+    CollectionEntity older =
+        collectionRepository.save(
+            CollectionEntity.builder()
+                .type(CollectionType.BLOG)
+                .isBlog(true)
+                .title("Flag blog older")
+                .slug("flag-blog-day-older")
+                .collectionDate(day)
+                .visibility(CollectionVisibility.LISTED)
+                .totalContent(0)
+                .createdAt(LocalDateTime.of(2026, 3, 15, 8, 0))
+                .build());
+    CollectionEntity newer =
+        collectionRepository.save(
+            CollectionEntity.builder()
+                .type(CollectionType.BLOG)
+                .isBlog(true)
+                .title("Flag blog newer")
+                .slug("flag-blog-day-newer")
+                .collectionDate(day)
+                .visibility(CollectionVisibility.LISTED)
+                .totalContent(0)
+                .createdAt(LocalDateTime.of(2026, 3, 15, 12, 0))
+                .build());
+    // Same day but is_blog=false: must not be part of the get-or-create key.
+    CollectionEntity sameDayNotBlog =
+        saveCollection(
+            "flag-day-not-blog",
+            CollectionType.MISC,
+            false,
+            false,
+            CollectionVisibility.LISTED,
+            day);
+
+    List<CollectionEntity> found = collectionRepository.findBlogsByCollectionDate(day);
+
+    List<Long> ids = found.stream().map(CollectionEntity::getId).toList();
+    assertThat(ids).containsExactly(older.getId(), newer.getId());
+    assertThat(ids).doesNotContain(sameDayNotBlog.getId());
+  }
+
+  @Test
+  void findClientGalleriesByVisibilityIn_keysOnIsClient() {
+    CollectionEntity listedGallery =
+        saveCollection(
+            "flag-cg-listed",
+            CollectionType.CLIENT_GALLERY,
+            true,
+            false,
+            CollectionVisibility.LISTED,
+            LocalDate.of(2026, 4, 1));
+    CollectionEntity unlistedGallery =
+        saveCollection(
+            "flag-cg-unlisted",
+            CollectionType.CLIENT_GALLERY,
+            true,
+            false,
+            CollectionVisibility.UNLISTED,
+            LocalDate.of(2026, 4, 2));
+    CollectionEntity hiddenGallery =
+        saveCollection(
+            "flag-cg-hidden",
+            CollectionType.CLIENT_GALLERY,
+            true,
+            false,
+            CollectionVisibility.HIDDEN,
+            LocalDate.of(2026, 4, 3));
+    CollectionEntity notClient =
+        saveCollection(
+            "flag-cg-not-client",
+            CollectionType.PORTFOLIO,
+            false,
+            false,
+            CollectionVisibility.LISTED,
+            LocalDate.of(2026, 4, 4));
+
+    List<Long> ids =
+        collectionRepository
+            .findClientGalleriesByVisibilityIn(
+                List.of(CollectionVisibility.LISTED, CollectionVisibility.UNLISTED))
+            .stream()
+            .map(CollectionEntity::getId)
+            .toList();
+
+    assertThat(ids).contains(listedGallery.getId(), unlistedGallery.getId());
+    assertThat(ids).doesNotContain(hiddenGallery.getId(), notClient.getId());
+  }
+
+  @Test
+  void findClientGalleriesAndQualifyingParents_includesDerivedParentsWithoutTypeFilter() {
+    List<CollectionVisibility> scope = List.of(CollectionVisibility.LISTED);
+
+    CollectionEntity standaloneGallery =
+        saveCollection(
+            "flag-parent-standalone",
+            CollectionType.CLIENT_GALLERY,
+            true,
+            false,
+            CollectionVisibility.LISTED,
+            LocalDate.of(2026, 5, 1));
+
+    // PARENT-typed wrapper with a visible client child: qualifies (as before).
+    CollectionEntity parentTyped =
+        saveCollection(
+            "flag-parent-typed",
+            CollectionType.PARENT,
+            false,
+            false,
+            CollectionVisibility.LISTED,
+            LocalDate.of(2026, 5, 2));
+    CollectionEntity childOfParentTyped =
+        saveCollection(
+            "flag-parent-typed-child",
+            CollectionType.CLIENT_GALLERY,
+            true,
+            false,
+            CollectionVisibility.LISTED,
+            LocalDate.of(2026, 5, 3));
+    linkChild(parentTyped.getId(), childOfParentTyped.getId(), true);
+
+    // Derived parent: NOT typed PARENT, but has a visible is_client child -> must now qualify.
+    CollectionEntity derivedParent =
+        saveCollection(
+            "flag-parent-derived",
+            CollectionType.MISC,
+            false,
+            false,
+            CollectionVisibility.LISTED,
+            LocalDate.of(2026, 5, 4));
+    CollectionEntity childOfDerived =
+        saveCollection(
+            "flag-parent-derived-child",
+            CollectionType.CLIENT_GALLERY,
+            true,
+            false,
+            CollectionVisibility.LISTED,
+            LocalDate.of(2026, 5, 5));
+    linkChild(derivedParent.getId(), childOfDerived.getId(), true);
+
+    // Parent whose only client child is HIDDEN: child fails the visibility scope -> excluded.
+    CollectionEntity parentOfHiddenChild =
+        saveCollection(
+            "flag-parent-hidden-child",
+            CollectionType.PARENT,
+            false,
+            false,
+            CollectionVisibility.LISTED,
+            LocalDate.of(2026, 5, 6));
+    CollectionEntity hiddenChild =
+        saveCollection(
+            "flag-parent-hidden-child-c",
+            CollectionType.CLIENT_GALLERY,
+            true,
+            false,
+            CollectionVisibility.HIDDEN,
+            LocalDate.of(2026, 5, 7));
+    linkChild(parentOfHiddenChild.getId(), hiddenChild.getId(), true);
+
+    // Parent linked to a client child through a soft-removed (visible=false) row: excluded.
+    CollectionEntity parentOfSoftRemoved =
+        saveCollection(
+            "flag-parent-soft-removed",
+            CollectionType.PARENT,
+            false,
+            false,
+            CollectionVisibility.LISTED,
+            LocalDate.of(2026, 5, 8));
+    CollectionEntity softRemovedChild =
+        saveCollection(
+            "flag-parent-soft-removed-c",
+            CollectionType.CLIENT_GALLERY,
+            true,
+            false,
+            CollectionVisibility.LISTED,
+            LocalDate.of(2026, 5, 9));
+    linkChild(parentOfSoftRemoved.getId(), softRemovedChild.getId(), false);
+
+    // Parent of only non-client children: excluded.
+    CollectionEntity parentOfNonClient =
+        saveCollection(
+            "flag-parent-non-client",
+            CollectionType.PARENT,
+            false,
+            false,
+            CollectionVisibility.LISTED,
+            LocalDate.of(2026, 5, 10));
+    CollectionEntity nonClientChild =
+        saveCollection(
+            "flag-parent-non-client-c",
+            CollectionType.PORTFOLIO,
+            false,
+            false,
+            CollectionVisibility.LISTED,
+            LocalDate.of(2026, 5, 11));
+    linkChild(parentOfNonClient.getId(), nonClientChild.getId(), true);
+
+    List<Long> ids =
+        collectionRepository.findClientGalleriesAndQualifyingParents(scope).stream()
+            .map(CollectionEntity::getId)
+            .toList();
+
+    assertThat(ids)
+        .contains(
+            standaloneGallery.getId(),
+            parentTyped.getId(),
+            derivedParent.getId(),
+            childOfParentTyped.getId(),
+            childOfDerived.getId(),
+            softRemovedChild.getId());
+    assertThat(ids)
+        .doesNotContain(
+            parentOfHiddenChild.getId(),
+            parentOfSoftRemoved.getId(),
+            parentOfNonClient.getId(),
+            hiddenChild.getId(),
+            nonClientChild.getId());
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/dao/CollectionListReadRepositoryIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/dao/CollectionListReadRepositoryIntegrationTest.java
@@ -7,6 +7,8 @@ import edens.zac.portfolio.backend.entity.CollectionContentEntity;
 import edens.zac.portfolio.backend.entity.CollectionEntity;
 import edens.zac.portfolio.backend.entity.ContentImageEntity;
 import edens.zac.portfolio.backend.entity.TagEntity;
+import edens.zac.portfolio.backend.model.CollectionRequests;
+import edens.zac.portfolio.backend.services.CollectionProcessingUtil;
 import edens.zac.portfolio.backend.types.CollectionType;
 import edens.zac.portfolio.backend.types.CollectionVisibility;
 import edens.zac.portfolio.backend.types.ContentType;
@@ -28,6 +30,7 @@ class CollectionListReadRepositoryIntegrationTest extends AbstractPostgresIntegr
   @Autowired private CollectionRepository collectionRepository;
   @Autowired private TagRepository tagRepository;
   @Autowired private ContentRepository contentRepository;
+  @Autowired private CollectionProcessingUtil collectionProcessingUtil;
 
   private CollectionEntity saveCollection(String slug, LocalDate date, CollectionVisibility vis) {
     return collectionRepository.save(
@@ -129,6 +132,38 @@ class CollectionListReadRepositoryIntegrationTest extends AbstractPostgresIntegr
             .map(CollectionEntity::getId)
             .toList();
     assertThat(includingHidden).contains(hidden.getId());
+  }
+
+  @Test
+  void createdCollectionWithUnspecifiedVisibility_doesNotSurfaceInProdListedOnlyListing() {
+    // Prod reads scope listings to LISTED only (CollectionVisibility.visibleScope(false));
+    // the dev scope includes UNLISTED and HIDDEN, which masks this behavior locally. A
+    // collection created without an explicit visibility must default to UNLISTED and stay
+    // out of the LISTED-only listing until an admin explicitly lists it.
+    CollectionEntity created =
+        collectionRepository.save(
+            collectionProcessingUtil.toEntity(
+                new CollectionRequests.Create(CollectionType.BLOG, "Create Default Vis"), 30));
+    attachVisibleContent(created.getId());
+
+    assertThat(created.getVisibility()).isEqualTo(CollectionVisibility.UNLISTED);
+
+    List<Long> prodListing =
+        collectionRepository
+            .findNonEmptyByVisibilityInOrderByDate(CollectionVisibility.visibleScope(false))
+            .stream()
+            .map(CollectionEntity::getId)
+            .toList();
+    assertThat(prodListing).doesNotContain(created.getId());
+
+    // Dev/local scope still surfaces it -- the reason this drift was invisible in dev.
+    List<Long> devListing =
+        collectionRepository
+            .findNonEmptyByVisibilityInOrderByDate(CollectionVisibility.visibleScope(true))
+            .stream()
+            .map(CollectionEntity::getId)
+            .toList();
+    assertThat(devListing).contains(created.getId());
   }
 
   @Test

--- a/src/test/java/edens/zac/portfolio/backend/dao/CollectionRepositoryTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/dao/CollectionRepositoryTest.java
@@ -150,22 +150,20 @@ class CollectionRepositoryTest {
   }
 
   @Nested
-  class FindByTypeAndListedOrdered {
+  class FindListedBlogsOrdered {
 
     @SuppressWarnings("unchecked")
     @Test
-    void findByTypeAndListedOrderedSqlOrdersByRatingThenDate() {
-      when(namedParameterJdbcTemplate.query(
-              anyString(), any(MapSqlParameterSource.class), any(RowMapper.class)))
+    void findListedBlogsOrderedSqlFiltersOnIsBlogAndOrdersByRatingThenDate() {
+      when(namedParameterJdbcTemplate.query(anyString(), any(RowMapper.class)))
           .thenReturn(List.of());
 
-      collectionRepository.findByTypeAndListedOrdered(CollectionType.BLOG);
+      collectionRepository.findListedBlogsOrdered();
 
-      verify(namedParameterJdbcTemplate)
-          .query(sqlCaptor.capture(), any(MapSqlParameterSource.class), any(RowMapper.class));
+      verify(namedParameterJdbcTemplate).query(sqlCaptor.capture(), any(RowMapper.class));
       String sql = sqlCaptor.getValue();
       assertThat(sql).containsIgnoringCase("ORDER BY rating DESC NULLS LAST, collection_date DESC");
-      assertThat(sql).containsIgnoringCase("WHERE type = :type AND visibility = 'LISTED'");
+      assertThat(sql).containsIgnoringCase("WHERE is_blog = true AND visibility = 'LISTED'");
     }
   }
 

--- a/src/test/java/edens/zac/portfolio/backend/model/CollectionFlagSerializationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/model/CollectionFlagSerializationTest.java
@@ -136,6 +136,36 @@ class CollectionFlagSerializationTest {
   }
 
   @Test
+  @DisplayName("SaveAsCollectionRequest deserializes isClient/isBlog from exactly those names")
+  void saveAsCollectionRequest_deserializesFlags() throws Exception {
+    String json =
+        """
+        {"isClient": true, "isBlog": false}
+        """;
+
+    SaveAsCollectionRequest request = objectMapper.readValue(json, SaveAsCollectionRequest.class);
+
+    assertThat(request.isClient()).isTrue();
+    assertThat(request.isBlog()).isFalse();
+    assertThat(request.type()).isNull();
+  }
+
+  @Test
+  @DisplayName("SaveAsCollectionRequest without booleans leaves them null (legacy payload)")
+  void saveAsCollectionRequest_legacyPayloadLeavesFlagsNull() throws Exception {
+    String json =
+        """
+        {"type": "PORTFOLIO"}
+        """;
+
+    SaveAsCollectionRequest request = objectMapper.readValue(json, SaveAsCollectionRequest.class);
+
+    assertThat(request.type()).isEqualTo(CollectionType.PORTFOLIO);
+    assertThat(request.isClient()).isNull();
+    assertThat(request.isBlog()).isNull();
+  }
+
+  @Test
   @DisplayName("Update request deserializes isClient/isBlog from exactly those names")
   void updateRequest_deserializesFlags() throws Exception {
     String json =

--- a/src/test/java/edens/zac/portfolio/backend/model/CollectionFlagSerializationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/model/CollectionFlagSerializationTest.java
@@ -1,0 +1,154 @@
+package edens.zac.portfolio.backend.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edens.zac.portfolio.backend.types.CollectionType;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Locks the exact JSON property names of the new client/blog booleans on every collection-bearing
+ * payload. Guards against the Lombok/Jackson boolean-getter trap where a boolean {@code isClient}
+ * getter {@code isClient()} silently serializes as {@code "client"}.
+ */
+class CollectionFlagSerializationTest {
+
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    objectMapper = new ObjectMapper();
+    objectMapper.findAndRegisterModules();
+  }
+
+  @Test
+  @DisplayName("CollectionModel serializes isClient/isBlog under exactly those names")
+  void collectionModel_serializesExactFlagNames() throws Exception {
+    CollectionModel model =
+        CollectionModel.builder()
+            .id(1L)
+            .type(CollectionType.CLIENT_GALLERY)
+            .isClient(true)
+            .isBlog(false)
+            .title("Smith Wedding")
+            .slug("smith-wedding")
+            .build();
+
+    JsonNode json = objectMapper.readTree(objectMapper.writeValueAsString(model));
+
+    assertThat(json.has("isClient")).isTrue();
+    assertThat(json.get("isClient").booleanValue()).isTrue();
+    assertThat(json.has("isBlog")).isTrue();
+    assertThat(json.get("isBlog").booleanValue()).isFalse();
+    // The boolean-getter rename trap would emit these instead:
+    assertThat(json.has("client")).isFalse();
+    assertThat(json.has("blog")).isFalse();
+    // Legacy type still emitted during the dual-compat window.
+    assertThat(json.get("type").asText()).isEqualTo("CLIENT_GALLERY");
+  }
+
+  @Test
+  @DisplayName("Records.CollectionList serializes isClient/isBlog under exactly those names")
+  void collectionList_serializesExactFlagNames() throws Exception {
+    Records.CollectionList list =
+        new Records.CollectionList(
+            2L, "Daily Blog", "daily-blog", CollectionType.BLOG, null, null, false, true);
+
+    JsonNode json = objectMapper.readTree(objectMapper.writeValueAsString(list));
+
+    assertThat(json.has("isClient")).isTrue();
+    assertThat(json.get("isClient").booleanValue()).isFalse();
+    assertThat(json.has("isBlog")).isTrue();
+    assertThat(json.get("isBlog").booleanValue()).isTrue();
+    assertThat(json.has("client")).isFalse();
+    assertThat(json.has("blog")).isFalse();
+  }
+
+  @Test
+  @DisplayName("ContentModels.Collection serializes isClient/isBlog under exactly those names")
+  void contentModelsCollection_serializesExactFlagNames() throws Exception {
+    ContentModels.Collection block =
+        new ContentModels.Collection(
+            3L,
+            edens.zac.portfolio.backend.types.ContentType.COLLECTION,
+            "Wrapped Gallery",
+            null,
+            null,
+            0,
+            true,
+            null,
+            null,
+            30L,
+            "wrapped-gallery",
+            CollectionType.CLIENT_GALLERY,
+            true,
+            false,
+            null,
+            null,
+            null,
+            List.of());
+
+    JsonNode json = objectMapper.readTree(objectMapper.writeValueAsString(block));
+
+    assertThat(json.has("isClient")).isTrue();
+    assertThat(json.get("isClient").booleanValue()).isTrue();
+    assertThat(json.has("isBlog")).isTrue();
+    assertThat(json.get("isBlog").booleanValue()).isFalse();
+    assertThat(json.has("client")).isFalse();
+    assertThat(json.has("blog")).isFalse();
+  }
+
+  @Test
+  @DisplayName("Create request deserializes isClient/isBlog from exactly those names")
+  void createRequest_deserializesFlags() throws Exception {
+    String json =
+        """
+        {"title": "New Gallery", "isClient": true, "isBlog": false}
+        """;
+
+    CollectionRequests.Create create =
+        objectMapper.readValue(json, CollectionRequests.Create.class);
+
+    assertThat(create.isClient()).isTrue();
+    assertThat(create.isBlog()).isFalse();
+    assertThat(create.type()).isNull();
+    assertThat(create.title()).isEqualTo("New Gallery");
+  }
+
+  @Test
+  @DisplayName("Create request without booleans leaves them null (legacy type-only payload)")
+  void createRequest_legacyPayloadLeavesFlagsNull() throws Exception {
+    String json =
+        """
+        {"type": "BLOG", "title": "Legacy Blog"}
+        """;
+
+    CollectionRequests.Create create =
+        objectMapper.readValue(json, CollectionRequests.Create.class);
+
+    assertThat(create.type()).isEqualTo(CollectionType.BLOG);
+    assertThat(create.isClient()).isNull();
+    assertThat(create.isBlog()).isNull();
+  }
+
+  @Test
+  @DisplayName("Update request deserializes isClient/isBlog from exactly those names")
+  void updateRequest_deserializesFlags() throws Exception {
+    String json =
+        """
+        {"id": 9, "isClient": false, "isBlog": true}
+        """;
+
+    CollectionRequests.Update update =
+        objectMapper.readValue(json, CollectionRequests.Update.class);
+
+    assertThat(update.id()).isEqualTo(9L);
+    assertThat(update.isClient()).isFalse();
+    assertThat(update.isBlog()).isTrue();
+    assertThat(update.type()).isNull();
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/model/ContentRequestsTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/model/ContentRequestsTest.java
@@ -208,11 +208,12 @@ class ContentRequestsTest {
   }
 
   @Test
-  void collectionCreate_nullType_hasViolation() {
+  void collectionCreate_nullType_isValid() {
+    // Dual-compat window: type is optional (new frontends send only booleans + title; a create
+    // with neither type nor booleans resolves to MISC in the mapping layer).
     var create = new CollectionRequests.Create(null, "My Blog");
     Set<ConstraintViolation<CollectionRequests.Create>> violations = validator.validate(create);
-    assertThat(violations).isNotEmpty();
-    assertThat(violations).anyMatch(v -> v.getMessage().contains("Type is required"));
+    assertThat(violations).isEmpty();
   }
 
   @Test

--- a/src/test/java/edens/zac/portfolio/backend/services/AdminHomeServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/AdminHomeServiceTest.java
@@ -12,7 +12,6 @@ import edens.zac.portfolio.backend.dao.ContentRepository;
 import edens.zac.portfolio.backend.model.CollectionModel;
 import edens.zac.portfolio.backend.model.ContentModels;
 import edens.zac.portfolio.backend.model.Records;
-import edens.zac.portfolio.backend.types.CollectionType;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -109,13 +108,11 @@ class AdminHomeServiceTest {
           .thenReturn(Optional.of("https://cdn/example/random-image.webp"));
 
       var blog = collectionWithCoverImage(31L, "trip", "https://cdn/example/blog.webp", 900, 600);
-      when(collectionService.findVisibleByTypeOrderByDate(CollectionType.BLOG))
-          .thenReturn(List.of(blog));
+      when(collectionService.findVisibleBlogsOrderedByDate()).thenReturn(List.of(blog));
 
       var gallery =
           collectionWithCoverImage(41L, "smith", "https://cdn/example/gallery.webp", 1400, 933);
-      when(collectionService.findByTypeForAdminCovers(CollectionType.CLIENT_GALLERY))
-          .thenReturn(List.of(gallery));
+      when(collectionService.findClientGalleriesForAdminCovers()).thenReturn(List.of(gallery));
 
       List<Records.AdminHomeTileResponse> tiles = service.getTiles();
 
@@ -189,8 +186,7 @@ class AdminHomeServiceTest {
     @Test
     void emptyCandidatesYieldNullCover() {
       when(tileRepository.findAllOrderedByDisplay()).thenReturn(List.of(new TileRow("blogs", 5)));
-      when(collectionService.findVisibleByTypeOrderByDate(CollectionType.BLOG))
-          .thenReturn(List.of());
+      when(collectionService.findVisibleBlogsOrderedByDate()).thenReturn(List.of());
 
       List<Records.AdminHomeTileResponse> tiles = service.getTiles();
 

--- a/src/test/java/edens/zac/portfolio/backend/services/CollectionProcessingUtilTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/CollectionProcessingUtilTest.java
@@ -22,6 +22,7 @@ import edens.zac.portfolio.backend.model.Records;
 import edens.zac.portfolio.backend.types.CollectionType;
 import edens.zac.portfolio.backend.types.CollectionVisibility;
 import edens.zac.portfolio.backend.types.ContentType;
+import edens.zac.portfolio.backend.types.DisplayMode;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -259,9 +260,10 @@ class CollectionProcessingUtilTest {
 
   /**
    * Build an Update that only carries date-range fields (everything else null). Canonical 21-arg
-   * order: id, type, title, slug, description, locations, collectionDate, collectionEndDate,
-   * clearCollectionDate, clearCollectionEndDate, visibility, rating, displayMode, contentPerPage,
-   * rowsWide, coverImageId, tags, people, collections, siblings, parents.
+   * order: id, type, isClient, isBlog, title, slug, description, locations, collectionDate,
+   * collectionEndDate, clearCollectionDate, clearCollectionEndDate, visibility, rating,
+   * displayMode, contentPerPage, rowsWide, coverImageId, tags, people, collections, siblings,
+   * parents.
    */
   private static CollectionRequests.Update dateRangeUpdate(
       LocalDate collectionDate,
@@ -270,6 +272,8 @@ class CollectionProcessingUtilTest {
       Boolean clearCollectionEndDate) {
     return new CollectionRequests.Update(
         1L,
+        null,
+        null,
         null,
         null,
         null,
@@ -359,5 +363,210 @@ class CollectionProcessingUtilTest {
     CollectionModel model = util.convertToBasicModel(testEntity);
 
     assertEquals(LocalDate.of(2026, 3, 7), model.getCollectionEndDate());
+  }
+
+  // =============================================================================
+  // D10: chronological default display mode
+  // =============================================================================
+
+  @Test
+  void toEntity_defaultsDisplayModeToChronologicalForEveryType() {
+    // D10: the type-keyed default (BLOG -> CHRONOLOGICAL, everything else -> ORDERED) is gone.
+    // Every create without an explicit displayMode lands on CHRONOLOGICAL; ORDERED is opt-in
+    // via a later update.
+    when(collectionRepository.findBySlug(anyString())).thenReturn(Optional.empty());
+
+    for (CollectionType type : CollectionType.values()) {
+      CollectionRequests.Create request =
+          new CollectionRequests.Create(type, "Typed " + type.name());
+
+      CollectionEntity entity = util.toEntity(request, 30);
+
+      assertEquals(
+          DisplayMode.CHRONOLOGICAL,
+          entity.getDisplayMode(),
+          "Create default displayMode for type " + type + " must be CHRONOLOGICAL");
+    }
+  }
+
+  @Test
+  void applyBasicUpdates_explicitOrderedDisplayModeIsRespected() {
+    testEntity.setDisplayMode(DisplayMode.CHRONOLOGICAL);
+
+    util.applyBasicUpdates(
+        testEntity,
+        new CollectionRequests.Update(
+            1L,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            DisplayMode.ORDERED,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null));
+
+    assertEquals(DisplayMode.ORDERED, testEntity.getDisplayMode());
+  }
+
+  @Test
+  void convertToBasicModel_nullDisplayModeFallsBackToChronologicalRegardlessOfType() {
+    testEntity.setType(CollectionType.PORTFOLIO);
+    testEntity.setDisplayMode(null);
+
+    CollectionModel model = util.convertToBasicModel(testEntity);
+
+    assertEquals(DisplayMode.CHRONOLOGICAL, model.getDisplayMode());
+  }
+
+  @Test
+  void convertToBasicModel_storedOrderedDisplayModeIsPreserved() {
+    // Existing rows are NOT backfilled: a stored ORDERED mode must survive conversion.
+    testEntity.setDisplayMode(DisplayMode.ORDERED);
+
+    CollectionModel model = util.convertToBasicModel(testEntity);
+
+    assertEquals(DisplayMode.ORDERED, model.getDisplayMode());
+  }
+
+  // =============================================================================
+  // Dual-compat type/flag resolution on create and update
+  // =============================================================================
+
+  @Test
+  void toEntity_isClientTrue_setsClientGalleryTypeAndFlags() {
+    when(collectionRepository.findBySlug(anyString())).thenReturn(Optional.empty());
+    CollectionRequests.Create request =
+        new CollectionRequests.Create(null, "Boolean Gallery", null, null, null, null, true, false);
+
+    CollectionEntity entity = util.toEntity(request, 30);
+
+    assertEquals(CollectionType.CLIENT_GALLERY, entity.getType());
+    assertTrue(entity.isClient());
+    assertFalse(entity.isBlog());
+  }
+
+  @Test
+  void toEntity_legacyBlogType_derivesIsBlog() {
+    when(collectionRepository.findBySlug(anyString())).thenReturn(Optional.empty());
+    CollectionRequests.Create request =
+        new CollectionRequests.Create(CollectionType.BLOG, "Legacy Blog");
+
+    CollectionEntity entity = util.toEntity(request, 30);
+
+    assertEquals(CollectionType.BLOG, entity.getType());
+    assertFalse(entity.isClient());
+    assertTrue(entity.isBlog());
+  }
+
+  @Test
+  void toEntity_neitherTypeNorBooleans_landsOnMisc() {
+    when(collectionRepository.findBySlug(anyString())).thenReturn(Optional.empty());
+    CollectionRequests.Create request = new CollectionRequests.Create(null, "Untyped Create");
+
+    CollectionEntity entity = util.toEntity(request, 30);
+
+    assertEquals(CollectionType.MISC, entity.getType());
+    assertFalse(entity.isClient());
+    assertFalse(entity.isBlog());
+  }
+
+  @Test
+  void applyBasicUpdates_isBlogTrue_setsBlogTypeAndFlags() {
+    testEntity.setType(CollectionType.MISC);
+
+    util.applyBasicUpdates(
+        testEntity,
+        new CollectionRequests.Update(
+            1L, null, false, true, null, null, null, null, null, null, null, null, null, null, null,
+            null, null, null, null, null, null, null, null));
+
+    assertEquals(CollectionType.BLOG, testEntity.getType());
+    assertTrue(testEntity.isBlog());
+    assertFalse(testEntity.isClient());
+  }
+
+  @Test
+  void applyBasicUpdates_legacyClientGalleryType_derivesIsClient() {
+    testEntity.setType(CollectionType.MISC);
+
+    util.applyBasicUpdates(
+        testEntity,
+        new CollectionRequests.Update(
+            1L,
+            CollectionType.CLIENT_GALLERY,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null));
+
+    assertEquals(CollectionType.CLIENT_GALLERY, testEntity.getType());
+    assertTrue(testEntity.isClient());
+    assertFalse(testEntity.isBlog());
+  }
+
+  @Test
+  void applyBasicUpdates_bothFlagsTrue_isRejected() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            util.applyBasicUpdates(
+                testEntity,
+                new CollectionRequests.Update(
+                    1L, null, true, true, null, null, null, null, null, null, null, null, null,
+                    null, null, null, null, null, null, null, null, null, null)));
+  }
+
+  @Test
+  void applyBasicUpdates_noTypeOrFlagsInRequest_leavesTypeAndFlagsUntouched() {
+    testEntity.setType(CollectionType.BLOG);
+    testEntity.setBlog(true);
+
+    // Description-only update: no type field and no booleans in the request.
+    util.applyBasicUpdates(
+        testEntity,
+        new CollectionRequests.Update(
+            1L,
+            null,
+            null,
+            null,
+            "New description",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null));
+
+    assertEquals(CollectionType.BLOG, testEntity.getType());
+    assertTrue(testEntity.isBlog());
   }
 }

--- a/src/test/java/edens/zac/portfolio/backend/services/CollectionProcessingUtilTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/CollectionProcessingUtilTest.java
@@ -147,7 +147,6 @@ class CollectionProcessingUtilTest {
     // Arrange
     CollectionEntity entity = new CollectionEntity();
     entity.setType(CollectionType.CLIENT_GALLERY);
-    // Reset to HIDDEN (the field default) so the type-specific override applies.
     entity.setVisibility(CollectionVisibility.HIDDEN);
 
     // Act
@@ -156,8 +155,39 @@ class CollectionProcessingUtilTest {
     // Assert
     // Config JSON removed; ensure other defaults still apply
     assertEquals(30, result.getContentPerPage());
-    // Client galleries are private by default -> UNLISTED (direct slug access only).
-    assertEquals(CollectionVisibility.UNLISTED, result.getVisibility());
+    // Visibility is no longer touched here: the create-path default (UNLISTED) lives in
+    // toEntity, and this method must not flip an entity's visibility.
+    assertEquals(CollectionVisibility.HIDDEN, result.getVisibility());
+  }
+
+  @Test
+  void toEntity_createWithoutVisibility_defaultsToUnlisted() {
+    // Create request carries no visibility field -> privacy-first UNLISTED default.
+    when(collectionRepository.findBySlug(anyString())).thenReturn(Optional.empty());
+    CollectionRequests.Create request =
+        new CollectionRequests.Create(CollectionType.PORTFOLIO, "New Portfolio");
+
+    CollectionEntity entity = util.toEntity(request, 30);
+
+    assertEquals(CollectionVisibility.UNLISTED, entity.getVisibility());
+  }
+
+  @Test
+  void toEntity_unlistedDefaultAppliesToAllTypes() {
+    // The old CLIENT_GALLERY special case is gone: UNLISTED is the universal create default.
+    when(collectionRepository.findBySlug(anyString())).thenReturn(Optional.empty());
+
+    for (CollectionType type : CollectionType.values()) {
+      CollectionRequests.Create request =
+          new CollectionRequests.Create(type, "Typed " + type.name());
+
+      CollectionEntity entity = util.toEntity(request, 30);
+
+      assertEquals(
+          CollectionVisibility.UNLISTED,
+          entity.getVisibility(),
+          "Create default for type " + type + " must be UNLISTED");
+    }
   }
 
   @Test

--- a/src/test/java/edens/zac/portfolio/backend/services/CollectionServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/CollectionServiceTest.java
@@ -1041,6 +1041,8 @@ class CollectionServiceTest {
               20L,
               "portfolio",
               CollectionType.PORTFOLIO,
+              false,
+              false,
               null,
               null,
               null,
@@ -1287,6 +1289,8 @@ class CollectionServiceTest {
           childId,
           "child-" + childId,
           type,
+          false,
+          false,
           null,
           null,
           null,
@@ -1805,9 +1809,11 @@ class CollectionServiceTest {
 
     private CollectionRequests.Update updateWithParents(
         CollectionRequests.CollectionUpdate parents) {
-      // Canonical 21-arg constructor: id + 19 nulls + parents (last).
+      // Canonical 23-arg constructor: id + 21 nulls + parents (last).
       return new CollectionRequests.Update(
           current.getId(),
+          null,
+          null,
           null,
           null,
           null,

--- a/src/test/java/edens/zac/portfolio/backend/services/CollectionTypeCompatTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/CollectionTypeCompatTest.java
@@ -89,11 +89,54 @@ class CollectionTypeCompatTest {
     }
 
     @Test
-    void singleFalseFlagCountsAsProvided() {
-      // isClient=false alone (isBlog absent) still enters the booleans-win path: flags were
-      // provided and neither is true, so a stored BLOG type folds to MISC.
+    void nullFlagInheritsFromCurrentType_partialUpdateDoesNotDemote() {
+      // isClient=false alone (isBlog absent) leaves isBlog untouched: it inherits true from
+      // the stored BLOG type, so the collection stays a blog.
       var resolved = CollectionTypeCompat.resolve(false, null, null, CollectionType.BLOG);
+      assertThat(resolved.type()).isEqualTo(CollectionType.BLOG);
+      assertThat(resolved.isClient()).isFalse();
+      assertThat(resolved.isBlog()).isTrue();
+    }
+
+    @Test
+    void partialIsBlogFalse_onClientGallery_staysClientGallery() {
+      // The partial-update contract: {"isBlog": false} on a CLIENT_GALLERY must not clear the
+      // untouched isClient flag (which would silently demote the collection to MISC).
+      var resolved = CollectionTypeCompat.resolve(null, false, null, CollectionType.CLIENT_GALLERY);
+      assertThat(resolved.type()).isEqualTo(CollectionType.CLIENT_GALLERY);
+      assertThat(resolved.isClient()).isTrue();
+      assertThat(resolved.isBlog()).isFalse();
+    }
+
+    @Test
+    void explicitTrueClearsTheOtherInheritedFlag() {
+      // Setting isBlog=true on a CLIENT_GALLERY switches category: the untouched isClient
+      // would inherit true, but an explicit true wins and clears it (no 400).
+      var resolved = CollectionTypeCompat.resolve(null, true, null, CollectionType.CLIENT_GALLERY);
+      assertThat(resolved.type()).isEqualTo(CollectionType.BLOG);
+      assertThat(resolved.isClient()).isFalse();
+      assertThat(resolved.isBlog()).isTrue();
+    }
+
+    @Test
+    void explicitFalseOnTheEncodingFlagDemotesToMisc() {
+      // isClient=false alone on a CLIENT_GALLERY explicitly clears the flag that encoded the
+      // type; the untouched isBlog inherits false, so the collection folds to MISC.
+      var resolved = CollectionTypeCompat.resolve(false, null, null, CollectionType.CLIENT_GALLERY);
       assertThat(resolved.type()).isEqualTo(CollectionType.MISC);
+      assertThat(resolved.isClient()).isFalse();
+      assertThat(resolved.isBlog()).isFalse();
+    }
+
+    @Test
+    void nullFlagInheritsFromRequestedTypeOverCurrentType() {
+      // "Unless type is set": a request carrying a legacy type derives the untouched flag from
+      // that type, not from the entity's current type.
+      var resolved =
+          CollectionTypeCompat.resolve(
+              null, false, CollectionType.CLIENT_GALLERY, CollectionType.MISC);
+      assertThat(resolved.type()).isEqualTo(CollectionType.CLIENT_GALLERY);
+      assertThat(resolved.isClient()).isTrue();
       assertThat(resolved.isBlog()).isFalse();
     }
 

--- a/src/test/java/edens/zac/portfolio/backend/services/CollectionTypeCompatTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/CollectionTypeCompatTest.java
@@ -1,0 +1,171 @@
+package edens.zac.portfolio.backend.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import edens.zac.portfolio.backend.types.CollectionType;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+/** Unit tests for every {@link CollectionTypeCompat#resolve} rule branch. */
+class CollectionTypeCompatTest {
+
+  @Nested
+  class BooleansProvided {
+
+    @Test
+    void isClientTrue_derivesClientGallery() {
+      var resolved = CollectionTypeCompat.resolve(true, null, null, null);
+      assertThat(resolved.type()).isEqualTo(CollectionType.CLIENT_GALLERY);
+      assertThat(resolved.isClient()).isTrue();
+      assertThat(resolved.isBlog()).isFalse();
+    }
+
+    @Test
+    void isBlogTrue_derivesBlog() {
+      var resolved = CollectionTypeCompat.resolve(null, true, null, null);
+      assertThat(resolved.type()).isEqualTo(CollectionType.BLOG);
+      assertThat(resolved.isClient()).isFalse();
+      assertThat(resolved.isBlog()).isTrue();
+    }
+
+    @Test
+    void booleansWinOverProvidedType() {
+      // Legacy type says MISC but the boolean says client gallery: booleans win.
+      var resolved = CollectionTypeCompat.resolve(true, false, CollectionType.MISC, null);
+      assertThat(resolved.type()).isEqualTo(CollectionType.CLIENT_GALLERY);
+      assertThat(resolved.isClient()).isTrue();
+    }
+
+    @Test
+    void neitherTrue_currentlyClientGallery_foldsToMisc() {
+      var resolved =
+          CollectionTypeCompat.resolve(false, false, null, CollectionType.CLIENT_GALLERY);
+      assertThat(resolved.type()).isEqualTo(CollectionType.MISC);
+      assertThat(resolved.isClient()).isFalse();
+      assertThat(resolved.isBlog()).isFalse();
+    }
+
+    @Test
+    void neitherTrue_currentlyBlog_foldsToMisc() {
+      var resolved = CollectionTypeCompat.resolve(false, false, null, CollectionType.BLOG);
+      assertThat(resolved.type()).isEqualTo(CollectionType.MISC);
+    }
+
+    @Test
+    void neitherTrue_preservesNonClientBlogCurrentType() {
+      var resolved = CollectionTypeCompat.resolve(false, false, null, CollectionType.PORTFOLIO);
+      assertThat(resolved.type()).isEqualTo(CollectionType.PORTFOLIO);
+      assertThat(resolved.isClient()).isFalse();
+      assertThat(resolved.isBlog()).isFalse();
+    }
+
+    @Test
+    void neitherTrue_requestedTypeWinsOverCurrentType() {
+      // A request carrying both booleans (both false) and a legacy type keeps the requested type
+      // when it does not conflict with the flags.
+      var resolved =
+          CollectionTypeCompat.resolve(
+              false, false, CollectionType.ART_GALLERY, CollectionType.MISC);
+      assertThat(resolved.type()).isEqualTo(CollectionType.ART_GALLERY);
+    }
+
+    @Test
+    void neitherTrue_requestedClientGalleryTypeFoldsToMisc() {
+      // Booleans disclaim client/blog, so a legacy CLIENT_GALLERY type request folds to MISC.
+      var resolved =
+          CollectionTypeCompat.resolve(false, false, CollectionType.CLIENT_GALLERY, null);
+      assertThat(resolved.type()).isEqualTo(CollectionType.MISC);
+    }
+
+    @Test
+    void createWithNeitherBooleanTrueAndNoType_landsOnMisc() {
+      var resolved = CollectionTypeCompat.resolve(false, false, null, null);
+      assertThat(resolved.type()).isEqualTo(CollectionType.MISC);
+      assertThat(resolved.isClient()).isFalse();
+      assertThat(resolved.isBlog()).isFalse();
+    }
+
+    @Test
+    void singleFalseFlagCountsAsProvided() {
+      // isClient=false alone (isBlog absent) still enters the booleans-win path: flags were
+      // provided and neither is true, so a stored BLOG type folds to MISC.
+      var resolved = CollectionTypeCompat.resolve(false, null, null, CollectionType.BLOG);
+      assertThat(resolved.type()).isEqualTo(CollectionType.MISC);
+      assertThat(resolved.isBlog()).isFalse();
+    }
+
+    @Test
+    void bothTrue_isRejectedWith400Semantics() {
+      assertThatThrownBy(() -> CollectionTypeCompat.resolve(true, true, null, null))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("mutually exclusive");
+    }
+  }
+
+  @Nested
+  class LegacyTypeOnly {
+
+    @Test
+    void clientGalleryType_derivesIsClient() {
+      var resolved = CollectionTypeCompat.resolve(null, null, CollectionType.CLIENT_GALLERY, null);
+      assertThat(resolved.type()).isEqualTo(CollectionType.CLIENT_GALLERY);
+      assertThat(resolved.isClient()).isTrue();
+      assertThat(resolved.isBlog()).isFalse();
+    }
+
+    @Test
+    void blogType_derivesIsBlog() {
+      var resolved = CollectionTypeCompat.resolve(null, null, CollectionType.BLOG, null);
+      assertThat(resolved.type()).isEqualTo(CollectionType.BLOG);
+      assertThat(resolved.isClient()).isFalse();
+      assertThat(resolved.isBlog()).isTrue();
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+        value = CollectionType.class,
+        names = {"PORTFOLIO", "ART_GALLERY", "HOME", "PARENT", "MISC"})
+    void otherTypes_deriveFalseFalse(CollectionType type) {
+      var resolved = CollectionTypeCompat.resolve(null, null, type, null);
+      assertThat(resolved.type()).isEqualTo(type);
+      assertThat(resolved.isClient()).isFalse();
+      assertThat(resolved.isBlog()).isFalse();
+    }
+
+    @Test
+    void noTypeAndNoBooleans_fallsBackToCurrentType() {
+      var resolved = CollectionTypeCompat.resolve(null, null, null, CollectionType.BLOG);
+      assertThat(resolved.type()).isEqualTo(CollectionType.BLOG);
+      assertThat(resolved.isBlog()).isTrue();
+    }
+
+    @Test
+    void nothingProvidedAtAll_landsOnMisc() {
+      var resolved = CollectionTypeCompat.resolve(null, null, null, null);
+      assertThat(resolved.type()).isEqualTo(CollectionType.MISC);
+      assertThat(resolved.isClient()).isFalse();
+      assertThat(resolved.isBlog()).isFalse();
+    }
+  }
+
+  @Nested
+  class DeriveHelpers {
+
+    @Test
+    void deriveIsClient_onlyForClientGallery() {
+      assertThat(CollectionTypeCompat.deriveIsClient(CollectionType.CLIENT_GALLERY)).isTrue();
+      assertThat(CollectionTypeCompat.deriveIsClient(CollectionType.BLOG)).isFalse();
+      assertThat(CollectionTypeCompat.deriveIsClient(CollectionType.MISC)).isFalse();
+    }
+
+    @Test
+    void deriveIsBlog_onlyForBlog() {
+      assertThat(CollectionTypeCompat.deriveIsBlog(CollectionType.BLOG)).isTrue();
+      assertThat(CollectionTypeCompat.deriveIsBlog(CollectionType.CLIENT_GALLERY)).isFalse();
+      assertThat(CollectionTypeCompat.deriveIsBlog(CollectionType.PARENT)).isFalse();
+    }
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/services/ImageUploadPipelineServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/ImageUploadPipelineServiceTest.java
@@ -728,10 +728,8 @@ class ImageUploadPipelineServiceTest {
       when(imageProcessingService.savePreparedImageWithDedupe(any(), any()))
           .thenReturn(createResult(101L))
           .thenReturn(createResult(102L));
-      when(collectionRepository.findByTypeAndCollectionDate(CollectionType.BLOG, day1))
-          .thenReturn(List.of());
-      when(collectionRepository.findByTypeAndCollectionDate(CollectionType.BLOG, day2))
-          .thenReturn(List.of());
+      when(collectionRepository.findBlogsByCollectionDate(day1)).thenReturn(List.of());
+      when(collectionRepository.findBlogsByCollectionDate(day2)).thenReturn(List.of());
       when(collectionService.createCollection(any()))
           .thenReturn(blogResponse(1L, day1))
           .thenReturn(blogResponse(2L, day2));
@@ -772,8 +770,7 @@ class ImageUploadPipelineServiceTest {
           .thenReturn(prepared("a.jpg", day, List.of(), List.of()));
       when(imageProcessingService.savePreparedImageWithDedupe(any(), any()))
           .thenReturn(createResult(101L));
-      when(collectionRepository.findByTypeAndCollectionDate(CollectionType.BLOG, day))
-          .thenReturn(List.of(existingBlog));
+      when(collectionRepository.findBlogsByCollectionDate(day)).thenReturn(List.of(existingBlog));
 
       // Act
       service.ingestFilesGroupedByDay(request);
@@ -805,8 +802,7 @@ class ImageUploadPipelineServiceTest {
           .thenReturn(prepared("a.jpg", day, List.of(), List.of()));
       when(imageProcessingService.savePreparedImageWithDedupe(any(), any()))
           .thenReturn(createResult(101L));
-      when(collectionRepository.findByTypeAndCollectionDate(CollectionType.BLOG, day))
-          .thenReturn(List.of(oldest, newer));
+      when(collectionRepository.findBlogsByCollectionDate(day)).thenReturn(List.of(oldest, newer));
 
       // Act
       service.ingestFilesGroupedByDay(request);
@@ -832,8 +828,7 @@ class ImageUploadPipelineServiceTest {
           .thenReturn(prepared("a.jpg", exifDay, List.of(), List.of()));
       when(imageProcessingService.savePreparedImageWithDedupe(any(), any()))
           .thenReturn(createResult(101L));
-      when(collectionRepository.findByTypeAndCollectionDate(CollectionType.BLOG, exifDay))
-          .thenReturn(List.of());
+      when(collectionRepository.findBlogsByCollectionDate(exifDay)).thenReturn(List.of());
       when(collectionService.createCollection(any())).thenReturn(blogResponse(1L, exifDay));
 
       // Act
@@ -865,8 +860,7 @@ class ImageUploadPipelineServiceTest {
           .thenReturn(prepared("b.jpg", day, List.of(), List.of()));
       when(imageProcessingService.savePreparedImageWithDedupe(any(), any()))
           .thenReturn(createResult(102L));
-      when(collectionRepository.findByTypeAndCollectionDate(CollectionType.BLOG, day))
-          .thenReturn(List.of());
+      when(collectionRepository.findBlogsByCollectionDate(day)).thenReturn(List.of());
       when(collectionService.createCollection(any())).thenReturn(blogResponse(1L, day));
 
       // Act
@@ -901,8 +895,7 @@ class ImageUploadPipelineServiceTest {
           .thenReturn(prepared("a.jpg", day, List.of(), List.of()));
       when(imageProcessingService.savePreparedImageWithDedupe(any(), any()))
           .thenReturn(createResult(101L));
-      when(collectionRepository.findByTypeAndCollectionDate(CollectionType.BLOG, day))
-          .thenReturn(List.of());
+      when(collectionRepository.findBlogsByCollectionDate(day)).thenReturn(List.of());
       when(collectionService.createCollection(any())).thenReturn(blogResponse(1L, day));
 
       // Act
@@ -939,8 +932,7 @@ class ImageUploadPipelineServiceTest {
           .thenReturn(prepared("a.jpg", day, List.of(), List.of()));
       when(imageProcessingService.savePreparedImageWithDedupe(any(), any()))
           .thenReturn(createResult(101L));
-      when(collectionRepository.findByTypeAndCollectionDate(CollectionType.BLOG, day))
-          .thenReturn(List.of());
+      when(collectionRepository.findBlogsByCollectionDate(day)).thenReturn(List.of());
       when(collectionService.createCollection(any())).thenReturn(blogResponse(1L, day));
 
       // Act

--- a/src/test/java/edens/zac/portfolio/backend/services/TagServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/TagServiceTest.java
@@ -132,6 +132,33 @@ class TagServiceTest {
   }
 
   @Test
+  void convertTagToCollection_passesClientBlogBooleansThroughToCreate() {
+    TagEntity tag = unconvertedTag();
+    when(tagRepository.findById(5L)).thenReturn(Optional.of(tag));
+    when(collectionRepository.findBySlug("landscape")).thenReturn(Optional.empty());
+    when(collectionService.createCollection(any())).thenReturn(responseWithId(99L, "landscape-1"));
+    CollectionEntity created = new CollectionEntity();
+    created.setId(99L);
+    when(collectionRepository.findById(99L)).thenReturn(Optional.of(created));
+    when(tagRepository.findCollectionsByTagId(eq(5L), anyList())).thenReturn(List.of());
+    when(tagRepository.findImageContentByTagId(eq(5L), anyList())).thenReturn(List.of());
+    when(collectionService.getUpdateCollectionData("landscape"))
+        .thenReturn(responseWithId(99L, "landscape"));
+
+    tagService.convertTagToCollection(
+        5L, new SaveAsCollectionRequest(null, null, null, true, null));
+
+    ArgumentCaptor<CollectionRequests.Create> createCaptor =
+        ArgumentCaptor.forClass(CollectionRequests.Create.class);
+    verify(collectionService).createCollection(createCaptor.capture());
+    // Booleans flow through untouched; the defaulted PORTFOLIO type rides along and
+    // CollectionTypeCompat resolves the pair downstream (isClient wins over the default).
+    assertThat(createCaptor.getValue().isClient()).isTrue();
+    assertThat(createCaptor.getValue().isBlog()).isNull();
+    assertThat(createCaptor.getValue().type()).isEqualTo(CollectionType.PORTFOLIO);
+  }
+
+  @Test
   void convertTagToCollection_defaultScope_excludesHiddenAndSkipsPasswordGatedMembers() {
     TagEntity tag = unconvertedTag();
     when(tagRepository.findById(5L)).thenReturn(Optional.of(tag));


### PR DESCRIPTION
Introduces `is_client` / `is_blog` as the storage truth for what `CollectionType.CLIENT_GALLERY` and `BLOG` currently encode, and moves the query layer onto them.

## What changes

**Migration (V50)** — adds both booleans `NOT NULL DEFAULT FALSE`, backfills them from `type`, and idempotently seeds `art-gallery` / `portfolio` label tags attached to matching collections, so that grouping survives the eventual type drop. MISC stays untagged; PARENT/HOME are carried by graph and slug rather than tags.

**`CollectionTypeCompat`** — one mapping util, applied in `toEntity` and `applyBasicUpdates`. Booleans win over legacy type; legacy type derives booleans when flags are absent; `isClient && isBlog` is rejected as 400.

**Query ports** — `findListedBlogsOrdered`, `findBlogsByCollectionDate`, and `findClientGalleriesByVisibilityIn` now key on the booleans. The all-client-galleries query additionally surfaces derived parents (any collection with a visible `is_client` child), dropping the parent-side type filter.

**Payloads** — `CollectionModel`, `Records.CollectionList`, `ContentModels.Collection`, and the create/update requests all carry `isClient`/`isBlog`, with exact JSON names locked by a serialization test. `type` is still emitted and accepted, and is now optional on create.

**Create surfaces** — `SaveAsCollectionRequest` (tag promote) and the multipart `createCollectionWithImages` endpoint were the two collection-creating paths still requiring the legacy type. Both now accept the booleans; multipart with neither type nor booleans lands on MISC.

## Two bugs fixed along the way

- **Partial updates silently demoted collections.** The Update DTO documents its flags as partial ("null leaves it untouched"), but `resolve` treated any non-null flag as a complete statement and coerced the other to false. `{"id":9,"isBlog":false}` on a CLIENT_GALLERY demoted it to MISC, cleared `is_client`, and dropped it from all-client-galleries. Null now inherits from the effective base type; only an explicit `false` clears a flag.
- **New collections defaulted to a visible state.** They now default to `UNLISTED`.

## This is phase 1, and it is a net add

Worth being explicit, since the branch name suggests otherwise: **nothing is deleted here.** The `type` column survives, all 103 `CollectionType` references in `src/main/java` remain, and `CollectionTypeCompat` is +104/−0 of new scaffolding whose only job is keeping the two representations in sync.

Production code is +406/−174; the remaining ~1100 added lines are tests. The codebase is strictly heavier after this merge than before.

The payoff is phase 2 — dropping `collection.type`, deleting `CollectionTypeCompat`, and collapsing those 103 branch points — which is only possible once both deploys are verified. That phase currently exists as a comment in the migration file and nothing else. It needs a tracking issue, or the dual-compat window never closes and this is permanently a net add.

## Migration numbering

The deferred personal-role fold (`V48__fold_personal_roles.sql`) must ship as V51+. Out-of-order is off and V49/V50 are applied, so a replayed V48 is silently skipped. Separately, `RoleRepository:78` still claims the role `kind` column "is dropped in V49" — stale, and now wrong, since V49 is the GIF migration. Left out of this diff; belongs with the fold.

## Verification

`mvn clean install` — BUILD SUCCESS, 1134 tests. `CollectionFlagRepositoryIntegrationTest` applies V47 → V49 → V50 against Testcontainers Postgres 16.

Requires deploying before edens.zac#229, which reads these fields.