### PR TITLE
feat(user): email invites, real invite URLs, and a cover for grant-only users

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,3 +55,13 @@ DOCKER_MEMORY_LIMIT=768M
 WEBAUTHN_RP_ID=zacedens.com
 WEBAUTHN_RP_NAME=Zac Edens Photography
 WEBAUTHN_ALLOWED_ORIGINS=https://zacedens.com,https://www.zacedens.com
+
+# Email (AWS SES v2). EMAIL_FRONTEND_BASE_URL is the origin used to build client invite links
+# (/invite/<token>) and gallery links in emails — it must be the real public site, never localhost.
+# Set it explicitly here: docker-compose injects the variable unconditionally, so whatever lands in
+# the container environment overrides the Spring properties default.
+# Leave EMAIL_ENABLED=false until the SES domain identity and from-address are verified and the
+# account is out of the SES sandbox; while false, sends short-circuit to a log line.
+EMAIL_ENABLED=false
+EMAIL_FROM_ADDRESS=no-reply@zacedens.com
+EMAIL_FRONTEND_BASE_URL=https://zacedens.com

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,9 +51,13 @@ services:
       WEBAUTHN_ALLOWED_ORIGINS: ${WEBAUTHN_ALLOWED_ORIGINS:-http://localhost:3000,http://localhost:3001}
 
       # Email (AWS SES v2) — disabled by default; flip EMAIL_ENABLED=true once SES domain + from-address are verified.
+      # These defaults are PRODUCTION values: compose injects the variable unconditionally, so an
+      # env-var default here SHADOWS the Spring properties default and wins on every deploy. A
+      # localhost default would silently put localhost links in real invite/gallery emails. For
+      # local work, run the dev profile (application-dev.properties) or set the vars in .env.
       EMAIL_ENABLED: ${EMAIL_ENABLED:-false}
-      EMAIL_FROM_ADDRESS: ${EMAIL_FROM_ADDRESS:-no-reply@edens.zac}
-      EMAIL_FRONTEND_BASE_URL: ${EMAIL_FRONTEND_BASE_URL:-http://localhost:3000}
+      EMAIL_FROM_ADDRESS: ${EMAIL_FROM_ADDRESS:-no-reply@zacedens.com}
+      EMAIL_FRONTEND_BASE_URL: ${EMAIL_FRONTEND_BASE_URL:-https://zacedens.com}
 
       # JVM memory: local dev uses 1g (48GB machine), EC2 prod uses 384m (1GB instance)
       # EC2 prod override: JAVA_OPTS=-Xmx384m -Xms256m

--- a/src/main/java/edens/zac/portfolio/backend/controller/admin/AdminUserController.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/admin/AdminUserController.java
@@ -13,6 +13,7 @@ import edens.zac.portfolio.backend.dao.RoleRepository;
 import edens.zac.portfolio.backend.entity.AppUserEntity;
 import edens.zac.portfolio.backend.model.AuthPrincipal;
 import edens.zac.portfolio.backend.model.CollectionModel;
+import edens.zac.portfolio.backend.services.EmailService;
 import edens.zac.portfolio.backend.services.UserInviteService;
 import edens.zac.portfolio.backend.services.UserMergeService;
 import edens.zac.portfolio.backend.services.UserPageAssembler;
@@ -28,6 +29,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -63,6 +66,7 @@ public class AdminUserController {
   private final RoleRepository roleRepository;
   private final UserPageAssembler userPageAssembler;
   private final UserMergeService userMergeService;
+  private final EmailService emailService;
   private final String frontendBaseUrl;
 
   public AdminUserController(
@@ -71,12 +75,14 @@ public class AdminUserController {
       RoleRepository roleRepository,
       UserPageAssembler userPageAssembler,
       UserMergeService userMergeService,
+      EmailService emailService,
       @Value("${email.frontend-base-url}") String frontendBaseUrl) {
     this.appUserRepository = appUserRepository;
     this.userInviteService = userInviteService;
     this.roleRepository = roleRepository;
     this.userPageAssembler = userPageAssembler;
     this.userMergeService = userMergeService;
+    this.emailService = emailService;
     this.frontendBaseUrl = frontendBaseUrl;
   }
 
@@ -114,6 +120,7 @@ public class AdminUserController {
     Long userId = appUserRepository.insert(newUser);
     String rawToken = userInviteService.createInvite(userId, email);
     String inviteUrl = buildInviteUrl(rawToken);
+    sendInviteEmailAfterCommit(email, request.displayName(), inviteUrl);
 
     log.info("Admin created user (userId={}, email={})", userId, email);
     return ResponseEntity.status(HttpStatus.CREATED)
@@ -159,8 +166,10 @@ public class AdminUserController {
     }
     AppUserEntity user = maybeUser.get();
     String rawToken = userInviteService.regenerateInvite(user.getId(), user.getEmail());
+    String inviteUrl = buildInviteUrl(rawToken);
+    sendInviteEmailAfterCommit(user.getEmail(), user.getName(), inviteUrl);
     log.info("Admin regenerated invite (userId={})", user.getId());
-    return ResponseEntity.ok(new CreateUserResponse(user.getId(), buildInviteUrl(rawToken)));
+    return ResponseEntity.ok(new CreateUserResponse(user.getId(), inviteUrl));
   }
 
   /**
@@ -337,6 +346,36 @@ public class AdminUserController {
   /** Build the public invite URL, tolerating a {@code frontendBaseUrl} that ends in a slash. */
   private String buildInviteUrl(String rawToken) {
     return frontendBaseUrl.replaceAll("/+$", "") + "/invite/" + rawToken;
+  }
+
+  /**
+   * Send the invite email only once the surrounding transaction commits.
+   *
+   * <p>Both invite endpoints are {@code @Transactional}. Sending inline would mail a live link for
+   * a token that a rollback then erases, and would hold a database transaction open across an SES
+   * round-trip. Registering an {@code afterCommit} hook keeps the invite row and the email
+   * consistent: no commit, no email.
+   *
+   * <p>Delivery is best-effort and deliberately never fails the request — {@link EmailService}
+   * returns a typed reason rather than throwing, and while {@code email.enabled} is false it
+   * short-circuits to a log line. The response still carries {@code inviteUrl}, so the admin
+   * copy-link flow works identically whether or not email is switched on.
+   *
+   * <p>With no active transaction (standalone MockMvc tests) there is nothing to wait for, so the
+   * send happens immediately.
+   */
+  private void sendInviteEmailAfterCommit(String email, String displayName, String inviteUrl) {
+    if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+      emailService.sendInviteEmail(email, displayName, inviteUrl);
+      return;
+    }
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization() {
+          @Override
+          public void afterCommit() {
+            emailService.sendInviteEmail(email, displayName, inviteUrl);
+          }
+        });
   }
 
   /** The acting admin's user id for audit columns, or null in dev where the gate is open. */

--- a/src/main/java/edens/zac/portfolio/backend/services/EmailService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/EmailService.java
@@ -15,15 +15,17 @@ import software.amazon.awssdk.services.sesv2.model.SendEmailRequest;
 import software.amazon.awssdk.services.sesv2.model.SesV2Exception;
 
 /**
- * Sends transactional gallery emails via AWS SES v2.
+ * Sends transactional emails via AWS SES v2.
  *
- * <p>One public method today: {@link #sendGalleryPasswordEmail}, which delivers a clickable gallery
- * URL plus the plaintext password the admin just set. Returns a typed {@link SendResult} so the
- * caller can surface "email-disabled" or "ses-error" reasons without leaking exception detail.
+ * <p>Two public methods: {@link #sendGalleryPasswordEmail}, which delivers a clickable gallery URL
+ * plus the plaintext password the admin just set, and {@link #sendInviteEmail}, which delivers a
+ * single-use account-setup link to a newly invited client. Both return a typed {@link SendResult}
+ * so the caller can surface "email-disabled" or "ses-error" reasons without leaking exception
+ * detail.
  *
  * <p>The {@code email.enabled} flag short-circuits the whole flow before any AWS call. This lets
  * the rest of the password admin endpoint ship while SES domain verification and sandbox-removal
- * are in flight.
+ * are in flight — invite creation still returns a copyable link, so nothing depends on delivery.
  */
 @Service
 @Slf4j
@@ -74,6 +76,44 @@ public class EmailService {
     String htmlBody = buildHtml(collectionTitle, galleryUrl, plaintextPassword);
     String textBody = buildText(collectionTitle, galleryUrl, plaintextPassword);
 
+    return dispatch(
+        toEmail, subject, htmlBody, textBody, "gallery password email (slug=" + slug + ")");
+  }
+
+  /**
+   * Send the "you've been invited" email carrying a single-use account-setup link.
+   *
+   * <p>The invite URL is built by the caller rather than from {@code frontendBaseUrl} here, because
+   * the controller already owns that join (and strips a trailing slash), so the emailed link is
+   * guaranteed byte-identical to the one returned in the API response for copy-linking.
+   *
+   * <p>The link is a bearer credential: it is never logged, and the whole body is escaped.
+   *
+   * @param toEmail recipient address (the invited account's email)
+   * @param displayName invitee's display name for the greeting; may be null or blank
+   * @param inviteUrl the fully-built {@code <origin>/invite/<token>} link
+   * @return {@link SendResult} with {@code sent=true} on success, otherwise a reason code
+   */
+  public SendResult sendInviteEmail(String toEmail, String displayName, String inviteUrl) {
+    if (!enabled) {
+      log.info("Email disabled -- skipping invite email (to={})", toEmail);
+      return new SendResult(false, "email-disabled");
+    }
+
+    String subject = "You've been invited to Zac Eden Photography";
+    String htmlBody = buildInviteHtml(displayName, inviteUrl);
+    String textBody = buildInviteText(displayName, inviteUrl);
+
+    return dispatch(toEmail, subject, htmlBody, textBody, "invite email");
+  }
+
+  /**
+   * Build and send one SES message, mapping both failure families onto {@code "ses-error"}.
+   *
+   * @param label short description used only for logging; never include a token or password
+   */
+  private SendResult dispatch(
+      String toEmail, String subject, String htmlBody, String textBody, String label) {
     SendEmailRequest request =
         SendEmailRequest.builder()
             .fromEmailAddress(fromAddress)
@@ -94,14 +134,14 @@ public class EmailService {
 
     try {
       sesClient.sendEmail(request);
-      log.info("Sent gallery password email (slug={}, to={})", slug, toEmail);
+      log.info("Sent {} (to={})", label, toEmail);
       return new SendResult(true, null);
     } catch (SesV2Exception | SdkClientException e) {
       // SesV2Exception = SES API rejected the request (verification, sandbox, recipient).
       // SdkClientException = client-side failure (timeout, credentials, region, network).
       log.error(
-          "Failed to send gallery password email (slug={}, to={}, kind={}): {}",
-          slug,
+          "Failed to send {} (to={}, kind={}): {}",
+          label,
           toEmail,
           e.getClass().getSimpleName(),
           e.getMessage());
@@ -159,6 +199,65 @@ public class EmailService {
         + "<hr style=\"border:0;border-top:1px solid #eeeeee;margin:32px 0;\">"
         + "<p style=\"margin:0;font-size:12px;color:#888888;\">Zac Eden Photography</p>"
         + "</td></tr></table></body></html>";
+  }
+
+  /**
+   * Hardcoded inline-styled HTML invite body, mirroring {@link #buildHtml}. Every interpolated
+   * value is HTML-escaped — the display name is admin-supplied and the URL carries a token.
+   */
+  private String buildInviteHtml(String displayName, String inviteUrl) {
+    String safeUrl = HtmlUtils.htmlEscape(inviteUrl);
+    String greeting =
+        isBlank(displayName) ? "Hello," : "Hi " + HtmlUtils.htmlEscape(displayName.trim()) + ",";
+    return "<!DOCTYPE html>"
+        + "<html lang=\"en\"><head><meta charset=\"UTF-8\">"
+        + "<title>You've been invited</title></head>"
+        + "<body style=\"margin:0;padding:0;background:#ffffff;color:#111111;"
+        + "font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;\">"
+        + "<table role=\"presentation\" width=\"100%\" cellpadding=\"0\" cellspacing=\"0\" "
+        + "border=\"0\" style=\"max-width:560px;margin:0 auto;padding:32px 24px;\">"
+        + "<tr><td>"
+        + "<h1 style=\"margin:0 0 16px 0;font-size:20px;font-weight:600;color:#111111;\">"
+        + "You've been invited"
+        + "</h1>"
+        + "<p style=\"margin:0 0 24px 0;font-size:15px;line-height:1.5;color:#333333;\">"
+        + greeting
+        + " Set up your account to view the galleries and photos shared with you."
+        + "</p>"
+        + "<p style=\"margin:0 0 32px 0;\">"
+        + "<a href=\""
+        + safeUrl
+        + "\" "
+        + "style=\"display:inline-block;padding:12px 24px;background:#111111;color:#ffffff;"
+        + "text-decoration:none;font-size:15px;font-weight:500;border-radius:2px;\">"
+        + "Set up your account"
+        + "</a>"
+        + "</p>"
+        + "<p style=\"margin:0 0 16px 0;font-size:13px;color:#666666;line-height:1.5;\">"
+        + "This link works once and expires in 7 days. Do not forward it — anyone with the link "
+        + "can claim the account. If you were not expecting this, you can ignore this email."
+        + "</p>"
+        + "<hr style=\"border:0;border-top:1px solid #eeeeee;margin:32px 0;\">"
+        + "<p style=\"margin:0;font-size:12px;color:#888888;\">Zac Eden Photography</p>"
+        + "</td></tr></table></body></html>";
+  }
+
+  /** Plain-text invite body. Same content, no styling. */
+  private String buildInviteText(String displayName, String inviteUrl) {
+    String greeting = isBlank(displayName) ? "Hello," : "Hi " + displayName.trim() + ",";
+    return greeting
+        + "\n\n"
+        + "You've been invited to Zac Eden Photography. Set up your account to view the galleries "
+        + "and photos shared with you:\n\n"
+        + inviteUrl
+        + "\n\n"
+        + "This link works once and expires in 7 days. Do not forward it -- anyone with the link "
+        + "can claim the account. If you were not expecting this, you can ignore this email.\n\n"
+        + "-- Zac Eden Photography";
+  }
+
+  private static boolean isBlank(String value) {
+    return value == null || value.isBlank();
   }
 
   /** Plain-text fallback body. Same content, no styling, raw password (no escaping needed). */

--- a/src/main/java/edens/zac/portfolio/backend/services/UserPageAssembler.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/UserPageAssembler.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -25,10 +26,11 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * Builds the {@code /user} synthetic {@link CollectionModel}: a self-only, PARENT-shaped
  * aggregation of every collection a signed-in user is associated with, plus a cover drawn from
- * their tagged content. The association set is the de-duplicated union of (a) collections the
- * user's linked person is tagged on via {@code collection_people} and (b) collections the user
- * reaches through a role grant (membership via a role). The page-level auth check guarantees the
- * viewer is the owner, so this leans on {@code UNLISTED} visibility rather than a gate.
+ * their tagged content (falling back to an associated collection's own cover when they are tagged
+ * in nothing). The association set is the de-duplicated union of (a) collections the user's linked
+ * person is tagged on via {@code collection_people} and (b) collections the user reaches through a
+ * role grant (membership via a role). The page-level auth check guarantees the viewer is the owner,
+ * so this leans on {@code UNLISTED} visibility rather than a gate.
  *
  * <p>Mirrors the block-building shape of {@link SyntheticCollectionResolver} (PARENT model of
  * {@link ContentModels.Collection} blocks via {@link
@@ -77,11 +79,14 @@ public class UserPageAssembler {
     body.addAll(taggedBlocks);
     reindexSequentially(body);
 
-    // Cover and title only apply when the viewer is an actual tagged person (has tagged collections
-    // or tagged standalone content); a grant-only viewer keeps the generic title and no cover.
+    // The title only applies when the viewer is an actual tagged person (has tagged collections or
+    // tagged standalone content); a grant-only viewer keeps the generic title. The cover, however,
+    // always falls back to one of the viewer's associated collections, so a user who has an account
+    // but is tagged in nothing still gets an entry-point image instead of a blank header.
     Optional<ContentPersonEntity> person =
         identity.filter(p -> !personCollectionIds.isEmpty() || !taggedBlocks.isEmpty());
-    ContentModels.Image cover = person.flatMap(p -> resolveCover(p.getId())).orElse(null);
+    ContentModels.Image cover =
+        person.flatMap(p -> resolveCover(p.getId())).orElseGet(() -> firstCollectionCover(body));
     String title = person.map(ContentPersonEntity::getPersonName).orElse(DEFAULT_TITLE);
 
     // Description is set unconditionally from the user account row, independent of person tagging.
@@ -161,5 +166,26 @@ public class UserPageAssembler {
         .findRandomImageIdByPersonId(personId)
         .flatMap(contentRepository::findImageById)
         .map(contentModelConverter::convertImageEntityToModel);
+  }
+
+  /**
+   * Fallback cover for a viewer with no self-tagged image: the cover of the newest associated
+   * collection that has one, or {@code null} when the viewer has no collections (or none of them
+   * carry a cover).
+   *
+   * <p>Costs no additional query — {@link #buildCollectionBlocks} already hydrates each block's
+   * cover through {@link CollectionProcessingUtil#batchConvertToBasicModels}, which batch-loads
+   * them to avoid an N+1. The body is already ordered collection-date desc, so "first" means
+   * "newest", which keeps the choice deterministic across requests (unlike {@link #resolveCover},
+   * which is deliberately random over the viewer's tagged images).
+   */
+  private static ContentModels.Image firstCollectionCover(List<ContentModel> body) {
+    return body.stream()
+        .filter(ContentModels.Collection.class::isInstance)
+        .map(ContentModels.Collection.class::cast)
+        .map(ContentModels.Collection::coverImage)
+        .filter(Objects::nonNull)
+        .findFirst()
+        .orElse(null);
   }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -120,5 +120,5 @@ app.auth.webauthn.challenge-ttl-minutes=5
 # Email (AWS SES v2)
 # Disabled by default — flip to true once SES domain + from-address verification land.
 email.enabled=${EMAIL_ENABLED:false}
-email.from-address=${EMAIL_FROM_ADDRESS:no-reply@edens.zac}
+email.from-address=${EMAIL_FROM_ADDRESS:no-reply@zacedens.com}
 email.frontend-base-url=${EMAIL_FRONTEND_BASE_URL:https://zacedens.com}

--- a/src/test/java/edens/zac/portfolio/backend/controller/admin/AdminUserControllerTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/admin/AdminUserControllerTest.java
@@ -21,6 +21,7 @@ import edens.zac.portfolio.backend.dao.RoleRepository;
 import edens.zac.portfolio.backend.entity.AppUserEntity;
 import edens.zac.portfolio.backend.entity.RoleEntity;
 import edens.zac.portfolio.backend.model.CollectionModel;
+import edens.zac.portfolio.backend.services.EmailService;
 import edens.zac.portfolio.backend.services.UserInviteService;
 import edens.zac.portfolio.backend.services.UserMergeService;
 import edens.zac.portfolio.backend.services.UserPageAssembler;
@@ -50,6 +51,7 @@ class AdminUserControllerTest {
   @Mock private RoleRepository roleRepository;
   @Mock private UserPageAssembler userPageAssembler;
   @Mock private UserMergeService userMergeService;
+  @Mock private EmailService emailService;
 
   // Trailing slash on purpose: exercises the trailing-slash-safe invite-URL join.
   private static final String FRONTEND_BASE_URL = "https://app.example.com/";
@@ -63,6 +65,7 @@ class AdminUserControllerTest {
             roleRepository,
             userPageAssembler,
             userMergeService,
+            emailService,
             FRONTEND_BASE_URL);
     mockMvc =
         MockMvcBuilders.standaloneSetup(controller)
@@ -88,6 +91,27 @@ class AdminUserControllerTest {
           .andExpect(jsonPath("$.userId").value(42))
           // Trailing slash on the base URL must not produce a double slash before "invite".
           .andExpect(jsonPath("$.inviteUrl").value("https://app.example.com/invite/raw-token-abc"));
+
+      // The invitee is emailed the same link that is returned for copy-linking.
+      verify(emailService)
+          .sendInviteEmail(
+              "alice@example.com", "Alice", "https://app.example.com/invite/raw-token-abc");
+    }
+
+    @Test
+    void createUserDoesNotEmailWhenEmailAlreadyExists() throws Exception {
+      when(appUserRepository.findByEmail("taken@example.com"))
+          .thenReturn(
+              Optional.of(AppUserEntity.builder().id(1L).email("taken@example.com").build()));
+
+      mockMvc
+          .perform(
+              post("/api/admin/users")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"email\":\"taken@example.com\",\"displayName\":\"Taken\"}"))
+          .andExpect(status().isConflict());
+
+      verify(emailService, never()).sendInviteEmail(anyString(), any(), anyString());
     }
 
     @Test
@@ -214,6 +238,7 @@ class AdminUserControllerTest {
           AppUserEntity.builder()
               .id(5L)
               .email("bob@example.com")
+              .name("Bob")
               .status(UserStatus.INVITED)
               .build();
       when(appUserRepository.findById(5L)).thenReturn(Optional.of(bob));
@@ -224,6 +249,10 @@ class AdminUserControllerTest {
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.userId").value(5))
           .andExpect(jsonPath("$.inviteUrl").value("https://app.example.com/invite/fresh-token"));
+
+      // A re-issued invite is emailed too, so a resend reaches the invitee without a manual copy.
+      verify(emailService)
+          .sendInviteEmail("bob@example.com", "Bob", "https://app.example.com/invite/fresh-token");
     }
 
     @Test
@@ -233,6 +262,7 @@ class AdminUserControllerTest {
       mockMvc.perform(post("/api/admin/users/999/invite")).andExpect(status().isNotFound());
 
       verify(userInviteService, never()).regenerateInvite(anyLong(), anyString());
+      verify(emailService, never()).sendInviteEmail(anyString(), any(), anyString());
     }
   }
 

--- a/src/test/java/edens/zac/portfolio/backend/services/EmailServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/EmailServiceTest.java
@@ -42,6 +42,21 @@ class EmailServiceTest {
       assertThat(result.reason()).isEqualTo("email-disabled");
       verify(sesClient, never()).sendEmail(any(SendEmailRequest.class));
     }
+
+    @Test
+    void inviteShortCircuitsWithoutCallingSes() {
+      EmailService service = newService(false);
+
+      EmailService.SendResult result =
+          service.sendInviteEmail(
+              "invitee@example.com", "Dana", "https://edens.zac/invite/tok-123");
+
+      // Invites must stay shippable while SES verification is in flight: the send no-ops and the
+      // caller still returns the copyable link.
+      assertThat(result.sent()).isFalse();
+      assertThat(result.reason()).isEqualTo("email-disabled");
+      verify(sesClient, never()).sendEmail(any(SendEmailRequest.class));
+    }
   }
 
   @Nested
@@ -113,6 +128,77 @@ class EmailServiceTest {
 
       // Text body: raw password (no HTML, no escaping needed).
       assertThat(textBody).contains("p<>&\"'word");
+    }
+
+    @Test
+    void sendsInviteRequestWithExpectedShape() {
+      EmailService service = newService(true);
+
+      EmailService.SendResult result =
+          service.sendInviteEmail(
+              "invitee@example.com", "Dana", "https://edens.zac/invite/tok-123");
+
+      ArgumentCaptor<SendEmailRequest> captor = ArgumentCaptor.forClass(SendEmailRequest.class);
+      verify(sesClient).sendEmail(captor.capture());
+
+      SendEmailRequest sent = captor.getValue();
+      assertThat(sent.fromEmailAddress()).isEqualTo("no-reply@edens.zac");
+      assertThat(sent.destination().toAddresses()).containsExactly("invitee@example.com");
+      assertThat(sent.content().simple().subject().data()).contains("invited");
+
+      Body body = sent.content().simple().body();
+      // The caller-built URL is used verbatim in both bodies — it must match the copyable link.
+      assertThat(body.html().data()).contains("https://edens.zac/invite/tok-123");
+      assertThat(body.text().data()).contains("https://edens.zac/invite/tok-123");
+      assertThat(body.html().data()).contains("Dana");
+      assertThat(body.text().data()).contains("Dana");
+
+      assertThat(result.sent()).isTrue();
+      assertThat(result.reason()).isNull();
+    }
+
+    @Test
+    void inviteFallsBackToGenericGreetingWhenDisplayNameMissing() {
+      EmailService service = newService(true);
+
+      service.sendInviteEmail("invitee@example.com", null, "https://edens.zac/invite/tok-123");
+
+      ArgumentCaptor<SendEmailRequest> captor = ArgumentCaptor.forClass(SendEmailRequest.class);
+      verify(sesClient).sendEmail(captor.capture());
+      Body body = captor.getValue().content().simple().body();
+
+      assertThat(body.text().data()).startsWith("Hello,");
+      assertThat(body.html().data()).contains("Hello,");
+      assertThat(body.text().data()).doesNotContain("null");
+      assertThat(body.html().data()).doesNotContain("null");
+    }
+
+    @Test
+    void inviteHtmlEscapesDisplayName() {
+      EmailService service = newService(true);
+
+      service.sendInviteEmail(
+          "invitee@example.com", "<script>alert('xss')</script>", "https://edens.zac/invite/tok");
+
+      ArgumentCaptor<SendEmailRequest> captor = ArgumentCaptor.forClass(SendEmailRequest.class);
+      verify(sesClient).sendEmail(captor.capture());
+      String htmlBody = captor.getValue().content().simple().body().html().data();
+
+      assertThat(htmlBody).doesNotContain("<script>alert('xss')</script>");
+      assertThat(htmlBody).contains("&lt;script&gt;");
+    }
+
+    @Test
+    void inviteSesExceptionReturnsErrorReason() {
+      EmailService service = newService(true);
+      when(sesClient.sendEmail(any(SendEmailRequest.class)))
+          .thenThrow(SesV2Exception.builder().message("rejected").build());
+
+      EmailService.SendResult result =
+          service.sendInviteEmail("invitee@example.com", "Dana", "https://edens.zac/invite/tok");
+
+      assertThat(result.sent()).isFalse();
+      assertThat(result.reason()).isEqualTo("ses-error");
     }
 
     @Test

--- a/src/test/java/edens/zac/portfolio/backend/services/UserPageAssemblerIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/UserPageAssemblerIntegrationTest.java
@@ -61,6 +61,22 @@ class UserPageAssemblerIntegrationTest extends AbstractPostgresIntegrationTest {
         date == null ? null : Timestamp.valueOf(date));
   }
 
+  /**
+   * Seed an image and make it the collection's cover. Deliberately tags nobody — the fallback
+   * exists precisely for users who are tagged in nothing, so a tagged cover would not exercise it.
+   */
+  private void seedCollectionCover(Long collectionId, String webUrl) {
+    Long contentId =
+        jdbc.queryForObject(
+            "INSERT INTO content (content_type) VALUES ('IMAGE') RETURNING id", Long.class);
+    jdbc.update(
+        "INSERT INTO content_image (id, title, image_url_web, image_width, image_height) "
+            + "VALUES (?, 'cover', ?, 1600, 1200)",
+        contentId,
+        webUrl);
+    jdbc.update("UPDATE collection SET cover_image_id = ? WHERE id = ?", contentId, collectionId);
+  }
+
   private void tagCollection(Long collectionId, Long personId) {
     jdbc.update(
         "INSERT INTO collection_people (collection_id, person_id) VALUES (?, ?)",
@@ -197,7 +213,46 @@ class UserPageAssemblerIntegrationTest extends AbstractPostgresIntegrationTest {
 
     assertThat(referencedCollectionIds(model)).containsExactly(granted);
     assertThat(model.getTitle()).isEqualTo("Your Galleries");
+    // The granted collection carries no cover of its own, so there is nothing to fall back to.
     assertThat(model.getCoverImage()).isNull();
+  }
+
+  @Test
+  void grantOnlyUserFallsBackToGrantedCollectionCover() {
+    Long userId = seedUser("grantcover-" + UUID.randomUUID() + "@example.com");
+    Long granted = seedCollection("CLIENT_GALLERY", LocalDateTime.now().minusDays(1));
+    seedCollectionCover(granted, "https://cdn/granted-cover.webp");
+    grant(userId, granted);
+
+    CollectionModel model = assembler.assembleForUser(userId);
+
+    // Tagged in nothing, but a role grant reaches a collection that has a cover — so the page gets
+    // an entry-point image instead of a blank header.
+    assertThat(model.getCoverImage()).isNotNull();
+    assertThat(model.getCoverImage().imageUrl()).isEqualTo("https://cdn/granted-cover.webp");
+    assertThat(model.getCoverImage().imageWidth()).isEqualTo(1600);
+    assertThat(model.getCoverImage().imageHeight()).isEqualTo(1200);
+    assertThat(model.getTitle()).isEqualTo("Your Galleries");
+  }
+
+  @Test
+  void coverFallbackPicksNewestCollectionThatHasACover() {
+    Long userId = seedUser("newestcover-" + UUID.randomUUID() + "@example.com");
+    Long older = seedCollection("CLIENT_GALLERY", LocalDateTime.now().minusDays(30));
+    Long newer = seedCollection("CLIENT_GALLERY", LocalDateTime.now().minusDays(2));
+    Long newestWithoutCover = seedCollection("CLIENT_GALLERY", LocalDateTime.now().minusDays(1));
+    seedCollectionCover(older, "https://cdn/older-cover.webp");
+    seedCollectionCover(newer, "https://cdn/newer-cover.webp");
+    grant(userId, older);
+    grant(userId, newer);
+    grant(userId, newestWithoutCover);
+
+    CollectionModel model = assembler.assembleForUser(userId);
+
+    // Body order is collection-date desc, so the fallback is the newest collection that actually
+    // has a cover — the even newer coverless one is skipped rather than yielding null.
+    assertThat(model.getCoverImage()).isNotNull();
+    assertThat(model.getCoverImage().imageUrl()).isEqualTo("https://cdn/newer-cover.webp");
   }
 
   @Test
@@ -215,8 +270,26 @@ class UserPageAssemblerIntegrationTest extends AbstractPostgresIntegrationTest {
   }
 
   @Test
-  void linkedPersonWithoutTaggedImageHasNullCover() {
+  void linkedPersonWithoutTaggedImageFallsBackToCollectionCover() {
     Long userId = seedUserNamed("No Cover Person");
+    Long tagged = seedCollection("CLIENT_GALLERY", LocalDateTime.now().minusDays(1));
+    seedCollectionCover(tagged, "https://cdn/tagged-collection-cover.webp");
+    tagCollection(tagged, userId);
+
+    CollectionModel model = assembler.assembleForUser(userId);
+
+    // Tagged on the collection but on none of its images, so resolveCover finds nothing; the
+    // collection's own cover stands in. The person title still applies (they ARE a tagged person).
+    assertThat(referencedCollectionIds(model)).containsExactly(tagged);
+    assertThat(model.getCoverImage()).isNotNull();
+    assertThat(model.getCoverImage().imageUrl())
+        .isEqualTo("https://cdn/tagged-collection-cover.webp");
+    assertThat(model.getTitle()).isEqualTo("No Cover Person");
+  }
+
+  @Test
+  void linkedPersonWithoutTaggedImageOrCollectionCoverStillHasNullCover() {
+    Long userId = seedUserNamed("Nothing Anywhere");
     Long tagged = seedCollection("CLIENT_GALLERY", LocalDateTime.now().minusDays(1));
     tagCollection(tagged, userId);
 
@@ -224,7 +297,7 @@ class UserPageAssemblerIntegrationTest extends AbstractPostgresIntegrationTest {
 
     assertThat(referencedCollectionIds(model)).containsExactly(tagged);
     assertThat(model.getCoverImage()).isNull();
-    assertThat(model.getTitle()).isEqualTo("No Cover Person");
+    assertThat(model.getTitle()).isEqualTo("Nothing Anywhere");
   }
 
   @Test


### PR DESCRIPTION
Three fixes to the client invite and `/user` flow. Pairs with themancalledzac/edens.zac#0212-user-page-density-tabs on the frontend — the cover fix below is what un-blanks the `/user` header and home "Me" tile, and needs no frontend change.

## 1. Invite links pointed at `localhost`

`application.properties` already defaulted `email.frontend-base-url` to `https://zacedens.com`. The leak was [`docker-compose.yml`](docker-compose.yml) injecting `EMAIL_FRONTEND_BASE_URL` **unconditionally**, defaulting to `http://localhost:3000`. An env var outranks the properties default, so the correct value was shadowed and never reached — and `.env.example` never listed the key, so any deploy following the template emitted localhost links even with `SPRING_PROFILES_ACTIVE=prod`.

**Fixing only the properties file would have changed nothing in production.** The compose default is now the production value, and the key is explicit in `.env.example`.

Same pass fixes `email.from-address`, which defaulted to `no-reply@edens.zac`. `.zac` is not a TLD, so that address can never be SES-verified; it was left behind when the domain moved to `zacedens.com`. It is also the one email property with no inline `@Value` fallback, so it is load-bearing at startup.

`application-dev.properties` deliberately keeps `localhost:3000` — that only binds under the `dev` profile, where a local invite link must stay clickable.

## 2. Invites are now emailed

`EmailService.sendInviteEmail` mirrors `sendGalleryPasswordEmail`, with the SES request-building extracted into a shared `dispatch` helper. Wired into both `POST /api/admin/users` and `POST /api/admin/users/{id}/invite`.

The send is registered as an **`afterCommit` hook**, not run inline. Both endpoints are `@Transactional`, and sending inside the transaction would mail a live link for a token a rollback then erases — besides holding a DB transaction open across an SES round-trip. (`CollectionService.updateGalleryAccess` does send in-transaction today; that is a pre-existing flaw, not a pattern worth copying.)

**This ships dark.** `email.enabled` stays `false` pending SES domain verification and sandbox removal, so sends short-circuit to a log line and return `SendResult(false, "email-disabled")`. The response still carries `inviteUrl`, so the admin copy-link flow is unchanged either way. Flipping `EMAIL_ENABLED=true` is the only remaining step once SES is ready.

## 3. Grant-only users got a blank cover

`UserPageAssembler` resolved the `/user` cover exclusively from person-tagged images, so a user who reaches collections through a role grant but is tagged in no photos got `coverImage=null` — a blank `/user` header and a blank "Me" tile on the home page.

It now falls back to the newest associated collection's own cover. **This costs no additional query**: `buildCollectionBlocks` already hydrates those covers via `batchConvertToBasicModels` (which batch-loads them to avoid an N+1), and they are the same `ContentModels.Image` type as the target field.

## Review notes

- Two existing tests asserted the old null-cover contract and passed only because their fixtures happened to seed collections *without* covers. They now seed a cover and assert the fallback; the misleading `linkedPersonWithoutTaggedImageHasNullCover` is renamed. A separate test covers the genuine "nothing anywhere" case, which still returns null.
- **Verified RED first**: reverting just the fallback line fails exactly the three new tests with `Expecting actual not to be null`, while the two legitimate null-cover cases still pass.
- `AdminUserControllerTest` runs under standalone MockMvc with no real transaction, so `sendInviteEmailAfterCommit` falls through to an immediate send — which is why the controller tests can assert the send directly.
- No Flyway migration needed.

## Verification

`./mvnw clean install` — **1162 tests, 0 failures, 1 skipped**. `spotless:check` and `checkstyle:check` clean.

## Deliberately not included

- Renaming `email.frontend-base-url` → `app.frontend-base-url`. It is no longer email-only and does not match the `app.*` convention used elsewhere, but the rename touches three config surfaces plus two `@Value` sites and `EMAIL_FRONTEND_BASE_URL` may already be set in the live environment.
- `EmailService.java:72` concatenates `frontendBaseUrl + "/" + slug` raw while `AdminUserController.buildInviteUrl` strips a trailing slash — a real inconsistency, but out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)