### PR TITLE
fix(security): typeless U2 — S1-S6 hardening + D8 clear path

### DIFF
--- a/src/main/java/edens/zac/portfolio/backend/controller/prod/ContentDownloadControllerProd.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/prod/ContentDownloadControllerProd.java
@@ -14,7 +14,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.URI;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
@@ -70,12 +69,13 @@ public class ContentDownloadControllerProd {
       @RequestParam(defaultValue = "web") String format,
       HttpServletRequest request) {
 
-    // Auth gate: enforce only when a parent collection is password-protected.
-    Optional<CollectionEntity> parentCollection = contentService.findCollectionForImage(id);
-    if (parentCollection.isPresent() && parentCollection.get().getGalleryPassword() != null) {
-      if (!isDownloadAuthorized(request, parentCollection.get())) {
-        log.warn(
-            "Unauthorized image download (id={}, slug={})", id, parentCollection.get().getSlug());
+    // Auth gate: EVERY password-protected parent must authorize this request. An image can sit in
+    // several collections at once, so resolving one arbitrary parent let an unprotected wrapper
+    // waive a protected gallery's password. Fail closed -- a cookie for one gallery does not
+    // unlock an image that also lives in another.
+    for (CollectionEntity parentCollection : contentService.findProtectedCollectionsForImage(id)) {
+      if (!isDownloadAuthorized(request, parentCollection)) {
+        log.warn("Unauthorized image download (id={}, slug={})", id, parentCollection.getSlug());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
       }
     }

--- a/src/main/java/edens/zac/portfolio/backend/dao/CollectionRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/CollectionRepository.java
@@ -232,6 +232,31 @@ public class CollectionRepository extends BaseDao {
   }
 
   /**
+   * True when the collection references at least one child collection with {@code is_client =
+   * true}. This is the derived successor to the {@code type == PARENT} gate on gallery-access
+   * eligibility and password propagation: parent-ness is a property of the content graph, not a
+   * stored label. Admin-context, so it gates neither the child's own {@code visibility} nor the
+   * per-membership {@code cc.visible} -- exactly like {@link
+   * #findAllReferencedCollectionsByParentId}, whose result set it summarises.
+   */
+  @Transactional(readOnly = true)
+  public boolean hasClientGalleryChildren(Long parentId) {
+    String sql =
+        """
+        SELECT EXISTS (
+          SELECT 1
+          FROM collection_content cc
+          JOIN content_collection cct ON cct.id = cc.content_id
+          JOIN collection c ON c.id = cct.referenced_collection_id
+          WHERE cc.collection_id = :parentId
+            AND c.is_client = true
+        )
+        """;
+    MapSqlParameterSource params = createParameterSource().addValue("parentId", parentId);
+    return queryForObject(sql, (rs, rowNum) -> rs.getBoolean(1), params).orElse(false);
+  }
+
+  /**
    * Ids of children linked under a parent through a VISIBLE membership row ({@code cc.visible =
    * true}), regardless of the child collection's own {@code visibility}. Role-grant propagation
    * follows only visible links (mirroring the V47 backfill gate); removal walks use the

--- a/src/main/java/edens/zac/portfolio/backend/dao/CollectionRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/CollectionRepository.java
@@ -923,7 +923,11 @@ public class CollectionRepository extends BaseDao {
     if (contentIds == null || contentIds.isEmpty()) {
       return List.of();
     }
-    String sql = SELECT_COLLECTION_CONTENT + " WHERE content_id IN (:contentIds)";
+    // ORDER BY is load-bearing, not cosmetic: without it Postgres returns rows in an arbitrary
+    // order and any caller that resolves "the" parent of a piece of content picks a different
+    // collection on different requests (S1).
+    String sql =
+        SELECT_COLLECTION_CONTENT + " WHERE content_id IN (:contentIds) ORDER BY collection_id";
     MapSqlParameterSource params = createParameterSource().addValue("contentIds", contentIds);
     return query(sql, COLLECTION_CONTENT_ROW_MAPPER, params);
   }

--- a/src/main/java/edens/zac/portfolio/backend/services/CollectionService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/CollectionService.java
@@ -28,7 +28,6 @@ import edens.zac.portfolio.backend.model.ContentModels;
 import edens.zac.portfolio.backend.model.GeneralMetadataDTO;
 import edens.zac.portfolio.backend.model.LocationPageResponse;
 import edens.zac.portfolio.backend.model.Records;
-import edens.zac.portfolio.backend.types.CollectionType;
 import edens.zac.portfolio.backend.types.CollectionVisibility;
 import edens.zac.portfolio.backend.types.ContentType;
 import edens.zac.portfolio.backend.types.FilmFormat;
@@ -1466,23 +1465,23 @@ public class CollectionService {
    *   <li>password set, emails non-empty: set password and send one email per recipient
    * </ul>
    *
-   * <p>Accepted target types are {@link CollectionType#CLIENT_GALLERY} and {@link
-   * CollectionType#PARENT}. For PARENT targets, when {@link
+   * <p>Eligibility is derived, not typed: the target must either be a client gallery itself ({@code
+   * is_client}) or reference at least one client-gallery child ({@link
+   * edens.zac.portfolio.backend.dao.CollectionRepository#hasClientGalleryChildren}). When {@link
    * GalleryAccessRequest#propagateToChildren()} is {@code true}, the same password is batch-written
-   * to every {@link CollectionType#CLIENT_GALLERY} child referenced by the PARENT (other child
-   * types are skipped). Recipient emails are NOT propagated. Returns {@code
-   * GalleryAccessResponse(saved=false, reason="not-eligible-type")} for any other type.
+   * to every {@code is_client} child referenced by the target; non-client children are skipped.
+   * Recipient emails are NOT propagated. Returns {@code GalleryAccessResponse(saved=false,
+   * reason="not-eligible-type")} for an ineligible target.
    */
   @Transactional
   public GalleryAccessResponse updateGalleryAccess(Long id, GalleryAccessRequest request) {
     CollectionEntity entity = findEntityById(id);
 
-    if (entity.getType() != CollectionType.CLIENT_GALLERY
-        && entity.getType() != CollectionType.PARENT) {
+    if (!entity.isClient() && !collectionRepository.hasClientGalleryChildren(id)) {
       log.warn(
-          "Refusing gallery-access update on ineligible collection (id={}, type={})",
+          "Refusing gallery-access update on ineligible collection (id={}, slug={})",
           id,
-          entity.getType());
+          entity.getSlug());
       return new GalleryAccessResponse(false, false, "not-eligible-type", null, List.of());
     }
 
@@ -1525,37 +1524,36 @@ public class CollectionService {
   }
 
   /**
-   * When {@code request.propagateToChildren()} is {@code true} AND {@code parent} is of type {@link
-   * CollectionType#PARENT}, batch-update the same password on every {@link
-   * CollectionType#CLIENT_GALLERY} child referenced by that PARENT. Other child types (other
-   * PARENTs, PORTFOLIOs, BLOGs, etc.) are skipped.
+   * When {@code request.propagateToChildren()} is {@code true}, batch-update the same password on
+   * every {@code is_client} child referenced by the parent. Non-client children are skipped.
+   *
+   * <p>There is no parent-side gate any more. Parent-ness is derived from the content graph, so "is
+   * this a wrapper" is not a question this method can or should ask -- eligibility already answered
+   * it upstream, and a target with no client children simply writes nothing.
    */
   private void propagatePasswordToChildrenIfRequested(
       CollectionEntity parent, GalleryAccessRequest request) {
-    if (!Boolean.TRUE.equals(request.propagateToChildren())
-        || parent.getType() != CollectionType.PARENT) {
+    if (!Boolean.TRUE.equals(request.propagateToChildren())) {
       log.debug(
-          "Skipping password propagation (parentId={}, propagate={}, type={})",
+          "Skipping password propagation (parentId={}, propagate={})",
           parent.getId(),
-          request.propagateToChildren(),
-          parent.getType());
+          request.propagateToChildren());
       return;
     }
     List<CollectionEntity> children =
         collectionRepository.findAllReferencedCollectionsByParentId(parent.getId());
-    long clientGalleryCount =
-        children.stream().filter(c -> c.getType() == CollectionType.CLIENT_GALLERY).count();
+    long clientGalleryCount = children.stream().filter(CollectionEntity::isClient).count();
     log.info(
-        "Propagating password from parent (id={}, slug={}): {} children found, {} are CLIENT_GALLERY",
+        "Propagating password from parent (id={}, slug={}): {} children found, {} are client galleries",
         parent.getId(),
         parent.getSlug(),
         children.size(),
         clientGalleryCount);
     for (CollectionEntity child : children) {
-      if (child.getType() == CollectionType.CLIENT_GALLERY) {
+      if (child.isClient()) {
         collectionRepository.updateGalleryPassword(child.getId(), request.password());
         log.info(
-            "Propagated parent (id={}) gallery password to CLIENT_GALLERY child (id={}, slug={})",
+            "Propagated parent (id={}) gallery password to client child (id={}, slug={})",
             parent.getId(),
             child.getId(),
             child.getSlug());

--- a/src/main/java/edens/zac/portfolio/backend/services/CollectionService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/CollectionService.java
@@ -1566,10 +1566,29 @@ public class CollectionService {
    * to every {@code is_client} child referenced by the target; non-client children are skipped.
    * Recipient emails are NOT propagated. Returns {@code GalleryAccessResponse(saved=false,
    * reason="not-eligible-type")} for an ineligible target.
+   *
+   * <p>Eligibility gates only the SET path (D8). A {@code null} password is accepted on ANY
+   * collection: this method is the only writer that can clear {@code gallery_password} (see {@code
+   * CollectionRepository.save}, which omits the column on UPDATE), so a gated clear path would
+   * strand a row behind a password nothing could remove. Clearing cannot widen access beyond "no
+   * password", so it needs no gate.
    */
   @Transactional
   public GalleryAccessResponse updateGalleryAccess(Long id, GalleryAccessRequest request) {
     CollectionEntity entity = findEntityById(id);
+
+    // D8: clearing is unconditional and comes first. This method is the only writer that can
+    // clear gallery_password -- CollectionRepository.save deliberately omits the column on
+    // UPDATE -- so gating the clear path strands every row that holds an enforced password while
+    // failing the derived eligibility test below: a wrapper whose last client-gallery child was
+    // unlinked, and the gallery_password IS NOT NULL AND is_client = false rows U0's
+    // reconnaissance enumerates. Such a row keeps serving behind a password no endpoint can
+    // remove. A clear cannot widen access beyond "no password", so it needs no gate.
+    if (request.password() == null) {
+      collectionRepository.saveGalleryAccess(id, null, List.of());
+      log.info("Cleared gallery password and recipients (id={}, slug={})", id, entity.getSlug());
+      return new GalleryAccessResponse(true, false, null, null, List.of());
+    }
 
     if (!entity.isClient() && !collectionRepository.hasClientGalleryChildren(id)) {
       log.warn(
@@ -1581,12 +1600,6 @@ public class CollectionService {
 
     List<String> emails =
         request.emails() != null && !request.emails().isEmpty() ? request.emails() : List.of();
-
-    if (request.password() == null) {
-      collectionRepository.saveGalleryAccess(id, null, List.of());
-      log.info("Cleared gallery password and recipients (id={}, slug={})", id, entity.getSlug());
-      return new GalleryAccessResponse(true, false, null, null, List.of());
-    }
 
     collectionRepository.saveGalleryAccess(id, request.password(), emails);
     log.info(

--- a/src/main/java/edens/zac/portfolio/backend/services/CollectionService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/CollectionService.java
@@ -1422,19 +1422,7 @@ public class CollectionService {
 
     Set<Long> excludedIds =
         children.stream()
-            .filter(
-                c ->
-                    // S3: an unprotected parent must not publish a password-protected child's
-                    // title, description or cover image. Chosen over the alternative fix (add
-                    // isPasswordProtected to ContentModels.Collection and null out
-                    // coverImage/description) because that is a wire-format change requiring a
-                    // matching frontend locked-tile state, and this unit ships without one.
-                    (!parentIsProtected && c.getGalleryPassword() != null)
-                        // S4: relax per child, not model-wide. One client-gallery child used to
-                        // flip the whole response into "keep UNLISTED children" mode, un-hiding
-                        // every unrelated work-in-progress sibling under the same wrapper.
-                        || c.getVisibility() == CollectionVisibility.HIDDEN
-                        || (!c.isClient() && !c.getVisibility().appearsInLists()))
+            .filter(c -> isChildExcluded(c, parentIsProtected))
             .map(CollectionEntity::getId)
             .collect(Collectors.toSet());
 
@@ -1459,6 +1447,35 @@ public class CollectionService {
         excludedIds.size(),
         model.getSlug(),
         parentIsProtected);
+  }
+
+  /**
+   * Whether a referenced child collection must be stripped from a public parent's response.
+   *
+   * <p>Three independent reasons, each pinned by its own test:
+   *
+   * <ul>
+   *   <li>HIDDEN children never render publicly.
+   *   <li>S3: an unprotected parent must not publish a password-protected child's title,
+   *       description or cover image. {@code ContentModels.Collection} has no {@code
+   *       isPasswordProtected} field, so the frontend cannot render a locked tile -- dropping the
+   *       block is the only correct behaviour available without a wire change, and this unit is
+   *       specified as a no-model-change unit. The alternative (emit {@code isPasswordProtected}
+   *       and null out {@code coverImage}/{@code description}) is deliberately NOT implemented;
+   *       there is no second code path.
+   *   <li>S4: the UNLISTED relaxation is per child, not per model. It used to be computed once from
+   *       the whole response ("any child is a client gallery"), so linking a single gallery under a
+   *       wrapper un-hid every unrelated UNLISTED work-in-progress sibling.
+   * </ul>
+   */
+  private static boolean isChildExcluded(CollectionEntity child, boolean parentIsProtected) {
+    if (child.getVisibility() == CollectionVisibility.HIDDEN) {
+      return true;
+    }
+    if (!parentIsProtected && child.getGalleryPassword() != null) {
+      return true;
+    }
+    return !child.isClient() && !child.getVisibility().appearsInLists();
   }
 
   /**

--- a/src/main/java/edens/zac/portfolio/backend/services/CollectionService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/CollectionService.java
@@ -32,9 +32,12 @@ import edens.zac.portfolio.backend.types.CollectionVisibility;
 import edens.zac.portfolio.backend.types.ContentType;
 import edens.zac.portfolio.backend.types.FilmFormat;
 import java.time.LocalDateTime;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Deque;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -351,11 +354,18 @@ public class CollectionService {
    */
   @Transactional
   public void linkCollectionToParent(Long parentId, Long childCollectionId) {
-    collectionRepository
-        .findById(parentId)
-        .orElseThrow(
-            () ->
-                new ResourceNotFoundException("Parent collection not found with ID: " + parentId));
+    // `final` is load-bearing for checkstyle's VariableDeclarationUsageDistance: the parent is
+    // resolved up front (it must exist before anything else happens) but is not read until the
+    // S6 password propagation at the end of the method.
+    final CollectionEntity parentEntity =
+        collectionRepository
+            .findById(parentId)
+            .orElseThrow(
+                () ->
+                    new ResourceNotFoundException(
+                        "Parent collection not found with ID: " + parentId));
+
+    validateNoLinkCycle(parentId, childCollectionId);
 
     CollectionEntity childEntity =
         collectionRepository
@@ -401,6 +411,66 @@ public class CollectionService {
 
     // Waterfall: the new child inherits every grant the parent holds (origin preserved).
     roleGrantPropagationService.onChildLinked(parentId, childCollectionId);
+
+    // S6: linkage is a password-propagation trigger too, symmetric with the grant waterfall
+    // above. updateGalleryAccess was the only writer, so a client gallery linked after the
+    // password was set kept a null password -- and a null password means isPasswordProtected is
+    // false, content is never stripped, UNLISTED direct-slug access is permitted, and the download
+    // gate is skipped. Under a derived parent model, password-then-link is the routine ordering.
+    if (parentEntity.getGalleryPassword() != null
+        && childEntity.isClient()
+        && childEntity.getGalleryPassword() == null) {
+      collectionRepository.updateGalleryPassword(
+          childCollectionId, parentEntity.getGalleryPassword());
+      log.info(
+          "Propagated parent (id={}) gallery password to newly linked client child (id={}, slug={})",
+          parentId,
+          childCollectionId,
+          childEntity.getSlug());
+    }
+  }
+
+  /**
+   * Reject a link that would close a cycle, at the one funnel every child link passes through
+   * ({@code createChildCollection}, the staging auto-link, and tag conversion all call it).
+   *
+   * <p>The pre-existing {@code validateNoParentCycles} runs only on the inverse {@code parents}
+   * path and catches only self- and 2-cycles by its own admission. This is a full ancestor walk,
+   * cycle-guarded with a visited set exactly like {@code RoleGrantPropagationService#subtreeOf}, so
+   * an existing cycle in the data cannot make the guard itself loop. A cycle matters because every
+   * member becomes simultaneously an ancestor and a descendant of every other, so role grants merge
+   * across it -- a client gallery's grants would waterfall onto a public collection.
+   */
+  private void validateNoLinkCycle(Long parentId, Long childCollectionId) {
+    if (parentId.equals(childCollectionId)) {
+      throw new IllegalArgumentException(
+          "A collection cannot be its own parent (id=" + parentId + ")");
+    }
+    Set<Long> visited = new HashSet<>();
+    visited.add(parentId);
+    Deque<Long> pending = new ArrayDeque<>(parentIdsOf(parentId));
+    while (!pending.isEmpty()) {
+      Long current = pending.poll();
+      if (!visited.add(current)) {
+        continue;
+      }
+      if (current.equals(childCollectionId)) {
+        throw new IllegalArgumentException(
+            "Cycle detected: collection "
+                + childCollectionId
+                + " is already an ancestor of "
+                + parentId
+                + " and cannot also be its child");
+      }
+      pending.addAll(parentIdsOf(current));
+    }
+  }
+
+  /** Ids of every collection referencing this one as a child, regardless of link visibility. */
+  private List<Long> parentIdsOf(Long collectionId) {
+    return collectionRepository.findAllParentCollectionsByChildId(collectionId).stream()
+        .map(CollectionEntity::getId)
+        .toList();
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/edens/zac/portfolio/backend/services/CollectionService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/CollectionService.java
@@ -1418,16 +1418,23 @@ public class CollectionService {
     // Batch-load referenced children once — used for both context detection and visibility filter
     List<CollectionEntity> children = collectionRepository.findByIds(referencedIds);
 
-    boolean isClientGalleryContext =
-        model.isClient() || children.stream().anyMatch(CollectionEntity::isClient);
+    boolean parentIsProtected = Boolean.TRUE.equals(model.getIsPasswordProtected());
 
     Set<Long> excludedIds =
         children.stream()
             .filter(
                 c ->
-                    isClientGalleryContext
-                        ? c.getVisibility() == CollectionVisibility.HIDDEN
-                        : !c.getVisibility().appearsInLists())
+                    // S3: an unprotected parent must not publish a password-protected child's
+                    // title, description or cover image. Chosen over the alternative fix (add
+                    // isPasswordProtected to ContentModels.Collection and null out
+                    // coverImage/description) because that is a wire-format change requiring a
+                    // matching frontend locked-tile state, and this unit ships without one.
+                    (!parentIsProtected && c.getGalleryPassword() != null)
+                        // S4: relax per child, not model-wide. One client-gallery child used to
+                        // flip the whole response into "keep UNLISTED children" mode, un-hiding
+                        // every unrelated work-in-progress sibling under the same wrapper.
+                        || c.getVisibility() == CollectionVisibility.HIDDEN
+                        || (!c.isClient() && !c.getVisibility().appearsInLists()))
             .map(CollectionEntity::getId)
             .collect(Collectors.toSet());
 
@@ -1448,10 +1455,10 @@ public class CollectionService {
 
     model.setContent(filtered);
     log.debug(
-        "Filtered {} child collections from response (parent={}, clientGalleryContext={})",
+        "Filtered {} child collections from response (parent={}, parentIsProtected={})",
         excludedIds.size(),
         model.getSlug(),
-        isClientGalleryContext);
+        parentIsProtected);
   }
 
   /**

--- a/src/main/java/edens/zac/portfolio/backend/services/ContentService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/ContentService.java
@@ -683,28 +683,6 @@ public class ContentService {
   }
 
   /**
-   * Resolve a parent {@link CollectionEntity} for an image, used by the per-image download endpoint
-   * to decide whether to enforce a {@code passwordHash}-gated cookie. Images can belong to multiple
-   * collections (many-to-many via {@code collection_content}); this returns any matching parent
-   * (deterministic via {@code findContentByContentIdsIn} ordering). Returns empty when the image is
-   * orphaned.
-   */
-  @Transactional(readOnly = true)
-  public Optional<CollectionEntity> findCollectionForImage(Long imageId) {
-    log.debug("Finding parent collection for image ID: {}", imageId);
-    List<CollectionContentEntity> joinEntries =
-        collectionRepository.findContentByContentIdsIn(List.of(imageId));
-    if (joinEntries.isEmpty()) {
-      return Optional.empty();
-    }
-    Long collectionId = joinEntries.getFirst().getCollectionId();
-    if (collectionId == null) {
-      return Optional.empty();
-    }
-    return collectionRepository.findById(collectionId);
-  }
-
-  /**
    * Every password-protected collection that contains this image. The per-image download endpoint
    * must satisfy the gate for ALL of them: an image can belong to several collections at once
    * (many-to-many via {@code collection_content}), and resolving a single arbitrary parent let an

--- a/src/main/java/edens/zac/portfolio/backend/services/ContentService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/ContentService.java
@@ -704,6 +704,30 @@ public class ContentService {
     return collectionRepository.findById(collectionId);
   }
 
+  /**
+   * Every password-protected collection that contains this image. The per-image download endpoint
+   * must satisfy the gate for ALL of them: an image can belong to several collections at once
+   * (many-to-many via {@code collection_content}), and resolving a single arbitrary parent let an
+   * unprotected wrapper waive a protected gallery's password on a nondeterministic fraction of
+   * requests. Returns an empty list when the image is orphaned or every parent is unprotected.
+   */
+  @Transactional(readOnly = true)
+  public List<CollectionEntity> findProtectedCollectionsForImage(Long imageId) {
+    log.debug("Finding protected parent collections for image ID: {}", imageId);
+    List<Long> collectionIds =
+        collectionRepository.findContentByContentIdsIn(List.of(imageId)).stream()
+            .map(CollectionContentEntity::getCollectionId)
+            .filter(Objects::nonNull)
+            .distinct()
+            .toList();
+    if (collectionIds.isEmpty()) {
+      return List.of();
+    }
+    return collectionRepository.findByIds(collectionIds).stream()
+        .filter(collection -> collection.getGalleryPassword() != null)
+        .toList();
+  }
+
   // ---------------------------------------------------------------------------
   //  Download resolution
   // ---------------------------------------------------------------------------

--- a/src/test/java/edens/zac/portfolio/backend/controller/prod/ContentDownloadAuthTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/prod/ContentDownloadAuthTest.java
@@ -19,7 +19,6 @@ import edens.zac.portfolio.backend.types.CollectionType;
 import edens.zac.portfolio.backend.types.CollectionVisibility;
 import java.net.URI;
 import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -96,7 +95,8 @@ class ContentDownloadAuthTest {
     @Test
     void clientMember_redirects_withoutCookie() throws Exception {
       authenticate(7L);
-      when(contentService.findCollectionForImage(10L)).thenReturn(Optional.of(protectedGallery()));
+      when(contentService.findProtectedCollectionsForImage(10L))
+          .thenReturn(List.of(protectedGallery()));
       when(collectionAccessService.isClient(7L, 1L)).thenReturn(true);
       when(contentService.resolveImageDownload(10L, "web")).thenReturn(webResolution("img.webp"));
       when(downloadUrlService.presignObject(any(), any(), any())).thenReturn(PRESIGNED);
@@ -109,7 +109,8 @@ class ContentDownloadAuthTest {
     @Test
     void nonClientMember_gets401() throws Exception {
       authenticate(7L);
-      when(contentService.findCollectionForImage(10L)).thenReturn(Optional.of(protectedGallery()));
+      when(contentService.findProtectedCollectionsForImage(10L))
+          .thenReturn(List.of(protectedGallery()));
       when(collectionAccessService.isClient(7L, 1L)).thenReturn(false);
 
       mockMvc
@@ -121,7 +122,8 @@ class ContentDownloadAuthTest {
 
     @Test
     void anonymous_noMembership_noCookie_gets401() throws Exception {
-      when(contentService.findCollectionForImage(10L)).thenReturn(Optional.of(protectedGallery()));
+      when(contentService.findProtectedCollectionsForImage(10L))
+          .thenReturn(List.of(protectedGallery()));
 
       mockMvc
           .perform(get("/api/read/content/images/10/download"))
@@ -132,7 +134,8 @@ class ContentDownloadAuthTest {
 
     @Test
     void anonymous_validCookie_redirects() throws Exception {
-      when(contentService.findCollectionForImage(10L)).thenReturn(Optional.of(protectedGallery()));
+      when(contentService.findProtectedCollectionsForImage(10L))
+          .thenReturn(List.of(protectedGallery()));
       when(clientGalleryAuthService.validateAccessToken("smith-wedding", "tok")).thenReturn(true);
       when(contentService.resolveImageDownload(10L, "web")).thenReturn(webResolution("img.webp"));
       when(downloadUrlService.presignObject(any(), any(), any())).thenReturn(PRESIGNED);

--- a/src/test/java/edens/zac/portfolio/backend/controller/prod/ContentDownloadControllerProdTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/prod/ContentDownloadControllerProdTest.java
@@ -24,7 +24,6 @@ import edens.zac.portfolio.backend.types.CollectionVisibility;
 import jakarta.servlet.http.Cookie;
 import java.net.URI;
 import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -109,7 +108,8 @@ class ContentDownloadControllerProdTest {
 
     @Test
     void protectedCollection_validCookie_redirectsToPresignedUrl() throws Exception {
-      when(contentService.findCollectionForImage(10L)).thenReturn(Optional.of(protectedGallery()));
+      when(contentService.findProtectedCollectionsForImage(10L))
+          .thenReturn(List.of(protectedGallery()));
       when(clientGalleryAuthService.validateAccessToken("smith-wedding", "tok-123"))
           .thenReturn(true);
       when(contentService.resolveImageDownload(10L, "web"))
@@ -128,7 +128,8 @@ class ContentDownloadControllerProdTest {
 
     @Test
     void protectedCollection_noCookie_returns401() throws Exception {
-      when(contentService.findCollectionForImage(10L)).thenReturn(Optional.of(protectedGallery()));
+      when(contentService.findProtectedCollectionsForImage(10L))
+          .thenReturn(List.of(protectedGallery()));
 
       mockMvc
           .perform(get("/api/read/content/images/10/download"))
@@ -140,7 +141,7 @@ class ContentDownloadControllerProdTest {
 
     @Test
     void unprotectedCollection_noCookie_redirects() throws Exception {
-      when(contentService.findCollectionForImage(11L)).thenReturn(Optional.of(openCollection()));
+      when(contentService.findProtectedCollectionsForImage(11L)).thenReturn(List.of());
       when(contentService.resolveImageDownload(11L, "web"))
           .thenReturn(webResolution("open-001.webp"));
       when(downloadUrlService.presignObject(any(), any(), any())).thenReturn(PRESIGNED);
@@ -155,7 +156,8 @@ class ContentDownloadControllerProdTest {
 
     @Test
     void formatOriginal_redirectsWithJpegResolution() throws Exception {
-      when(contentService.findCollectionForImage(10L)).thenReturn(Optional.of(protectedGallery()));
+      when(contentService.findProtectedCollectionsForImage(10L))
+          .thenReturn(List.of(protectedGallery()));
       when(clientGalleryAuthService.validateAccessToken("smith-wedding", "tok-123"))
           .thenReturn(true);
       when(contentService.resolveImageDownload(10L, "original"))
@@ -175,7 +177,7 @@ class ContentDownloadControllerProdTest {
 
     @Test
     void serviceThrowsNotFound_returns404() throws Exception {
-      when(contentService.findCollectionForImage(10L)).thenReturn(Optional.empty());
+      when(contentService.findProtectedCollectionsForImage(10L)).thenReturn(List.of());
       when(contentService.resolveImageDownload(10L, "original"))
           .thenThrow(new ResourceNotFoundException("No original available for image 10"));
 
@@ -188,13 +190,61 @@ class ContentDownloadControllerProdTest {
 
     @Test
     void formatUnsupported_returns400() throws Exception {
-      when(contentService.findCollectionForImage(10L)).thenReturn(Optional.empty());
+      when(contentService.findProtectedCollectionsForImage(10L)).thenReturn(List.of());
       when(contentService.resolveImageDownload(10L, "raw"))
           .thenThrow(new IllegalArgumentException("Unsupported download format: raw"));
 
       mockMvc
           .perform(get("/api/read/content/images/10/download").param("format", "raw"))
           .andExpect(status().isBadRequest());
+
+      verify(downloadUrlService, never()).presignObject(any(), any(), any());
+    }
+
+    @Test
+    void imageInBothAProtectedGalleryAndAPublicCollection_noCookie_returns401() throws Exception {
+      // S1: an image may sit in several collections at once. The gate used to resolve ONE
+      // arbitrary parent from an unordered join, so the public wrapper waived the gallery's
+      // password on a nondeterministic fraction of requests. The service now hands the
+      // controller every protected parent; the public wrapper is simply not in that list.
+      when(contentService.findProtectedCollectionsForImage(10L))
+          .thenReturn(List.of(protectedGallery()));
+
+      mockMvc
+          .perform(get("/api/read/content/images/10/download"))
+          .andExpect(status().isUnauthorized());
+
+      verify(contentService, never()).resolveImageDownload(any(), any());
+      verify(downloadUrlService, never()).presignObject(any(), any(), any());
+    }
+
+    @Test
+    void imageInTwoProtectedGalleries_cookieForOnlyOne_returns401() throws Exception {
+      // "EVERY protected parent", not "any": a cookie for smith-wedding must not unlock an image
+      // that also lives in jones-wedding.
+      CollectionEntity otherGallery =
+          CollectionEntity.builder()
+              .id(3L)
+              .type(CollectionType.CLIENT_GALLERY)
+              .title("Jones Wedding")
+              .slug("jones-wedding")
+              .visibility(CollectionVisibility.UNLISTED)
+              .galleryPassword("moonlight")
+              .build();
+      when(contentService.findProtectedCollectionsForImage(10L))
+          .thenReturn(List.of(protectedGallery(), otherGallery));
+      when(clientGalleryAuthService.validateAccessToken("smith-wedding", "tok-123"))
+          .thenReturn(true);
+      // jones-wedding is deliberately NOT stubbed: there is no gallery_access_jones-wedding
+      // cookie, so GalleryAccessCookies.hasValidAccess calls validateAccessToken with a NULL
+      // token. Stubbing it for "tok-123" would be an argument mismatch that STRICT_STUBS turns
+      // into a 500, masking the 401 this test exists to prove.
+
+      mockMvc
+          .perform(
+              get("/api/read/content/images/10/download")
+                  .cookie(new Cookie("gallery_access_smith-wedding", "tok-123")))
+          .andExpect(status().isUnauthorized());
 
       verify(downloadUrlService, never()).presignObject(any(), any(), any());
     }

--- a/src/test/java/edens/zac/portfolio/backend/dao/CollectionFlagRepositoryIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/dao/CollectionFlagRepositoryIntegrationTest.java
@@ -515,4 +515,101 @@ class CollectionFlagRepositoryIntegrationTest extends AbstractPostgresIntegratio
 
     assertThat(ids).containsSubsequence(highRated.getId(), midRatedNewer.getId(), lowRated.getId());
   }
+
+  @Test
+  void hasClientGalleryChildren_trueWhenAnyChildIsClient() {
+    CollectionEntity wrapper =
+        saveCollection(
+            "s2-wrapper-with-client",
+            CollectionType.MISC,
+            false,
+            false,
+            CollectionVisibility.LISTED,
+            LocalDate.of(2026, 9, 1));
+    CollectionEntity clientChild =
+        saveCollection(
+            "s2-wrapper-client-child",
+            CollectionType.CLIENT_GALLERY,
+            true,
+            false,
+            CollectionVisibility.UNLISTED,
+            LocalDate.of(2026, 9, 2));
+    linkChild(wrapper.getId(), clientChild.getId(), true);
+
+    assertThat(collectionRepository.hasClientGalleryChildren(wrapper.getId())).isTrue();
+  }
+
+  @Test
+  void hasClientGalleryChildren_ignoresChildVisibilityAndLinkVisibility() {
+    // Admin-context query, mirroring findAllReferencedCollectionsByParentId: neither the child's
+    // own visibility nor the per-membership cc.visible gates it, so an admin can still lock a
+    // wrapper whose only client child is HIDDEN behind a soft-removed link.
+    CollectionEntity wrapper =
+        saveCollection(
+            "s2-wrapper-hidden-child",
+            CollectionType.MISC,
+            false,
+            false,
+            CollectionVisibility.LISTED,
+            LocalDate.of(2026, 9, 3));
+    CollectionEntity hiddenChild =
+        saveCollection(
+            "s2-hidden-client-child",
+            CollectionType.CLIENT_GALLERY,
+            true,
+            false,
+            CollectionVisibility.HIDDEN,
+            LocalDate.of(2026, 9, 4));
+    linkChild(wrapper.getId(), hiddenChild.getId(), false);
+
+    assertThat(collectionRepository.hasClientGalleryChildren(wrapper.getId())).isTrue();
+  }
+
+  @Test
+  void hasClientGalleryChildren_falseWhenNoChildIsClient() {
+    // The boolean is the truth, not the type: a CLIENT_GALLERY-typed child with is_client = false
+    // must not qualify.
+    CollectionEntity wrapper =
+        saveCollection(
+            "s2-wrapper-no-client",
+            CollectionType.MISC,
+            false,
+            false,
+            CollectionVisibility.LISTED,
+            LocalDate.of(2026, 9, 5));
+    CollectionEntity plainChild =
+        saveCollection(
+            "s2-plain-child",
+            CollectionType.PORTFOLIO,
+            false,
+            false,
+            CollectionVisibility.LISTED,
+            LocalDate.of(2026, 9, 6));
+    CollectionEntity driftedChild =
+        saveCollection(
+            "s2-drifted-child",
+            CollectionType.CLIENT_GALLERY,
+            false,
+            false,
+            CollectionVisibility.LISTED,
+            LocalDate.of(2026, 9, 7));
+    linkChild(wrapper.getId(), plainChild.getId(), true);
+    linkChild(wrapper.getId(), driftedChild.getId(), true);
+
+    assertThat(collectionRepository.hasClientGalleryChildren(wrapper.getId())).isFalse();
+  }
+
+  @Test
+  void hasClientGalleryChildren_falseForACollectionWithNoChildren() {
+    CollectionEntity leaf =
+        saveCollection(
+            "s2-leaf",
+            CollectionType.MISC,
+            false,
+            false,
+            CollectionVisibility.LISTED,
+            LocalDate.of(2026, 9, 8));
+
+    assertThat(collectionRepository.hasClientGalleryChildren(leaf.getId())).isFalse();
+  }
 }

--- a/src/test/java/edens/zac/portfolio/backend/services/CollectionLinkSecurityIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/CollectionLinkSecurityIntegrationTest.java
@@ -1,0 +1,135 @@
+package edens.zac.portfolio.backend.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import edens.zac.portfolio.backend.AbstractPostgresIntegrationTest;
+import edens.zac.portfolio.backend.dao.CollectionRepository;
+import edens.zac.portfolio.backend.entity.CollectionEntity;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * S5 and S6 on the single link funnel {@link CollectionService#linkCollectionToParent}: an ancestor
+ * may never be re-linked as a descendant, and a password already set on the parent waterfalls onto
+ * a client-gallery child at link time. Real Postgres because both walk the collection_content ->
+ * content_collection join chain.
+ *
+ * <p>Rows live in the SHARED singleton container (only auth tables are truncated), so every slug
+ * carries an s5-/s6- prefix and assertions never use global counts.
+ */
+class CollectionLinkSecurityIntegrationTest extends AbstractPostgresIntegrationTest {
+
+  @Autowired private CollectionService collectionService;
+  @Autowired private CollectionRepository collectionRepository;
+  @Autowired private JdbcTemplate jdbc;
+
+  private long seed(String slug, boolean isClient, String galleryPassword) {
+    jdbc.update(
+        "INSERT INTO collection (title, slug, type, visibility, is_client, is_blog,"
+            + " gallery_password) VALUES (?, ?, 'MISC', 'LISTED', ?, false, ?)",
+        slug,
+        slug,
+        isClient,
+        galleryPassword);
+    return jdbc.queryForObject("SELECT id FROM collection WHERE slug = ?", Long.class, slug);
+  }
+
+  // --- S5: cycle validation ---------------------------------------------------
+
+  @Test
+  void selfLink_isRejected() {
+    long only = seed("s5-self", false, null);
+
+    assertThatThrownBy(() -> collectionService.linkCollectionToParent(only, only))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("cannot be its own parent");
+  }
+
+  @Test
+  void twoCycle_isRejected() {
+    long a = seed("s5-two-a", false, null);
+    long b = seed("s5-two-b", false, null);
+    collectionService.linkCollectionToParent(a, b);
+
+    assertThatThrownBy(() -> collectionService.linkCollectionToParent(b, a))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cycle detected");
+  }
+
+  @Test
+  void threeCycle_isRejected() {
+    // validateNoParentCycles caught only self- and 2-cycles by its own admission. The ancestor
+    // walk must reject the deeper case, which is what merges role grants across a client gallery
+    // and a public collection.
+    long a = seed("s5-three-a", false, null);
+    long b = seed("s5-three-b", false, null);
+    long c = seed("s5-three-c", false, null);
+    collectionService.linkCollectionToParent(a, b);
+    collectionService.linkCollectionToParent(b, c);
+
+    assertThatThrownBy(() -> collectionService.linkCollectionToParent(c, a))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cycle detected");
+  }
+
+  @Test
+  void twoParentsSharingOneChild_isAllowed() {
+    // A diamond is not a cycle. The guard must not reject legitimate multi-parent linkage.
+    long left = seed("s5-diamond-left", false, null);
+    long right = seed("s5-diamond-right", false, null);
+    long shared = seed("s5-diamond-shared", false, null);
+    collectionService.linkCollectionToParent(left, shared);
+
+    collectionService.linkCollectionToParent(right, shared);
+
+    assertThat(collectionRepository.findAllParentCollectionsByChildId(shared))
+        .extracting(CollectionEntity::getId)
+        .containsExactlyInAnyOrder(left, right);
+  }
+
+  // --- S6: password propagates at link time ------------------------------------
+
+  @Test
+  void linkingClientChildUnderPasswordedParent_copiesPasswordDown() {
+    long parent = seed("s6-parent", false, "smith2026");
+    long child = seed("s6-client-child", true, null);
+
+    collectionService.linkCollectionToParent(parent, child);
+
+    assertThat(collectionRepository.findById(child).orElseThrow().getGalleryPassword())
+        .isEqualTo("smith2026");
+  }
+
+  @Test
+  void linkingClientChildThatAlreadyHasAPassword_leavesItAlone() {
+    long parent = seed("s6-parent-keep", false, "parentpw");
+    long child = seed("s6-client-child-keep", true, "childpw");
+
+    collectionService.linkCollectionToParent(parent, child);
+
+    assertThat(collectionRepository.findById(child).orElseThrow().getGalleryPassword())
+        .isEqualTo("childpw");
+  }
+
+  @Test
+  void linkingNonClientChildUnderPasswordedParent_doesNotCopyPassword() {
+    long parent = seed("s6-parent-nonclient", false, "parentpw");
+    long child = seed("s6-plain-child", false, null);
+
+    collectionService.linkCollectionToParent(parent, child);
+
+    assertThat(collectionRepository.findById(child).orElseThrow().getGalleryPassword()).isNull();
+  }
+
+  @Test
+  void linkingClientChildUnderAnUnprotectedParent_leavesTheChildOpen() {
+    long parent = seed("s6-parent-open", false, null);
+    long child = seed("s6-client-child-open", true, null);
+
+    collectionService.linkCollectionToParent(parent, child);
+
+    assertThat(collectionRepository.findById(child).orElseThrow().getGalleryPassword()).isNull();
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/services/CollectionServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/CollectionServiceTest.java
@@ -1217,13 +1217,11 @@ class CollectionServiceTest {
     }
 
     @Test
-    void parentOfMixedClientGalleryAndPortfolio_appliesClientGalleryContextToAllChildren() {
-      // Pinning current behavior: a PARENT with at least one CLIENT_GALLERY child flips the entire
-      // response into "client gallery context" — only HIDDEN children are dropped, regardless of
-      // the sibling child's type. So an UNLISTED PORTFOLIO sibling stays visible because the viewer
-      // is already inside the password-gated parent. The alternative (per-child context) is much
-      // more complex; this test pins the simpler whole-PARENT rule so a future refactor has to
-      // consciously change it.
+    void parentOfMixedClientGalleryAndPortfolio_dropsUnlistedNonClientSibling() {
+      // INVERTED PIN (was appliesClientGalleryContextToAllChildren). One client-gallery child used
+      // to flip the whole response into "keep UNLISTED children" mode, so linking a single gallery
+      // under a wrapper un-hid every unrelated work-in-progress sibling. The relaxation is now per
+      // child: an UNLISTED child survives only if it is itself a client gallery.
       String slug = "smith-wedding";
       CollectionEntity parent =
           CollectionEntity.builder()
@@ -1271,8 +1269,7 @@ class CollectionServiceTest {
 
       assertThat(result.getContent())
           .extracting(c -> ((ContentModels.Collection) c).referencedCollectionId())
-          .containsExactly(
-              301L, 302L, 303L); // gallery + both non-hidden portfolios kept; HIDDEN dropped
+          .containsExactly(301L, 303L); // client gallery + LISTED sibling; UNLISTED and HIDDEN gone
     }
 
     @Test
@@ -1322,6 +1319,104 @@ class CollectionServiceTest {
           .containsExactly(401L); // UNLISTED kept even though the wrapper is not a PARENT
     }
 
+    @Test
+    void unprotectedParent_dropsPasswordProtectedChild() {
+      // S3: ContentModels.Collection carries title, description, coverImage and dates but no
+      // isPasswordProtected, so the frontend cannot render a locked tile. An unprotected,
+      // crawlable, hour-cached parent page would publish the gallery's cover and client name.
+      String slug = "public-wrapper";
+      CollectionEntity parent =
+          CollectionEntity.builder()
+              .id(90L)
+              .slug(slug)
+              .type(CollectionType.MISC)
+              .visibility(CollectionVisibility.LISTED)
+              .build();
+
+      ContentModels.Collection lockedChild =
+          childCollectionContent(501L, CollectionType.CLIENT_GALLERY);
+      ContentModels.Collection openChild =
+          childCollectionContent(502L, CollectionType.CLIENT_GALLERY);
+
+      CollectionModel model =
+          CollectionModel.builder()
+              .id(90L)
+              .slug(slug)
+              .type(CollectionType.MISC)
+              .isPasswordProtected(false)
+              .content(new java.util.ArrayList<>(List.of(lockedChild, openChild)))
+              .build();
+
+      when(collectionRepository.findBySlug(slug)).thenReturn(Optional.of(parent));
+      when(collectionProcessingUtil.convertToModel(
+              eq(parent), any(), anyInt(), anyInt(), anyLong()))
+          .thenReturn(model);
+      when(collectionRepository.findByIds(List.of(501L, 502L)))
+          .thenReturn(
+              List.of(
+                  childEntity(
+                      501L,
+                      CollectionType.CLIENT_GALLERY,
+                      CollectionVisibility.UNLISTED,
+                      "sunshine"),
+                  childEntity(
+                      502L, CollectionType.CLIENT_GALLERY, CollectionVisibility.UNLISTED, null)));
+
+      CollectionModel result = service.getCollectionWithPagination(slug, 0, 10);
+
+      assertThat(result.getContent())
+          .extracting(c -> ((ContentModels.Collection) c).referencedCollectionId())
+          .containsExactly(502L);
+    }
+
+    @Test
+    void protectedParent_keepsPasswordProtectedChild() {
+      // The viewer is already behind the parent's own gate, so its protected children stay.
+      String slug = "locked-wrapper";
+      CollectionEntity parent =
+          CollectionEntity.builder()
+              .id(91L)
+              .slug(slug)
+              .type(CollectionType.MISC)
+              .visibility(CollectionVisibility.LISTED)
+              .build();
+
+      ContentModels.Collection lockedChild =
+          childCollectionContent(511L, CollectionType.CLIENT_GALLERY);
+      ContentModels.Collection openChild =
+          childCollectionContent(512L, CollectionType.CLIENT_GALLERY);
+
+      CollectionModel model =
+          CollectionModel.builder()
+              .id(91L)
+              .slug(slug)
+              .type(CollectionType.MISC)
+              .isPasswordProtected(true)
+              .content(new java.util.ArrayList<>(List.of(lockedChild, openChild)))
+              .build();
+
+      when(collectionRepository.findBySlug(slug)).thenReturn(Optional.of(parent));
+      when(collectionProcessingUtil.convertToModel(
+              eq(parent), any(), anyInt(), anyInt(), anyLong()))
+          .thenReturn(model);
+      when(collectionRepository.findByIds(List.of(511L, 512L)))
+          .thenReturn(
+              List.of(
+                  childEntity(
+                      511L,
+                      CollectionType.CLIENT_GALLERY,
+                      CollectionVisibility.UNLISTED,
+                      "sunshine"),
+                  childEntity(
+                      512L, CollectionType.CLIENT_GALLERY, CollectionVisibility.UNLISTED, null)));
+
+      CollectionModel result = service.getCollectionWithPagination(slug, 0, 10);
+
+      assertThat(result.getContent())
+          .extracting(c -> ((ContentModels.Collection) c).referencedCollectionId())
+          .containsExactly(511L, 512L);
+    }
+
     private ContentModels.Collection childCollectionContent(Long childId, CollectionType type) {
       return new ContentModels.Collection(
           childId,
@@ -1346,6 +1441,11 @@ class CollectionServiceTest {
 
     private CollectionEntity childEntity(
         Long id, CollectionType type, CollectionVisibility visibility) {
+      return childEntity(id, type, visibility, null);
+    }
+
+    private CollectionEntity childEntity(
+        Long id, CollectionType type, CollectionVisibility visibility, String galleryPassword) {
       // Flags are the storage truth and are kept in sync with type on every write, so a
       // non-drifted CLIENT_GALLERY row always carries is_client = true.
       return CollectionEntity.builder()
@@ -1353,6 +1453,7 @@ class CollectionServiceTest {
           .type(type)
           .isClient(type == CollectionType.CLIENT_GALLERY)
           .visibility(visibility)
+          .galleryPassword(galleryPassword)
           .build();
     }
   }

--- a/src/test/java/edens/zac/portfolio/backend/services/CollectionServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/CollectionServiceTest.java
@@ -1876,6 +1876,80 @@ class CollectionServiceTest {
   }
 
   @Nested
+  class GalleryAccessClearPath {
+
+    @Test
+    void ineligibleCollectionWithAStrandedPassword_canStillBeCleared() {
+      // D8. CollectionRepository.save omits gallery_password on UPDATE, so this endpoint is the
+      // only writer that can clear one. If eligibility gated the clear path, a collection that
+      // holds an enforced password but is neither a client gallery nor a parent of one -- the
+      // gallery_password IS NOT NULL AND is_client = false population -- would be permanently
+      // locked behind a password nothing could remove.
+      CollectionEntity stranded =
+          CollectionEntity.builder()
+              .id(100L)
+              .slug("orphaned-wrapper")
+              .isClient(false)
+              .galleryPassword("stale-pw")
+              .visibility(CollectionVisibility.UNLISTED)
+              .build();
+      when(collectionRepository.findById(100L)).thenReturn(Optional.of(stranded));
+
+      CollectionRequests.GalleryAccessResponse response =
+          service.updateGalleryAccess(
+              100L, new CollectionRequests.GalleryAccessRequest(null, List.of(), false));
+
+      assertThat(response.saved()).isTrue();
+      assertThat(response.reason()).isNull();
+      verify(collectionRepository).saveGalleryAccess(100L, null, List.of());
+      // The clear path returns before the gate, so the EXISTS query is never issued.
+      verify(collectionRepository, never()).hasClientGalleryChildren(anyLong());
+    }
+
+    @Test
+    void clearingAnEligibleClientGalleryStillWorks() {
+      // Regression pin: moving the clear branch above the gate must not change the eligible case.
+      CollectionEntity gallery =
+          CollectionEntity.builder()
+              .id(101L)
+              .slug("smith-wedding")
+              .isClient(true)
+              .galleryPassword("secretpw")
+              .visibility(CollectionVisibility.UNLISTED)
+              .build();
+      when(collectionRepository.findById(101L)).thenReturn(Optional.of(gallery));
+
+      CollectionRequests.GalleryAccessResponse response =
+          service.updateGalleryAccess(
+              101L, new CollectionRequests.GalleryAccessRequest(null, List.of(), false));
+
+      assertThat(response.saved()).isTrue();
+      assertThat(response.password()).isNull();
+      verify(collectionRepository).saveGalleryAccess(101L, null, List.of());
+    }
+
+    @Test
+    void clearingNeverPropagatesToChildrenEvenWhenPropagateIsTrue() {
+      // A clear is not a set. propagateToChildren must not waterfall a null.
+      CollectionEntity wrapper =
+          CollectionEntity.builder()
+              .id(102L)
+              .slug("company-a")
+              .isClient(true)
+              .galleryPassword("secretpw")
+              .visibility(CollectionVisibility.LISTED)
+              .build();
+      when(collectionRepository.findById(102L)).thenReturn(Optional.of(wrapper));
+
+      service.updateGalleryAccess(
+          102L, new CollectionRequests.GalleryAccessRequest(null, List.of(), true));
+
+      verify(collectionRepository, never()).findAllReferencedCollectionsByParentId(anyLong());
+      verify(collectionRepository, never()).updateGalleryPassword(anyLong(), anyString());
+    }
+  }
+
+  @Nested
   class IsGalleryAccessAuthorized {
 
     @Test

--- a/src/test/java/edens/zac/portfolio/backend/services/CollectionServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/CollectionServiceTest.java
@@ -1531,28 +1531,23 @@ class CollectionServiceTest {
   class SaveGalleryAccessParentPropagation {
 
     @Test
-    void parentTypeWithPropagateTrue_updatesPasswordOnChildClientGalleries() {
+    void wrapperWithClientGalleryChildren_propagateTrue_updatesPasswordOnEachClientChild() {
+      // The R1/S2 scenario: the wrapper is NOT itself a client gallery. Eligibility comes from
+      // hasClientGalleryChildren; propagation is gated on the request flag alone.
       CollectionEntity parent =
           CollectionEntity.builder()
               .id(100L)
               .slug("company-a")
-              .type(CollectionType.PARENT)
+              .isClient(false)
               .visibility(CollectionVisibility.LISTED)
               .build();
       CollectionEntity child1 =
-          CollectionEntity.builder()
-              .id(101L)
-              .slug("smith-wedding")
-              .type(CollectionType.CLIENT_GALLERY)
-              .build();
+          CollectionEntity.builder().id(101L).slug("smith-wedding").isClient(true).build();
       CollectionEntity child2 =
-          CollectionEntity.builder()
-              .id(102L)
-              .slug("jones-wedding")
-              .type(CollectionType.CLIENT_GALLERY)
-              .build();
+          CollectionEntity.builder().id(102L).slug("jones-wedding").isClient(true).build();
 
       when(collectionRepository.findById(100L)).thenReturn(Optional.of(parent));
+      when(collectionRepository.hasClientGalleryChildren(100L)).thenReturn(true);
       when(collectionRepository.findAllReferencedCollectionsByParentId(100L))
           .thenReturn(List.of(child1, child2));
 
@@ -1567,15 +1562,16 @@ class CollectionServiceTest {
     }
 
     @Test
-    void parentTypeWithPropagateFalse_skipsChildPropagation() {
+    void wrapperWithClientGalleryChildren_propagateFalse_skipsChildPropagation() {
       CollectionEntity parent =
           CollectionEntity.builder()
               .id(100L)
               .slug("company-a")
-              .type(CollectionType.PARENT)
+              .isClient(false)
               .visibility(CollectionVisibility.LISTED)
               .build();
       when(collectionRepository.findById(100L)).thenReturn(Optional.of(parent));
+      when(collectionRepository.hasClientGalleryChildren(100L)).thenReturn(true);
 
       CollectionRequests.GalleryAccessRequest request =
           new CollectionRequests.GalleryAccessRequest("secretpw", List.of(), false);
@@ -1587,15 +1583,16 @@ class CollectionServiceTest {
     }
 
     @Test
-    void parentTypeWithPropagateNull_skipsChildPropagation() {
+    void wrapperWithClientGalleryChildren_propagateNull_skipsChildPropagation() {
       CollectionEntity parent =
           CollectionEntity.builder()
               .id(100L)
               .slug("company-a")
-              .type(CollectionType.PARENT)
+              .isClient(false)
               .visibility(CollectionVisibility.LISTED)
               .build();
       when(collectionRepository.findById(100L)).thenReturn(Optional.of(parent));
+      when(collectionRepository.hasClientGalleryChildren(100L)).thenReturn(true);
 
       CollectionRequests.GalleryAccessRequest request =
           new CollectionRequests.GalleryAccessRequest("secretpw", List.of(), null);
@@ -1607,50 +1604,66 @@ class CollectionServiceTest {
     }
 
     @Test
-    void clientGalleryTypeWithPropagateTrue_skipsChildPropagation() {
+    void standaloneClientGallery_isEligibleWithoutQueryingChildren() {
+      // isClient short-circuits the OR, so the EXISTS query is never issued for a plain gallery.
       CollectionEntity gallery =
           CollectionEntity.builder()
               .id(100L)
               .slug("smith-wedding")
-              .type(CollectionType.CLIENT_GALLERY)
+              .isClient(true)
               .visibility(CollectionVisibility.UNLISTED)
               .build();
       when(collectionRepository.findById(100L)).thenReturn(Optional.of(gallery));
+
+      CollectionRequests.GalleryAccessRequest request =
+          new CollectionRequests.GalleryAccessRequest("secretpw", List.of(), false);
+
+      service.updateGalleryAccess(100L, request);
+
+      verify(collectionRepository).saveGalleryAccess(100L, "secretpw", List.of());
+      verify(collectionRepository, never()).hasClientGalleryChildren(anyLong());
+    }
+
+    @Test
+    void standaloneClientGallery_propagateTrue_writesNoChildPasswordsWhenItHasNoChildren() {
+      // The parent-side type gate is gone, so propagation now runs for any eligible target. A
+      // childless gallery simply finds nothing to write.
+      CollectionEntity gallery =
+          CollectionEntity.builder()
+              .id(100L)
+              .slug("smith-wedding")
+              .isClient(true)
+              .visibility(CollectionVisibility.UNLISTED)
+              .build();
+      when(collectionRepository.findById(100L)).thenReturn(Optional.of(gallery));
+      when(collectionRepository.findAllReferencedCollectionsByParentId(100L)).thenReturn(List.of());
 
       CollectionRequests.GalleryAccessRequest request =
           new CollectionRequests.GalleryAccessRequest("secretpw", List.of(), true);
 
       service.updateGalleryAccess(100L, request);
 
-      verify(collectionRepository, never()).findAllReferencedCollectionsByParentId(anyLong());
       verify(collectionRepository, never()).updateGalleryPassword(anyLong(), anyString());
     }
 
     @Test
-    void parentTypeWithPropagateTrue_skipsNonClientGalleryChildren() {
+    void propagateTrue_skipsNonClientChildren() {
       CollectionEntity parent =
           CollectionEntity.builder()
               .id(100L)
               .slug("mixed-parent")
-              .type(CollectionType.PARENT)
+              .isClient(false)
               .visibility(CollectionVisibility.LISTED)
               .build();
       CollectionEntity clientChild =
-          CollectionEntity.builder()
-              .id(101L)
-              .slug("smith-wedding")
-              .type(CollectionType.CLIENT_GALLERY)
-              .build();
+          CollectionEntity.builder().id(101L).slug("smith-wedding").isClient(true).build();
       CollectionEntity portfolioChild =
-          CollectionEntity.builder()
-              .id(102L)
-              .slug("studio-portfolio")
-              .type(CollectionType.PORTFOLIO)
-              .build();
+          CollectionEntity.builder().id(102L).slug("studio-portfolio").isClient(false).build();
       CollectionEntity blogChild =
-          CollectionEntity.builder().id(103L).slug("studio-blog").type(CollectionType.BLOG).build();
+          CollectionEntity.builder().id(103L).slug("studio-blog").isBlog(true).build();
 
       when(collectionRepository.findById(100L)).thenReturn(Optional.of(parent));
+      when(collectionRepository.hasClientGalleryChildren(100L)).thenReturn(true);
       when(collectionRepository.findAllReferencedCollectionsByParentId(100L))
           .thenReturn(List.of(clientChild, portfolioChild, blogChild));
 
@@ -1665,23 +1678,24 @@ class CollectionServiceTest {
     }
 
     @Test
-    void parentTypeWithPropagateTrue_propagatesToUnlistedChildren() {
+    void propagateTrue_propagatesToUnlistedChildren() {
       CollectionEntity parent =
           CollectionEntity.builder()
               .id(100L)
               .slug("company-a")
-              .type(CollectionType.PARENT)
+              .isClient(false)
               .visibility(CollectionVisibility.LISTED)
               .build();
       CollectionEntity unlistedChild =
           CollectionEntity.builder()
               .id(101L)
               .slug("private-wedding")
-              .type(CollectionType.CLIENT_GALLERY)
+              .isClient(true)
               .visibility(CollectionVisibility.UNLISTED)
               .build();
 
       when(collectionRepository.findById(100L)).thenReturn(Optional.of(parent));
+      when(collectionRepository.hasClientGalleryChildren(100L)).thenReturn(true);
       when(collectionRepository.findAllReferencedCollectionsByParentId(100L))
           .thenReturn(List.of(unlistedChild));
 
@@ -1691,6 +1705,28 @@ class CollectionServiceTest {
       service.updateGalleryAccess(100L, request);
 
       verify(collectionRepository).updateGalleryPassword(101L, "secretpw");
+    }
+
+    @Test
+    void neitherClientNorParentOfClientGalleries_returnsNotEligible() {
+      CollectionEntity plain =
+          CollectionEntity.builder()
+              .id(100L)
+              .slug("just-a-portfolio")
+              .isClient(false)
+              .visibility(CollectionVisibility.LISTED)
+              .build();
+      when(collectionRepository.findById(100L)).thenReturn(Optional.of(plain));
+      when(collectionRepository.hasClientGalleryChildren(100L)).thenReturn(false);
+
+      CollectionRequests.GalleryAccessResponse response =
+          service.updateGalleryAccess(
+              100L, new CollectionRequests.GalleryAccessRequest("secretpw", List.of(), true));
+
+      assertThat(response.saved()).isFalse();
+      assertThat(response.reason()).isEqualTo("not-eligible-type");
+      verify(collectionRepository, never()).saveGalleryAccess(anyLong(), anyString(), any());
+      verify(collectionRepository, never()).updateGalleryPassword(anyLong(), anyString());
     }
   }
 

--- a/src/test/java/edens/zac/portfolio/backend/services/CollectionServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/CollectionServiceTest.java
@@ -1417,6 +1417,50 @@ class CollectionServiceTest {
           .containsExactly(511L, 512L);
     }
 
+    @Test
+    void clientGalleryWrapper_dropsUnlistedNonClientChild() {
+      // S4 from the other direction: the parent is itself a client gallery, which used to be
+      // enough to keep every UNLISTED child. Only the client-gallery child survives now.
+      String slug = "gallery-wrapper";
+      CollectionEntity parent =
+          CollectionEntity.builder()
+              .id(92L)
+              .slug(slug)
+              .type(CollectionType.CLIENT_GALLERY)
+              .visibility(CollectionVisibility.LISTED)
+              .build();
+
+      ContentModels.Collection unlistedPortfolio =
+          childCollectionContent(521L, CollectionType.PORTFOLIO);
+      ContentModels.Collection unlistedGallery =
+          childCollectionContent(522L, CollectionType.CLIENT_GALLERY);
+
+      CollectionModel model =
+          CollectionModel.builder()
+              .id(92L)
+              .slug(slug)
+              .type(CollectionType.CLIENT_GALLERY)
+              .isClient(true)
+              .content(new java.util.ArrayList<>(List.of(unlistedPortfolio, unlistedGallery)))
+              .build();
+
+      when(collectionRepository.findBySlug(slug)).thenReturn(Optional.of(parent));
+      when(collectionProcessingUtil.convertToModel(
+              eq(parent), any(), anyInt(), anyInt(), anyLong()))
+          .thenReturn(model);
+      when(collectionRepository.findByIds(List.of(521L, 522L)))
+          .thenReturn(
+              List.of(
+                  childEntity(521L, CollectionType.PORTFOLIO, CollectionVisibility.UNLISTED),
+                  childEntity(522L, CollectionType.CLIENT_GALLERY, CollectionVisibility.UNLISTED)));
+
+      CollectionModel result = service.getCollectionWithPagination(slug, 0, 10);
+
+      assertThat(result.getContent())
+          .extracting(c -> ((ContentModels.Collection) c).referencedCollectionId())
+          .containsExactly(522L);
+    }
+
     private ContentModels.Collection childCollectionContent(Long childId, CollectionType type) {
       return new ContentModels.Collection(
           childId,

--- a/src/test/java/edens/zac/portfolio/backend/services/ContentDownloadGateIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/ContentDownloadGateIntegrationTest.java
@@ -1,0 +1,130 @@
+package edens.zac.portfolio.backend.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import edens.zac.portfolio.backend.AbstractPostgresIntegrationTest;
+import edens.zac.portfolio.backend.dao.CollectionRepository;
+import edens.zac.portfolio.backend.entity.CollectionContentEntity;
+import edens.zac.portfolio.backend.entity.CollectionEntity;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * S1: the per-image download gate must see EVERY password-protected parent of an image, not the
+ * arbitrary first row of an unordered join. Runs against real Postgres because the join query is a
+ * hand-written string; a mocked JdbcTemplate cannot catch a malformed ORDER BY clause.
+ *
+ * <p>Rows seeded here live in the SHARED singleton container (only auth tables are truncated), so
+ * every slug carries an s1- prefix and assertions never use exact global counts.
+ */
+class ContentDownloadGateIntegrationTest extends AbstractPostgresIntegrationTest {
+
+  @Autowired private ContentService contentService;
+  @Autowired private CollectionRepository collectionRepository;
+  @Autowired private JdbcTemplate jdbc;
+
+  /**
+   * A bare IMAGE content row. The download gate joins collection_content only, never content_image,
+   * so no child row is needed.
+   */
+  private Long seedImageContent() {
+    return jdbc.queryForObject(
+        "INSERT INTO content (content_type, created_at, updated_at)"
+            + " VALUES ('IMAGE', NOW(), NOW()) RETURNING id",
+        Long.class);
+  }
+
+  private Long seedCollection(String slug, String galleryPassword) {
+    jdbc.update(
+        "INSERT INTO collection (title, slug, type, visibility, is_client, is_blog,"
+            + " gallery_password) VALUES (?, ?, 'MISC', 'LISTED', false, false, ?)",
+        slug,
+        slug,
+        galleryPassword);
+    return jdbc.queryForObject("SELECT id FROM collection WHERE slug = ?", Long.class, slug);
+  }
+
+  private void link(Long collectionId, Long contentId) {
+    collectionRepository.saveContent(
+        CollectionContentEntity.builder()
+            .collectionId(collectionId)
+            .contentId(contentId)
+            .orderIndex(0)
+            .visible(true)
+            .build());
+  }
+
+  @Test
+  void findContentByContentIdsIn_ordersByCollectionId() {
+    Long contentId = seedImageContent();
+    Long lower = seedCollection("s1-order-lower", null);
+    Long higher = seedCollection("s1-order-higher", null);
+    // Insert the HIGHER collection id first so insertion order and id order disagree.
+    link(higher, contentId);
+    link(lower, contentId);
+
+    assertThat(collectionRepository.findContentByContentIdsIn(List.of(contentId)))
+        .extracting(CollectionContentEntity::getCollectionId)
+        .containsExactly(lower, higher);
+  }
+
+  @Test
+  void findProtectedCollectionsForImage_findsGalleryWhenThePublicWrapperSortsFirst() {
+    // The exact S1 exposure: image in protected 'smith-wedding-full' AND public 'weddings'.
+    // The public wrapper has the lower id, so it is the row an unordered LIMIT-1 style read wins.
+    Long contentId = seedImageContent();
+    Long publicWrapper = seedCollection("s1-public-first", null);
+    Long protectedGallery = seedCollection("s1-protected-second", "sunshine");
+    link(publicWrapper, contentId);
+    link(protectedGallery, contentId);
+
+    assertThat(contentService.findProtectedCollectionsForImage(contentId))
+        .extracting(CollectionEntity::getId)
+        .containsExactly(protectedGallery);
+  }
+
+  @Test
+  void findProtectedCollectionsForImage_findsGalleryWhenTheGallerySortsFirst() {
+    // Same image, opposite id order: the answer must not depend on which parent sorts first.
+    Long contentId = seedImageContent();
+    Long protectedGallery = seedCollection("s1-protected-first", "sunshine");
+    Long publicWrapper = seedCollection("s1-public-second", null);
+    link(protectedGallery, contentId);
+    link(publicWrapper, contentId);
+
+    assertThat(contentService.findProtectedCollectionsForImage(contentId))
+        .extracting(CollectionEntity::getId)
+        .containsExactly(protectedGallery);
+  }
+
+  @Test
+  void findProtectedCollectionsForImage_returnsEveryProtectedParent() {
+    Long contentId = seedImageContent();
+    Long galleryOne = seedCollection("s1-protected-one", "alpha");
+    Long galleryTwo = seedCollection("s1-protected-two", "bravo");
+    link(galleryOne, contentId);
+    link(galleryTwo, contentId);
+
+    assertThat(contentService.findProtectedCollectionsForImage(contentId))
+        .extracting(CollectionEntity::getId)
+        .containsExactlyInAnyOrder(galleryOne, galleryTwo);
+  }
+
+  @Test
+  void findProtectedCollectionsForImage_returnsEmptyWhenNoParentIsProtected() {
+    Long contentId = seedImageContent();
+    link(seedCollection("s1-open-one", null), contentId);
+    link(seedCollection("s1-open-two", null), contentId);
+
+    assertThat(contentService.findProtectedCollectionsForImage(contentId)).isEmpty();
+  }
+
+  @Test
+  void findProtectedCollectionsForImage_returnsEmptyForAnOrphanImage() {
+    Long contentId = seedImageContent();
+
+    assertThat(contentService.findProtectedCollectionsForImage(contentId)).isEmpty();
+  }
+}


### PR DESCRIPTION
Closes the six latent access-control defects (S1-S6) from the typeless-collection spec §4, plus decision D8, so the exposure window Rule B opens in U4 is already shut before it opens.

No wire-format change, no migration. Correct and deployable today.

## Fixes

- **S1** — `findContentByContentIdsIn` had no `ORDER BY`, so the per-image download gate authorized against a Postgres-arbitrary parent. An image in both a protected gallery and a public wrapper handed out a presigned full-resolution S3 URL on a nondeterministic fraction of requests. Adds `ORDER BY collection_id` and `findProtectedCollectionsForImage`, which returns *every* protected parent; the controller now fails closed across all of them. `findCollectionForImage` deleted.
- **S2** — gallery-access eligibility becomes `isClient() || hasClientGalleryChildren(id)` (new EXISTS query); the propagation gate becomes `propagateToChildren` alone; the child filter becomes `child.isClient()`. Previously a wrapper with client-gallery children either 400'd or saved while writing zero children, leaving those galleries serving anonymously.
- **S3** — an unprotected parent no longer publishes a password-protected child's title, description or cover. Chosen over adding `isPasswordProtected` to the wire model, which would need a frontend locked-tile state this unit ships without.
- **S4** — the UNLISTED relaxation is now per child, not computed once per response. One client-gallery child used to un-hide every unrelated UNLISTED sibling under the same wrapper. The pinning test is inverted, not deleted.
- **S5** — `linkCollectionToParent` gains a full visited-set ancestor walk. It previously had no cycle check at all; `validateNoParentCycles` runs only on the inverse `parents` path and catches self- and 2-cycles only.
- **S6** — linkage is now a password-propagation trigger, symmetric with the role-grant waterfall. A client gallery linked *after* the password was set kept a null password, which meant no content stripping, permitted UNLISTED direct-slug access, and a skipped download gate.
- **D8** — `updateGalleryAccess` accepts `password: null` unconditionally; eligibility gates only the set path. This endpoint is the only writer that can clear `gallery_password`, so a gated clear path stranded any row holding an enforced password that failed the derived test.

## Scope limit — please do not read this as "every link path is guarded"

`handleCollectionToCollectionUpdates` (`CollectionService:871`, from `updateCollection:513`) builds its `ContentCollectionEntity` and `collection_content` row inline and never calls `linkCollectionToParent`, so **the admin collection-update path remains cycle-unguarded**. Spec §4 S5 names `linkCollectionToParent` as the fix site, so this PR does not widen scope — but the gap is real and is carried forward for U4.

## Verification

`mvn clean install` — BUILD SUCCESS. New real-Postgres coverage: `ContentDownloadGateIntegrationTest` (6), `CollectionLinkSecurityIntegrationTest` (8), 4 added to `CollectionFlagRepositoryIntegrationTest`. `CollectionServiceTest` at 73 tests, 0 failures.

Gated on U0 (V51) being deployed. Gates U4 together with U3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)