### PR TITLE
refactor(db)!: typeless U5 — drop collection.type

### DIFF
--- a/src/main/java/edens/zac/portfolio/backend/dao/CollectionRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/CollectionRepository.java
@@ -641,8 +641,9 @@ public class CollectionRepository extends BaseDao {
    * Persist a CollectionEntity. Neither branch writes {@code recipient_emails}, and UPDATE also
    * omits {@code gallery_password}: both columns are owned exclusively by {@link
    * #saveGalleryAccess}, which writes them atomically as a pair. Neither branch touches {@code
-   * type} -- the column is retained for one release as a rollback artifact and carries a DEFAULT
-   * from V51.
+   * type}: V52 dropped the column outright, so naming it here again fails at runtime on every
+   * create and update. Restoring it takes {@code collection_type_archive} (V51) plus a pre-U4
+   * application build -- see {@code V52__drop_collection_type.sql}.
    */
   @Transactional
   public CollectionEntity save(CollectionEntity entity) {

--- a/src/main/resources/db/migration/V52__drop_collection_type.sql
+++ b/src/main/resources/db/migration/V52__drop_collection_type.sql
@@ -1,0 +1,69 @@
+-- V52: drop collection.type. THIS IS IRREVERSIBLE.
+--
+-- Closes the sequence begun by V50 (add is_client/is_blog) and V51 (make type nullable,
+-- snapshot it into collection_type_archive). U4 removed the last application read and write
+-- of this column; nothing in src/main references it. See
+-- docs/superpowers/specs/2026-07-26-typeless-collection.md, unit U5.
+--
+-- WHERE EACH FORMER ENUM VALUE LIVES NOW
+-- --------------------------------------
+--   CLIENT_GALLERY -> collection.is_client = true          (stored, V50; NOT NULL)
+--   BLOG           -> collection.is_blog   = true          (stored, V50; NOT NULL)
+--   PARENT         -> DERIVED, never stored. A collection is a parent iff it holds at
+--                     least one COLLECTION content block:
+--                       EXISTS (SELECT 1 FROM collection_content cc
+--                               JOIN content_collection cct ON cct.id = cc.content_id
+--                               WHERE cc.collection_id = :id
+--                                 AND cct.referenced_collection_id IS NOT NULL)
+--   HOME           -> DERIVED, never stored: slug = 'home'. V41's unique index on slug
+--                     guarantees at most one such row.
+--   PORTFOLIO      -> GONE. No successor concept. V50 seeded a 'Portfolio' label tag as a
+--                     transitional grouping; V51 removed those rows per decision D6.
+--   ART_GALLERY    -> GONE. No successor concept. Same 'Art Gallery' tag story as above.
+--   MISC           -> GONE. No successor concept: carrying neither flag IS the meaning.
+--
+-- IRREVERSIBLE, AND WHY THE FLAGS CANNOT RECONSTRUCT IT
+-- ----------------------------------------------------
+-- is_client and is_blog are BOTH false for PORTFOLIO, ART_GALLERY, PARENT, HOME and MISC.
+-- Five distinct former values collapse onto one flag pair, so a rollback that re-derives
+-- `type` from the flags produces garbage for every row that was not a client gallery or a
+-- blog. Do NOT attempt it. collection_type_archive (V51) is the only faithful source.
+--
+-- ROLLBACK RECIPE -- restore BY ID FROM collection_type_archive, never from the flags:
+--
+--   ALTER TABLE collection ADD COLUMN type VARCHAR(50);
+--   UPDATE collection c SET type = a.type
+--     FROM collection_type_archive a WHERE a.id = c.id;
+--   -- Rows created after V51 took its snapshot have no archive row. Their original value is
+--   -- unrecoverable; 'MISC' is the same default V51 gave the column, so this is lossless in
+--   -- practice for them (they were created by an app that no longer set the column at all).
+--   UPDATE collection SET type = 'MISC' WHERE type IS NULL;
+--   ALTER TABLE collection ALTER COLUMN type SET DEFAULT 'MISC';
+--   ALTER TABLE collection ALTER COLUMN type SET NOT NULL;
+--   CREATE INDEX idx_collection_type ON collection (type);   -- auto-dropped below; recreate it
+--
+-- A rollback also requires reverting the application to a pre-U4 build, because U4 deleted
+-- CollectionType, CollectionTypeCompat and every SQL site that projected the column. Restoring
+-- the column alone buys nothing.
+--
+-- NO "DROP INDEX" STATEMENT HERE, DELIBERATELY
+-- --------------------------------------------
+-- Postgres drops every index that depends on a dropped column, so `idx_collection_type` goes
+-- with the column below. Do NOT add a defensive
+--     DROP INDEX idx_collection_type_visible_date;
+-- -- that index was already auto-dropped by V20's `ALTER TABLE collection DROP COLUMN visible`
+-- (it was a partial index WHERE visible = true, created by V9). A bare DROP INDEX on a
+-- non-existent index aborts the migration and blocks application boot. If a future migration
+-- ever needs one, it must use IF EXISTS.
+--
+-- Audit query -- run manually before deploying (V15 and V50 established this convention).
+-- Records the final distribution being destroyed, and confirms the archive covers it:
+--
+-- SELECT c.type, c.is_client, c.is_blog, count(*) AS rows,
+--        count(a.id) AS archived
+-- FROM collection c LEFT JOIN collection_type_archive a ON a.id = c.id
+-- GROUP BY 1, 2, 3 ORDER BY 1;
+
+-- IF EXISTS so that re-running against an environment where the column is already gone is a
+-- no-op rather than a boot-blocking failure -- the same class of hazard as the DROP INDEX note.
+ALTER TABLE collection DROP COLUMN IF EXISTS type;

--- a/src/test/java/edens/zac/portfolio/backend/RoleMigrationIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/RoleMigrationIntegrationTest.java
@@ -28,9 +28,7 @@ class RoleMigrationIntegrationTest extends AbstractPostgresIntegrationTest {
 
   private long seedCollection(String slug) {
     jdbc.update(
-        "INSERT INTO collection (title, slug, type, visibility) VALUES (?, ?, 'CLIENT_GALLERY', 'UNLISTED')",
-        slug,
-        slug);
+        "INSERT INTO collection (title, slug, visibility) VALUES (?, ?, 'UNLISTED')", slug, slug);
     return jdbc.queryForObject("SELECT id FROM collection WHERE slug=?", Long.class, slug);
   }
 

--- a/src/test/java/edens/zac/portfolio/backend/RoleWaterfallMigrationIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/RoleWaterfallMigrationIntegrationTest.java
@@ -61,9 +61,7 @@ class RoleWaterfallMigrationIntegrationTest extends AbstractPostgresIntegrationT
 
   private long seedCollection(String slug) {
     jdbc.update(
-        "INSERT INTO collection (title, slug, type, visibility) VALUES (?, ?, 'CLIENT_GALLERY', 'UNLISTED')",
-        slug,
-        slug);
+        "INSERT INTO collection (title, slug, visibility) VALUES (?, ?, 'UNLISTED')", slug, slug);
     return jdbc.queryForObject("SELECT id FROM collection WHERE slug=?", Long.class, slug);
   }
 

--- a/src/test/java/edens/zac/portfolio/backend/UserCollectionMigrationIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/UserCollectionMigrationIntegrationTest.java
@@ -43,7 +43,7 @@ class UserCollectionMigrationIntegrationTest extends AbstractPostgresIntegration
         "INSERT INTO users (name, webauthn_user_handle, status) VALUES ('Member Mary', gen_random_uuid(), 'ACTIVE')");
     Long userId = jdbc.queryForObject("SELECT id FROM users WHERE name='Member Mary'", Long.class);
     jdbc.update(
-        "INSERT INTO collection (title, slug, type, visibility) VALUES ('C', 'c-slug', 'CLIENT_GALLERY', 'UNLISTED')");
+        "INSERT INTO collection (title, slug, visibility) VALUES ('C', 'c-slug', 'UNLISTED')");
     Long collectionId =
         jdbc.queryForObject("SELECT id FROM collection WHERE slug='c-slug'", Long.class);
 
@@ -62,7 +62,7 @@ class UserCollectionMigrationIntegrationTest extends AbstractPostgresIntegration
     // Seed a second collection so the bad-role insert is a fresh (user, collection) pair —
     // ensures only the CHECK constraint can throw, not a PK unique-violation on the same pair.
     jdbc.update(
-        "INSERT INTO collection (title, slug, type, visibility) VALUES ('C2', 'c2-slug', 'CLIENT_GALLERY', 'UNLISTED')");
+        "INSERT INTO collection (title, slug, visibility) VALUES ('C2', 'c2-slug', 'UNLISTED')");
     Long collectionId2 =
         jdbc.queryForObject("SELECT id FROM collection WHERE slug='c2-slug'", Long.class);
     org.assertj.core.api.Assertions.assertThatThrownBy(

--- a/src/test/java/edens/zac/portfolio/backend/UserMergeIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/UserMergeIntegrationTest.java
@@ -56,8 +56,8 @@ class UserMergeIntegrationTest extends AbstractPostgresIntegrationTest {
   private Long newCollection() {
     String slug = "merge-test-" + UUID.randomUUID();
     return jdbc.queryForObject(
-        "INSERT INTO collection (title, slug, type, visibility) "
-            + "VALUES (?, ?, 'CLIENT_GALLERY', 'UNLISTED') RETURNING id",
+        "INSERT INTO collection (title, slug, visibility) "
+            + "VALUES (?, ?, 'UNLISTED') RETURNING id",
         Long.class,
         slug,
         slug);

--- a/src/test/java/edens/zac/portfolio/backend/controller/prod/ContentDownloadAuthTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/prod/ContentDownloadAuthTest.java
@@ -83,6 +83,16 @@ class ContentDownloadAuthTest {
         .build();
   }
 
+  private static CollectionEntity openCollection() {
+    return CollectionEntity.builder()
+        .id(2L)
+        .title("Open Portfolio")
+        .slug("open-portfolio")
+        .visibility(CollectionVisibility.LISTED)
+        .galleryPassword(null)
+        .build();
+  }
+
   // ---------------------------------------------------------------------------
   //  Image download — CLIENT membership bypass
   // ---------------------------------------------------------------------------
@@ -210,6 +220,47 @@ class ContentDownloadAuthTest {
           .andExpect(status().isFound());
 
       verify(collectionAccessService, never()).isClient(any(), any());
+    }
+
+    @Test
+    void clientOfTheForeignGallery_redirects_throughAPublicWrapper() throws Exception {
+      // The requested slug is an unprotected wrapper, so its own password gate is a no-op and the
+      // CLIENT grant is consumed by the SECOND gate instead: the protected gallery that also holds
+      // the images this download would serve. Fail-closed must not mean fail-always -- a grant that
+      // satisfies the gating gallery still gets the download through the wrapper.
+      authenticate(7L);
+      when(collectionService.findEntityBySlug("open-portfolio")).thenReturn(openCollection());
+      when(contentService.findProtectedCollectionsForCollectionDownload(2L, null))
+          .thenReturn(List.of(protectedGallery()));
+      when(collectionAccessService.isClient(7L, 1L)).thenReturn(true);
+      when(contentService.resolveCollectionDownloadEntries(2L, "web", null))
+          .thenReturn(List.of(webResolution("img.webp")));
+      when(downloadUrlService.presignObject(any(), any(), any())).thenReturn(PRESIGNED);
+
+      mockMvc
+          .perform(get("/api/read/collections/open-portfolio/download"))
+          .andExpect(status().isFound());
+
+      verify(clientGalleryAuthService, never()).validateAccessToken(any(), any());
+    }
+
+    @Test
+    void nonClientOfTheForeignGallery_gets401_throughAPublicWrapper() throws Exception {
+      // Same wrapper, no CLIENT grant on the gating gallery: the second gate refuses. The gate runs
+      // before resolution, so nothing is even resolved for an unauthorized caller.
+      authenticate(7L);
+      when(collectionService.findEntityBySlug("open-portfolio")).thenReturn(openCollection());
+      when(contentService.findProtectedCollectionsForCollectionDownload(2L, null))
+          .thenReturn(List.of(protectedGallery()));
+      when(collectionAccessService.isClient(7L, 1L)).thenReturn(false);
+
+      mockMvc
+          .perform(get("/api/read/collections/open-portfolio/download"))
+          .andExpect(status().isUnauthorized());
+
+      verify(contentService, never()).resolveCollectionDownloadEntries(any(), any(), any());
+      verify(downloadUrlService, never()).presignObject(any(), any(), any());
+      verify(downloadUrlService, never()).zipToS3AndPresign(any(), any());
     }
   }
 }

--- a/src/test/java/edens/zac/portfolio/backend/controller/prod/ContentDownloadControllerProdTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/prod/ContentDownloadControllerProdTest.java
@@ -412,5 +412,40 @@ class ContentDownloadControllerProdTest {
           .andExpect(status().isFound())
           .andExpect(header().string("Location", ZIP_PRESIGNED.toString()));
     }
+
+    @Test
+    void protectedCollection_cookieForItself_butImageAlsoInAnotherGallery_returns401()
+        throws Exception {
+      // "EVERY protected parent", not "any" -- the collection-ZIP mirror of the per-image rule: a
+      // cookie for smith-wedding must not unlock images that also live in jones-wedding. Satisfying
+      // the slug in the URL is necessary, never sufficient.
+      CollectionEntity otherGallery =
+          CollectionEntity.builder()
+              .id(3L)
+              .title("Jones Wedding")
+              .slug("jones-wedding")
+              .visibility(CollectionVisibility.UNLISTED)
+              .galleryPassword("moonlight")
+              .build();
+      when(collectionService.findEntityBySlug("smith-wedding")).thenReturn(protectedGallery());
+      when(clientGalleryAuthService.validateAccessToken("smith-wedding", "tok-123"))
+          .thenReturn(true);
+      // jones-wedding is deliberately NOT stubbed: with no gallery_access_jones-wedding cookie,
+      // GalleryAccessCookies.hasValidAccess calls validateAccessToken with a NULL token. Stubbing
+      // it for "tok-123" would be an argument mismatch that STRICT_STUBS turns into a failure.
+      when(contentService.findProtectedCollectionsForCollectionDownload(eq(1L), any()))
+          .thenReturn(List.of(protectedGallery(), otherGallery));
+
+      mockMvc
+          .perform(
+              get("/api/read/collections/smith-wedding/download")
+                  .param("format", "original")
+                  .cookie(new Cookie("gallery_access_smith-wedding", "tok-123")))
+          .andExpect(status().isUnauthorized());
+
+      verify(contentService, never()).resolveCollectionDownloadEntries(any(), any(), any());
+      verify(downloadUrlService, never()).presignObject(any(), any(), any());
+      verify(downloadUrlService, never()).zipToS3AndPresign(any(), any());
+    }
   }
 }

--- a/src/test/java/edens/zac/portfolio/backend/dao/CollectionTypelessReadIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/dao/CollectionTypelessReadIntegrationTest.java
@@ -14,10 +14,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 /**
- * Proof that no read path projects collection.type any more. Each test seeds a row whose type
- * column holds a value no Java enum would ever have accepted; every query below must return it
- * without inspecting the column. Real Postgres because mocked JdbcTemplate cannot catch text-block
- * or StringBuilder-concatenation syntax errors in these hand-written statements.
+ * Proof that no read or write path names collection.type any more. U4 stopped projecting the
+ * column; V52 (U5) dropped it outright, so Postgres itself now rejects any statement that
+ * reintroduces it -- every test below fails loudly the moment one does. Real Postgres because a
+ * mocked JdbcTemplate cannot catch text-block or StringBuilder-concatenation syntax errors in these
+ * hand-written statements.
  */
 class CollectionTypelessReadIntegrationTest extends AbstractPostgresIntegrationTest {
 
@@ -25,20 +26,19 @@ class CollectionTypelessReadIntegrationTest extends AbstractPostgresIntegrationT
   @Autowired private CollectionSiblingRepository collectionSiblingRepository;
   @Autowired private JdbcTemplate jdbc;
 
-  private Long seedLegacyRow(String slug) {
+  private Long seedRow(String slug) {
     jdbc.update(
-        "INSERT INTO collection (type, is_client, is_blog, title, slug, visibility, total_content,"
-            + " created_at, updated_at) VALUES ('LEGACY_GONE', false, false, ?, ?, 'LISTED', 0,"
-            + " NOW(), NOW())",
+        "INSERT INTO collection (is_client, is_blog, title, slug, visibility, total_content,"
+            + " created_at, updated_at) VALUES (false, false, ?, ?, 'LISTED', 0, NOW(), NOW())",
         "Legacy " + slug,
         slug);
     return jdbc.queryForObject("SELECT id FROM collection WHERE slug = ?", Long.class, slug);
   }
 
   @Test
-  @DisplayName("findBySlug reads a row whose type column holds an unknown legacy value")
-  void findBySlug_legacyTypeValue_reads() {
-    seedLegacyRow("legacy-find-by-slug");
+  @DisplayName("findBySlug reads a row from a schema with no type column")
+  void findBySlug_typelessSchema_reads() {
+    seedRow("legacy-find-by-slug");
 
     Optional<CollectionEntity> found = collectionRepository.findBySlug("legacy-find-by-slug");
 
@@ -47,9 +47,9 @@ class CollectionTypelessReadIntegrationTest extends AbstractPostgresIntegrationT
   }
 
   @Test
-  @DisplayName("findIdTitleAndSlug reads a row whose type column holds an unknown legacy value")
-  void findIdTitleAndSlug_legacyTypeValue_reads() {
-    Long id = seedLegacyRow("legacy-id-title-slug");
+  @DisplayName("findIdTitleAndSlug reads a row from a schema with no type column")
+  void findIdTitleAndSlug_typelessSchema_reads() {
+    Long id = seedRow("legacy-id-title-slug");
 
     List<Records.CollectionList> rows = collectionRepository.findIdTitleAndSlug();
 
@@ -57,10 +57,10 @@ class CollectionTypelessReadIntegrationTest extends AbstractPostgresIntegrationT
   }
 
   @Test
-  @DisplayName("findSiblings reads a sibling whose type column holds an unknown legacy value")
-  void findSiblings_legacyTypeValue_reads() {
-    Long a = seedLegacyRow("legacy-sibling-a");
-    Long b = seedLegacyRow("legacy-sibling-b");
+  @DisplayName("findSiblings reads a sibling from a schema with no type column")
+  void findSiblings_typelessSchema_reads() {
+    Long a = seedRow("legacy-sibling-a");
+    Long b = seedRow("legacy-sibling-b");
     collectionSiblingRepository.addSibling(a, b);
 
     List<Records.SiblingRow> siblings = collectionSiblingRepository.findSiblings(a, true);
@@ -69,8 +69,8 @@ class CollectionTypelessReadIntegrationTest extends AbstractPostgresIntegrationT
   }
 
   @Test
-  @DisplayName("save INSERT omits type and relies on the V51 column default")
-  void save_insert_omitsTypeColumn() {
+  @DisplayName("save INSERT succeeds against a schema with no type column")
+  void save_insert_doesNotNameTheDroppedColumn() {
     CollectionEntity saved =
         collectionRepository.save(
             CollectionEntity.builder()
@@ -83,25 +83,31 @@ class CollectionTypelessReadIntegrationTest extends AbstractPostgresIntegrationT
                 .build());
 
     assertThat(saved.getId()).isNotNull();
-    String storedType =
-        jdbc.queryForObject(
-            "SELECT type FROM collection WHERE id = ?", String.class, saved.getId());
-    assertThat(storedType).isEqualTo("MISC");
+    assertThat(collectionRepository.findById(saved.getId()).orElseThrow().getSlug())
+        .isEqualTo("typeless-insert");
   }
 
   @Test
-  @DisplayName("save UPDATE omits type and leaves the stored legacy value untouched")
-  void save_update_leavesTypeColumnUntouched() {
-    Long id = seedLegacyRow("legacy-update");
+  @DisplayName("save UPDATE succeeds against a schema with no type column")
+  void save_update_doesNotNameTheDroppedColumn() {
+    Long id = seedRow("legacy-update");
     CollectionEntity entity = collectionRepository.findById(id).orElseThrow();
     entity.setTitle("Legacy Renamed");
 
     collectionRepository.save(entity);
 
-    String storedType =
-        jdbc.queryForObject("SELECT type FROM collection WHERE id = ?", String.class, id);
-    assertThat(storedType).isEqualTo("LEGACY_GONE");
     assertThat(collectionRepository.findById(id).orElseThrow().getTitle())
         .isEqualTo("Legacy Renamed");
+  }
+
+  @Test
+  @DisplayName("the dropped column really is absent, so the tests above are not vacuous")
+  void typeColumnIsAbsentFromTheSchema() {
+    Integer columns =
+        jdbc.queryForObject(
+            "SELECT count(*) FROM information_schema.columns WHERE table_schema = 'public'"
+                + " AND table_name = 'collection' AND column_name = 'type'",
+            Integer.class);
+    assertThat(columns).isZero();
   }
 }

--- a/src/test/java/edens/zac/portfolio/backend/dao/ContentRepositoryRoleVisibilityIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/dao/ContentRepositoryRoleVisibilityIntegrationTest.java
@@ -50,8 +50,8 @@ class ContentRepositoryRoleVisibilityIntegrationTest extends AbstractPostgresInt
   private Long seedUnlistedCollection() {
     String slug = "contentvis-" + UUID.randomUUID();
     return jdbcTemplate.queryForObject(
-        "INSERT INTO collection (title, slug, type, visibility) "
-            + "VALUES (?, ?, 'CLIENT_GALLERY', 'UNLISTED') RETURNING id",
+        "INSERT INTO collection (title, slug, visibility) "
+            + "VALUES (?, ?, 'UNLISTED') RETURNING id",
         Long.class,
         slug,
         slug);

--- a/src/test/java/edens/zac/portfolio/backend/dao/RoleRepositoryIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/dao/RoleRepositoryIntegrationTest.java
@@ -37,9 +37,7 @@ class RoleRepositoryIntegrationTest extends AbstractPostgresIntegrationTest {
 
   private long seedCollection(String slug) {
     jdbc.update(
-        "INSERT INTO collection (title, slug, type, visibility) VALUES (?, ?, 'CLIENT_GALLERY', 'UNLISTED')",
-        slug,
-        slug);
+        "INSERT INTO collection (title, slug, visibility) VALUES (?, ?, 'UNLISTED')", slug, slug);
     return jdbc.queryForObject("SELECT id FROM collection WHERE slug=?", Long.class, slug);
   }
 

--- a/src/test/java/edens/zac/portfolio/backend/dao/UserFollowedCollectionRepositoryIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/dao/UserFollowedCollectionRepositoryIntegrationTest.java
@@ -29,8 +29,8 @@ class UserFollowedCollectionRepositoryIntegrationTest extends AbstractPostgresIn
 
   private Long seedCollection(String slug) {
     return jdbcTemplate.queryForObject(
-        "INSERT INTO collection (type, title, slug, visibility) "
-            + "VALUES ('CLIENT_GALLERY', ?, ?, 'HIDDEN') RETURNING id",
+        "INSERT INTO collection (title, slug, visibility) "
+            + "VALUES (?, ?, 'HIDDEN') RETURNING id",
         Long.class,
         "Title " + slug,
         slug);

--- a/src/test/java/edens/zac/portfolio/backend/dao/UserSelectRepositoryIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/dao/UserSelectRepositoryIntegrationTest.java
@@ -31,8 +31,8 @@ class UserSelectRepositoryIntegrationTest extends AbstractPostgresIntegrationTes
 
   private Long seedCollection(String slug) {
     return jdbcTemplate.queryForObject(
-        "INSERT INTO collection (type, title, slug, visibility) "
-            + "VALUES ('CLIENT_GALLERY', ?, ?, 'HIDDEN') RETURNING id",
+        "INSERT INTO collection (title, slug, visibility) "
+            + "VALUES (?, ?, 'HIDDEN') RETURNING id",
         Long.class,
         "Title " + slug,
         slug);

--- a/src/test/java/edens/zac/portfolio/backend/dao/V51MigrationPrepIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/dao/V51MigrationPrepIntegrationTest.java
@@ -20,7 +20,9 @@ import org.testcontainers.containers.PostgreSQLContainer;
  * collection table, so V51's backfill UPDATE and its tag DELETEs would never touch a single row.
  * This test owns a dedicated container, migrates to V49, seeds one collection per legacy type plus
  * the operator tag V50 must reuse, migrates to V50 so the real label-tag backfill runs, seeds a
- * converted tag squatting the canonical slug, then migrates to latest and asserts V51's outcome.
+ * converted tag squatting the canonical slug, then migrates to V51 (NOT latest -- see the target
+ * below) and asserts V51's outcome. Migrations after V51 are deliberately out of this container's
+ * scope: V52 drops collection.type, which these assertions read.
  *
  * <p>V51's DML is deliberately NOT re-run inside the shared singleton container: its global
  * content_per_page UPDATE would rewrite the rows sibling fixtures depend on, producing

--- a/src/test/java/edens/zac/portfolio/backend/dao/V51MigrationPrepIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/dao/V51MigrationPrepIntegrationTest.java
@@ -90,7 +90,9 @@ class V51MigrationPrepIntegrationTest {
         miscId,
         convertedTagId);
 
-    migrateTo(dataSource, "latest");
+    // Pinned to 51, not "latest": this class asserts on collection.type, which V52 drops. A
+    // V51 test must be scoped to V51 regardless -- later migrations are other tests' business.
+    migrateTo(dataSource, "51");
   }
 
   private static String slugOf(String type) {

--- a/src/test/java/edens/zac/portfolio/backend/dao/V52DropCollectionTypeMigrationIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/dao/V52DropCollectionTypeMigrationIntegrationTest.java
@@ -1,0 +1,72 @@
+package edens.zac.portfolio.backend.dao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import edens.zac.portfolio.backend.AbstractPostgresIntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Verifies V52 against a real Postgres: {@code collection.type} is gone and the two surviving
+ * discriminators are intact. Schema introspection only -- this class deliberately inserts no rows,
+ * because the shared container truncates auth tables only and a stray collection row would leak
+ * into every other fixture's counts.
+ */
+class V52DropCollectionTypeMigrationIntegrationTest extends AbstractPostgresIntegrationTest {
+
+  @Autowired private JdbcTemplate jdbc;
+
+  private Integer countCollectionColumn(String column) {
+    return jdbc.queryForObject(
+        "SELECT count(*) FROM information_schema.columns "
+            + "WHERE table_schema = 'public' AND table_name = 'collection' AND column_name = ?",
+        Integer.class,
+        column);
+  }
+
+  private String nullabilityOf(String column) {
+    return jdbc.queryForObject(
+        "SELECT is_nullable FROM information_schema.columns "
+            + "WHERE table_schema = 'public' AND table_name = 'collection' AND column_name = ?",
+        String.class,
+        column);
+  }
+
+  @Test
+  @DisplayName("V52 removes the collection.type column entirely")
+  void collectionTypeColumnIsGone() {
+    assertThat(countCollectionColumn("type")).isZero();
+  }
+
+  @Test
+  @DisplayName("is_client and is_blog survive V52 and stay NOT NULL")
+  void discriminatorFlagsSurviveAsNotNull() {
+    assertThat(countCollectionColumn("is_client")).isEqualTo(1);
+    assertThat(countCollectionColumn("is_blog")).isEqualTo(1);
+    assertThat(nullabilityOf("is_client")).isEqualTo("NO");
+    assertThat(nullabilityOf("is_blog")).isEqualTo("NO");
+  }
+
+  @Test
+  @DisplayName("the V50 mutual-exclusion CHECK still guards the two flags")
+  void mutualExclusionCheckConstraintSurvives() {
+    Integer constraints =
+        jdbc.queryForObject(
+            "SELECT count(*) FROM pg_constraint WHERE conname = 'chk_collection_client_blog_excl'",
+            Integer.class);
+    assertThat(constraints).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("DROP COLUMN took idx_collection_type with it -- no DROP INDEX was needed")
+  void typeIndexWasAutoDroppedByTheColumnDrop() {
+    Integer indexes =
+        jdbc.queryForObject(
+            "SELECT count(*) FROM pg_indexes "
+                + "WHERE schemaname = 'public' AND indexname = 'idx_collection_type'",
+            Integer.class);
+    assertThat(indexes).isZero();
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/services/CollectionLinkSecurityIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/CollectionLinkSecurityIntegrationTest.java
@@ -27,8 +27,8 @@ class CollectionLinkSecurityIntegrationTest extends AbstractPostgresIntegrationT
 
   private long seed(String slug, boolean isClient, String galleryPassword) {
     jdbc.update(
-        "INSERT INTO collection (title, slug, type, visibility, is_client, is_blog,"
-            + " gallery_password) VALUES (?, ?, 'MISC', 'LISTED', ?, false, ?)",
+        "INSERT INTO collection (title, slug, visibility, is_client, is_blog,"
+            + " gallery_password) VALUES (?, ?, 'LISTED', ?, false, ?)",
         slug,
         slug,
         isClient,

--- a/src/test/java/edens/zac/portfolio/backend/services/ContentDownloadGateIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/ContentDownloadGateIntegrationTest.java
@@ -193,4 +193,27 @@ class ContentDownloadGateIntegrationTest extends AbstractPostgresIntegrationTest
     assertThat(contentService.findProtectedCollectionsForCollectionDownload(publicWrapper, null))
         .isEmpty();
   }
+
+  @Test
+  void collectionDownloadGate_unionsEveryProtectedParentAcrossTheWholeCollection() {
+    // A whole-collection ZIP is gated on the UNION over every image it serves: one unprotected
+    // image does not dilute another image's protected parent, and a gallery that gates two of the
+    // images is still reported once. Distinct from the subset case above, which narrows instead.
+    Long imageInBothGalleries = seedImage("s1zip-union-both");
+    Long imageInOneGallery = seedImage("s1zip-union-one");
+    Long openImage = seedImage("s1zip-union-open");
+    Long wrapper = seedCollection("s1zip-union-wrapper", null);
+    Long galleryOne = seedCollection("s1zip-union-alpha", "alpha");
+    Long galleryTwo = seedCollection("s1zip-union-bravo", "bravo");
+    link(wrapper, imageInBothGalleries);
+    link(wrapper, imageInOneGallery);
+    link(wrapper, openImage);
+    link(galleryOne, imageInBothGalleries);
+    link(galleryTwo, imageInBothGalleries);
+    link(galleryOne, imageInOneGallery);
+
+    assertThat(contentService.findProtectedCollectionsForCollectionDownload(wrapper, null))
+        .extracting(CollectionEntity::getId)
+        .containsExactlyInAnyOrder(galleryOne, galleryTwo);
+  }
 }

--- a/src/test/java/edens/zac/portfolio/backend/services/ContentDownloadGateIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/ContentDownloadGateIntegrationTest.java
@@ -38,8 +38,8 @@ class ContentDownloadGateIntegrationTest extends AbstractPostgresIntegrationTest
 
   private Long seedCollection(String slug, String galleryPassword) {
     jdbc.update(
-        "INSERT INTO collection (title, slug, type, visibility, is_client, is_blog,"
-            + " gallery_password) VALUES (?, ?, 'MISC', 'LISTED', false, false, ?)",
+        "INSERT INTO collection (title, slug, visibility, is_client, is_blog,"
+            + " gallery_password) VALUES (?, ?, 'LISTED', false, false, ?)",
         slug,
         slug,
         galleryPassword);

--- a/src/test/java/edens/zac/portfolio/backend/services/RoleGrantPropagationServiceIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/RoleGrantPropagationServiceIntegrationTest.java
@@ -36,9 +36,7 @@ class RoleGrantPropagationServiceIntegrationTest extends AbstractPostgresIntegra
 
   private long seedCollection(String slug) {
     jdbc.update(
-        "INSERT INTO collection (title, slug, type, visibility) VALUES (?, ?, 'CLIENT_GALLERY', 'UNLISTED')",
-        slug,
-        slug);
+        "INSERT INTO collection (title, slug, visibility) VALUES (?, ?, 'UNLISTED')", slug, slug);
     return jdbc.queryForObject("SELECT id FROM collection WHERE slug=?", Long.class, slug);
   }
 

--- a/src/test/java/edens/zac/portfolio/backend/services/RoleGrantVisibilityToggleIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/RoleGrantVisibilityToggleIntegrationTest.java
@@ -37,9 +37,7 @@ class RoleGrantVisibilityToggleIntegrationTest extends AbstractPostgresIntegrati
 
   private long seedCollection(String slug) {
     jdbc.update(
-        "INSERT INTO collection (title, slug, type, visibility) VALUES (?, ?, 'CLIENT_GALLERY', 'UNLISTED')",
-        slug,
-        slug);
+        "INSERT INTO collection (title, slug, visibility) VALUES (?, ?, 'UNLISTED')", slug, slug);
     return jdbc.queryForObject("SELECT id FROM collection WHERE slug=?", Long.class, slug);
   }
 

--- a/src/test/java/edens/zac/portfolio/backend/services/RuleBMixedContentIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/RuleBMixedContentIntegrationTest.java
@@ -42,8 +42,8 @@ class RuleBMixedContentIntegrationTest extends AbstractPostgresIntegrationTest {
 
   private Long seedCollection(String slug) {
     jdbc.update(
-        "INSERT INTO collection (title, slug, type, visibility, is_client, is_blog)"
-            + " VALUES (?, ?, 'MISC', 'LISTED', false, false)",
+        "INSERT INTO collection (title, slug, visibility, is_client, is_blog)"
+            + " VALUES (?, ?, 'LISTED', false, false)",
         slug,
         slug);
     return jdbc.queryForObject("SELECT id FROM collection WHERE slug = ?", Long.class, slug);

--- a/src/test/java/edens/zac/portfolio/backend/services/TagConversionIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/TagConversionIntegrationTest.java
@@ -30,7 +30,7 @@ class TagConversionIntegrationTest extends AbstractPostgresIntegrationTest {
 
   private long seedCollection(String slug, CollectionVisibility visibility, Integer rating) {
     jdbc.update(
-        "INSERT INTO collection (title, slug, type, visibility, rating) VALUES (?, ?, 'BLOG', ?, ?)",
+        "INSERT INTO collection (title, slug, visibility, rating) VALUES (?, ?, ?, ?)",
         slug,
         slug,
         visibility.name(),

--- a/src/test/java/edens/zac/portfolio/backend/services/TagViewIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/TagViewIntegrationTest.java
@@ -42,7 +42,7 @@ class TagViewIntegrationTest extends AbstractPostgresIntegrationTest {
 
   private long seedCollection(String slug, CollectionVisibility visibility, Integer rating) {
     jdbc.update(
-        "INSERT INTO collection (title, slug, type, visibility, rating) VALUES (?, ?, 'BLOG', ?, ?)",
+        "INSERT INTO collection (title, slug, visibility, rating) VALUES (?, ?, ?, ?)",
         slug,
         slug,
         visibility.name(),

--- a/src/test/java/edens/zac/portfolio/backend/services/UserPageAssemblerIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/UserPageAssemblerIntegrationTest.java
@@ -50,13 +50,12 @@ class UserPageAssemblerIntegrationTest extends AbstractPostgresIntegrationTest {
         name.toLowerCase().replace(' ', '-') + "-" + UUID.randomUUID() + "@example.com");
   }
 
-  private Long seedCollection(String type, LocalDateTime date) {
+  private Long seedCollection(LocalDateTime date) {
     return jdbc.queryForObject(
-        "INSERT INTO collection (title, slug, type, visibility, collection_date) "
-            + "VALUES ('Gallery', ?, ?, 'UNLISTED', ?) RETURNING id",
+        "INSERT INTO collection (title, slug, visibility, collection_date) "
+            + "VALUES ('Gallery', ?, 'UNLISTED', ?) RETURNING id",
         Long.class,
         "g-" + UUID.randomUUID(),
-        type,
         date == null ? null : Timestamp.valueOf(date));
   }
 
@@ -150,14 +149,14 @@ class UserPageAssemblerIntegrationTest extends AbstractPostgresIntegrationTest {
     // The account row IS the person identity: tag and grant against the same id.
     Long userId = seedUserNamed("Jane Doe");
 
-    Long tagged = seedCollection("CLIENT_GALLERY", LocalDateTime.now().minusDays(5));
+    Long tagged = seedCollection(LocalDateTime.now().minusDays(5));
     tagCollection(tagged, userId);
 
-    Long granted = seedCollection("CLIENT_GALLERY", LocalDateTime.now().minusDays(1));
+    Long granted = seedCollection(LocalDateTime.now().minusDays(1));
     grant(userId, granted);
 
     // A collection both tagged AND granted must collapse to a single block (de-dupe).
-    Long both = seedCollection("CLIENT_GALLERY", LocalDateTime.now().minusDays(3));
+    Long both = seedCollection(LocalDateTime.now().minusDays(3));
     tagCollection(both, userId);
     grant(userId, both);
 
@@ -204,7 +203,7 @@ class UserPageAssemblerIntegrationTest extends AbstractPostgresIntegrationTest {
   @Test
   void memberOnlyUserWithNoPersonLinkStillGetsMemberCollections() {
     Long userId = seedUser("grantonly-" + UUID.randomUUID() + "@example.com");
-    Long granted = seedCollection("CLIENT_GALLERY", LocalDateTime.now().minusDays(1));
+    Long granted = seedCollection(LocalDateTime.now().minusDays(1));
     grant(userId, granted);
 
     CollectionModel model = assembler.assembleForUser(userId);
@@ -218,7 +217,7 @@ class UserPageAssemblerIntegrationTest extends AbstractPostgresIntegrationTest {
   @Test
   void grantOnlyUserFallsBackToGrantedCollectionCover() {
     Long userId = seedUser("grantcover-" + UUID.randomUUID() + "@example.com");
-    Long granted = seedCollection("CLIENT_GALLERY", LocalDateTime.now().minusDays(1));
+    Long granted = seedCollection(LocalDateTime.now().minusDays(1));
     seedCollectionCover(granted, "https://cdn/granted-cover.webp");
     grant(userId, granted);
 
@@ -236,9 +235,9 @@ class UserPageAssemblerIntegrationTest extends AbstractPostgresIntegrationTest {
   @Test
   void coverFallbackPicksNewestCollectionThatHasACover() {
     Long userId = seedUser("newestcover-" + UUID.randomUUID() + "@example.com");
-    Long older = seedCollection("CLIENT_GALLERY", LocalDateTime.now().minusDays(30));
-    Long newer = seedCollection("CLIENT_GALLERY", LocalDateTime.now().minusDays(2));
-    Long newestWithoutCover = seedCollection("CLIENT_GALLERY", LocalDateTime.now().minusDays(1));
+    Long older = seedCollection(LocalDateTime.now().minusDays(30));
+    Long newer = seedCollection(LocalDateTime.now().minusDays(2));
+    Long newestWithoutCover = seedCollection(LocalDateTime.now().minusDays(1));
     seedCollectionCover(older, "https://cdn/older-cover.webp");
     seedCollectionCover(newer, "https://cdn/newer-cover.webp");
     grant(userId, older);
@@ -269,7 +268,7 @@ class UserPageAssemblerIntegrationTest extends AbstractPostgresIntegrationTest {
   @Test
   void linkedPersonWithoutTaggedImageFallsBackToCollectionCover() {
     Long userId = seedUserNamed("No Cover Person");
-    Long tagged = seedCollection("CLIENT_GALLERY", LocalDateTime.now().minusDays(1));
+    Long tagged = seedCollection(LocalDateTime.now().minusDays(1));
     seedCollectionCover(tagged, "https://cdn/tagged-collection-cover.webp");
     tagCollection(tagged, userId);
 
@@ -287,7 +286,7 @@ class UserPageAssemblerIntegrationTest extends AbstractPostgresIntegrationTest {
   @Test
   void linkedPersonWithoutTaggedImageOrCollectionCoverStillHasNullCover() {
     Long userId = seedUserNamed("Nothing Anywhere");
-    Long tagged = seedCollection("CLIENT_GALLERY", LocalDateTime.now().minusDays(1));
+    Long tagged = seedCollection(LocalDateTime.now().minusDays(1));
     tagCollection(tagged, userId);
 
     CollectionModel model = assembler.assembleForUser(userId);
@@ -331,7 +330,7 @@ class UserPageAssemblerIntegrationTest extends AbstractPostgresIntegrationTest {
   void bodyOrderingIsCollectionsThenContentBothDateDesc() {
     Long userId = seedUserNamed("Order Person");
 
-    Long collection = seedCollection("CLIENT_GALLERY", LocalDateTime.now().minusDays(2));
+    Long collection = seedCollection(LocalDateTime.now().minusDays(2));
     tagCollection(collection, userId);
     seedTaggedImage(userId, "https://cdn/img.webp", LocalDateTime.now().minusDays(3));
     seedTaggedGif(userId, "https://cdn/g.gif");

--- a/src/test/java/edens/zac/portfolio/backend/services/UserSavesServiceIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/UserSavesServiceIntegrationTest.java
@@ -54,8 +54,7 @@ class UserSavesServiceIntegrationTest extends AbstractPostgresIntegrationTest {
   private Long seedCollection(CollectionVisibility visibility) {
     String slug = "coll-" + UUID.randomUUID();
     return jdbcTemplate.queryForObject(
-        "INSERT INTO collection (title, slug, type, visibility) "
-            + "VALUES (?, ?, 'BLOG', ?) RETURNING id",
+        "INSERT INTO collection (title, slug, visibility) " + "VALUES (?, ?, ?) RETURNING id",
         Long.class,
         slug,
         slug,


### PR DESCRIPTION
**Stacked on #137 (U4). Do not merge until U4 has been deployed AND soaked in production.**

The final step: `ALTER TABLE collection DROP COLUMN type` (migration V52). After U4, that column is written by nothing and read by nothing.

## Rollback
`collection_type_archive` — created by V51 back in U0 — holds one row per collection with its original `type`, `is_client` and `is_blog`. That table is the **only** way back: `PORTFOLIO`, `ART_GALLERY`, `PARENT`, `HOME` and `MISC` are all `is_client=false, is_blog=false`, so they are indistinguishable from the flags alone once the column is gone. Keep that table indefinitely.

## Deliberately absent
No `DROP INDEX idx_collection_type_visible_date`. V20's `DROP COLUMN visible` already auto-dropped it, and a defensive drop would error, abort Flyway mid-migration, and block application boot on every subsequent start.

## Branch reconciliation note
This branch was originally cut from U4 *before* U4's review fixes landed, and both branches independently fixed the critical ZIP-download hole. Reconciled: U4's implementation survives (it gates on collection membership *before* resolution, so its gate set is a conservative superset, and it leaves the `DownloadResolution` model untouched). Four test cases from this branch's version were carried over rather than dropped — including the one proving a cookie for one gallery does not unlock an image that also lives in a second.

That merge also surfaced a bug neither branch could see alone: U4's new `RuleBMixedContentIntegrationTest` inserts into `collection.type`, which compiles fine and fails only once V52 drops the column. Fixed here.

## Verification
`mvn clean install` — **BUILD SUCCESS, 1194 tests, 0 failures**, 1 pre-existing skip.
`grep` confirms zero reads or writes of `collection.type` anywhere in `src/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)