### PR TITLE
fix: two live defects (tag-edit 500, client-gallery download 401) + user upgrade + doc sweep

### DIFF
--- a/.claude/api-patterns.md
+++ b/.claude/api-patterns.md
@@ -78,7 +78,7 @@ return ResponseEntity.noContent().build(); // 204 for deletes
 throw new IllegalArgumentException("Collection not found: " + slug);
 
 // 400 -- any other IllegalArgumentException
-throw new IllegalArgumentException("Invalid collection type: " + type);
+throw new IllegalArgumentException("Invalid visibility: " + visibility);
 
 // 400 -- invalid state
 throw new IllegalStateException("Cannot delete: collection has content");

--- a/.claude/architecture.md
+++ b/.claude/architecture.md
@@ -60,9 +60,10 @@ A single image can belong to multiple collections with different ordering/captio
 
 ### Collection Hierarchy
 - Collections can contain any ContentEntity type, in any mix — including references to other collections
-- Collections carry no type discriminator. Two stored booleans: `is_client` (password/role gated) and `is_blog` (appears in blog listings); mutually exclusive
-- Parent-ness is derived (holds >= 1 COLLECTION content block), never stored; `home` is derived from `slug = 'home'`
-- Collections have: slug, title, coverImage, date, visibility flags
+- Collections carry no type discriminator. Two stored booleans: `is_client` (password/role gated) and `is_blog` (appears in blog listings); mutually exclusive, and carrying neither is a valid state
+- Parent-ness is derived (holds >= 1 COLLECTION content block), never stored — computed server-side by `CollectionRepository.hasChildCollections` and exposed as `hasChildren` / `childCollectionIds`; `home` is derived from `slug = 'home'`
+- `PORTFOLIO`, `ART_GALLERY` and `MISC` are gone with no successor concept. The `collection.type` column was dropped by V52; `collection_type_archive` (V51) is the only faithful rollback record and must be retained — see [database.md](database.md)
+- Collections have: slug, title, coverImage, date range, visibility, rating, layout fields
 
 ## Data Flow: Image Upload
 1. Controller receives multipart file
@@ -75,12 +76,8 @@ A single image can belong to multiple collections with different ordering/captio
 ## Data Flow: API Request
 1. Controller receives request (params validated by `@Valid`)
 2. Calls service method (concrete class, no interface wrapper)
-3. Service uses DAO for database queries (JDBC)
+3. Service uses a DAO for database queries (JDBC; classes live in `dao/` and are named `*Repository`)
 4. DAO returns entities
 5. Service converts entities to models (DTOs)
 6. Controller wraps in `ResponseEntity<T>`
 7. On exception: `GlobalExceptionHandler` maps to appropriate HTTP status/body
-
-<!-- PLANNED CHANGES (refactor_2026.md):
-- Phase 4: DAOs will be consolidated and potentially renamed to *Repository
--->

--- a/.claude/database.md
+++ b/.claude/database.md
@@ -1,85 +1,207 @@
 # Database Schema
 
+Schema evolution is managed by Flyway (`src/main/resources/db/migration`, currently V2..V52).
+Tables that pre-date Flyway are reconstructed for tests by `src/test/resources/db/test-base-schema.sql`,
+which Flyway then migrates on top of.
+
 ## Primary Tables
 
 ### content (base table)
 ```sql
-id              BIGINT PRIMARY KEY
+id              BIGSERIAL PRIMARY KEY
 content_type    VARCHAR NOT NULL  -- IMAGE, TEXT, GIF, COLLECTION
-created_at      TIMESTAMP
-updated_at      TIMESTAMP
+created_at      TIMESTAMP NOT NULL
+updated_at      TIMESTAMP NOT NULL
 ```
 
 ### content_image (extends content)
 ```sql
-id              BIGINT PRIMARY KEY (FK -> content.id)
-title           VARCHAR
-image_url_web   VARCHAR NOT NULL
-image_url_full  VARCHAR
-image_width     INT
-image_height    INT
-iso             INT
-f_stop          VARCHAR
-shutter_speed   VARCHAR
-focal_length    VARCHAR
-rating          INT
-author          VARCHAR
-location        VARCHAR
-create_date     VARCHAR
-black_and_white BOOLEAN
-is_film         BOOLEAN
+id                 BIGINT PRIMARY KEY (FK -> content.id)
+title              VARCHAR(255)
+caption            TEXT              -- V26
+alt                VARCHAR(500)      -- V26
+image_width        INTEGER
+image_height       INTEGER
+iso                INTEGER
+author             VARCHAR(100)
+rating             INTEGER
+f_stop             VARCHAR(20)
+shutter_speed      VARCHAR(50)
+focal_length       VARCHAR(50)
+camera_id          BIGINT FK -> content_cameras.id
+lens_id            BIGINT FK -> content_lenses.id
+film_type_id       BIGINT FK -> content_film_types.id
+film_format        VARCHAR(20)       -- 35MM, 120, 4X5, ...
+black_and_white    BOOLEAN
+is_film            BOOLEAN
+image_url_web      VARCHAR(1024) NOT NULL
+image_url_original VARCHAR(1024)
+image_url_raw      VARCHAR(512)      -- V10
+capture_date       TIMESTAMP         -- V4 (DATE) -> V7/V14 (TIMESTAMP)
+last_export_date   TIMESTAMP         -- V4, dedupe
+original_filename  VARCHAR(512)      -- V4, dedupe
+```
+
+Partial unique dedupe index on `(original_filename, capture_date)` where both are non-null.
+`create_date` and `file_identifier` were dropped by V4 -- do not reference them.
+
+### content_text / content_gif / content_collection (extend content)
+```sql
+-- content_text
+id            BIGINT PRIMARY KEY (FK -> content.id)
+text_content  TEXT NOT NULL
+format_type   VARCHAR(50)
+
+-- content_gif
+id            BIGINT PRIMARY KEY (FK -> content.id)
+title         VARCHAR(255)
+gif_url       VARCHAR(1024)   -- 2000px "full" master
+gif_url_web   VARCHAR(512)    -- V25, 1080px "web" display variant
+thumbnail_url VARCHAR(1024)
+width         INTEGER
+height        INTEGER
+author        VARCHAR(100)
+create_date   VARCHAR(50)     -- still present here; only content_image dropped it (V4)
+rating        INTEGER         -- V24
+capture_date  TIMESTAMP       -- V49
+
+-- content_collection (a reference to another collection, rendered as a content block)
+id                       BIGINT PRIMARY KEY (FK -> content.id)
+referenced_collection_id BIGINT NOT NULL FK -> collection.id
 ```
 
 ### collection
 ```sql
-id              BIGINT PRIMARY KEY
-slug            VARCHAR UNIQUE NOT NULL
-title           VARCHAR NOT NULL
-collection_type VARCHAR  -- BLOG, PORTFOLIO, ART_GALLERY, CLIENT_GALLERY, HOME, MISC
-cover_image_url VARCHAR
-collection_date DATE
-is_visible      BOOLEAN
-has_access      BOOLEAN
-password        VARCHAR
-created_at      TIMESTAMP
-updated_at      TIMESTAMP
+id                  BIGSERIAL PRIMARY KEY
+is_client           BOOLEAN NOT NULL DEFAULT FALSE  -- V50: client gallery, password/role gated
+is_blog             BOOLEAN NOT NULL DEFAULT FALSE  -- V50: appears in blog listings
+title               VARCHAR(100) NOT NULL
+slug                VARCHAR(150) NOT NULL UNIQUE    -- V41: idx_collection_slug_unique
+description         VARCHAR(500)
+collection_date     DATE                            -- start of the date range
+collection_end_date DATE                            -- V43: inclusive end; NULL = single-day
+visibility          VARCHAR(16) NOT NULL            -- V20: LISTED, UNLISTED, HIDDEN
+rating              INTEGER                         -- V21: NULL or 0-5
+display_mode        VARCHAR(50)
+cover_image_id      BIGINT
+content_per_page    INTEGER
+total_content       INTEGER
+rows_wide           INT
+gallery_password    VARCHAR(255)                    -- V18: plaintext, client galleries only
+recipient_emails    TEXT[] NOT NULL DEFAULT '{}'    -- V18
+created_at          TIMESTAMP NOT NULL
+updated_at          TIMESTAMP NOT NULL
 ```
 
-### collection_content (join table)
+Check constraints: `chk_collection_client_blog_excl` (NOT (is_client AND is_blog)),
+`collection_visibility_chk`, `collection_rating_chk`.
+
+**There is no `type` column.** V52 dropped it. A collection is a named, slugged, ordered grouping
+of any mix of content, and `is_client` / `is_blog` are the only two stored discriminators. They are
+mutually exclusive; carrying neither is a valid, meaningful state. Everything else is derived or
+gone:
+
+| Former `type` value | Where it lives now |
+|---|---|
+| `CLIENT_GALLERY` | `collection.is_client = true` (stored) |
+| `BLOG` | `collection.is_blog = true` (stored) |
+| `PARENT` | Derived, never stored: the collection holds >= 1 COLLECTION content block. Computed server-side and exposed as `hasChildren` / `childCollectionIds` (`CollectionRepository.hasChildCollections`). |
+| `HOME` | Derived, never stored: `slug = 'home'`. V41's unique slug index guarantees at most one. |
+| `PORTFOLIO` | Gone. No successor concept. |
+| `ART_GALLERY` | Gone. No successor concept. |
+| `MISC` | Gone. No successor concept -- carrying neither flag *is* the meaning. |
+
+Never add `"type"` to a `collection` projection, INSERT or UPDATE: the column does not exist and
+naming it fails at runtime.
+
+### collection_type_archive (retain indefinitely)
 ```sql
-id              BIGINT PRIMARY KEY
-collection_id   BIGINT FK -> collection.id
-content_id      BIGINT FK -> content.id
-display_order   INT
-caption         VARCHAR
-is_visible      BOOLEAN
+id           BIGINT     -- collection.id at snapshot time; no PK/FK, created by CTAS
+slug         VARCHAR
+type         VARCHAR    -- the dropped enum value
+is_client    BOOLEAN
+is_blog      BOOLEAN
+archived_at  TIMESTAMP
 ```
+
+Created by V51 as `CREATE TABLE ... AS SELECT` over `collection` immediately before V52 dropped the
+column. **Do not drop this table.** `PORTFOLIO`, `ART_GALLERY`, `PARENT`, `HOME` and `MISC` are all
+`is_client = false, is_blog = false`, so five distinct former values collapse onto one flag pair and
+the old `type` is *not* reconstructable from the flags. This table is the only faithful rollback
+record. The rollback recipe lives in the header of `V52__drop_collection_type.sql`; it also requires
+reverting the application to a pre-U4 build.
+
+### collection_content (join table, ordered)
+```sql
+id              BIGSERIAL PRIMARY KEY
+collection_id   BIGINT NOT NULL FK -> collection.id
+content_id      BIGINT NOT NULL FK -> content.id
+order_index     INTEGER NOT NULL DEFAULT 0
+visible         BOOLEAN NOT NULL DEFAULT TRUE
+created_at      TIMESTAMP NOT NULL
+updated_at      TIMESTAMP NOT NULL
+```
+
+A single content row can belong to multiple collections with different ordering and per-collection
+visibility.
 
 ## Metadata Tables
 
-### tag / content_image_tags
+### tag / content_tags / collection_tags
 ```sql
 -- tag
-id    BIGINT PRIMARY KEY
-name  VARCHAR UNIQUE
+id                      BIGINT PRIMARY KEY
+tag_name                VARCHAR(100) NOT NULL UNIQUE
+slug                    VARCHAR(100) NOT NULL UNIQUE   -- V8
+converted_collection_id BIGINT FK -> collection.id     -- V39, set when a tag was saved as a collection
+created_at              TIMESTAMP
 
--- content_image_tags (join)
-image_id  BIGINT FK -> content_image.id
-tag_id    BIGINT FK -> tag.id
+-- content_tags (join, content-keyed)
+content_id  BIGINT FK -> content.id
+tag_id      BIGINT FK -> tag.id
+
+-- collection_tags (join)
+collection_id  BIGINT FK -> collection.id
+tag_id         BIGINT FK -> tag.id
 ```
 
-Similar pattern for: `person`, `camera`, `lens`, `film_type`
+### location / users
+```sql
+-- location joins: content_image_locations (content_id, location_id)   [V16; the key column was
+--                 renamed image_id -> content_id in V27]
+--                 collection_locations (collection_id, location_id)   [V16]
+-- people joins:   content_image_people (content_id, person_id)        [renamed in V27]
+--                 collection_people (collection_id, person_id)        [V22]
+```
+
+`person_id` references `users.id`. The old `content_people` table was merged into `app_user` and
+dropped by V35; `app_user` was renamed to `users` in the same migration. A person with no account is
+a `users` row with `status = 'PERSON'`.
+
+`content_cameras`, `content_lenses` and `content_film_types` are **not** join tables -- images
+reference them directly via the `camera_id` / `lens_id` / `film_type_id` FK columns above.
 
 ## Query Patterns
 
 ### Get collection with content (common)
 ```sql
-SELECT c.*, cc.display_order, cc.caption
+SELECT ci.*, cc.order_index
 FROM collection c
 JOIN collection_content cc ON c.id = cc.collection_id
 JOIN content_image ci ON cc.content_id = ci.id
-WHERE c.slug = ?
-ORDER BY cc.display_order
+WHERE c.slug = :slug AND cc.visible = true
+ORDER BY cc.order_index
+```
+
+### Derived parent-ness (replaces the dropped PARENT type)
+```sql
+SELECT EXISTS (
+  SELECT 1
+  FROM collection_content cc
+  JOIN content_collection cct ON cct.id = cc.content_id
+  WHERE cc.collection_id = :collectionId
+    AND cct.referenced_collection_id IS NOT NULL
+)
 ```
 
 ### Bulk content loading (performance)
@@ -90,11 +212,5 @@ SELECT * FROM content_image WHERE id IN (?, ?, ?)
 
 ## Data Access Layer
 - Uses `NamedParameterJdbcTemplate` (not JPA repositories)
-- DAOs extend `BaseDao` pattern
+- DAOs live in `dao/`, are named `*Repository`, and extend the abstract `BaseDao`
 - Entities are POJOs with Lombok, mapped manually from ResultSet
-
-<!-- PLANNED CHANGES (refactor_2026.md Phase 4):
-- Consolidate 14 DAOs down to 5-6 focused repositories
-- Potentially rename *Dao to *Repository
-- Evaluate Spring Data JDBC to reduce RowMapper boilerplate
--->

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Backend REST API for a photography portfolio and content management platform. Ha
 ## Features
 
 - **Image Upload & Processing** -- Multi-resolution thumbnail generation (web, thumbnail, small), EXIF metadata extraction (camera, lens, GPS, exposure), WebP conversion
-- **Collection Management** -- Four collection types (Blog, Portfolio, Art Gallery, Client Gallery) with pagination, ordering, and nested collection support
+- **Collection Management** -- A collection is a named, slugged, ordered grouping of any mix of content (images, text, GIFs, other collections), with pagination and ordering. Two stored flags specialize it: `isClient` (password-gated client gallery) and `isBlog` (appears in blog listings); parent-ness and the home page are derived from the content graph and the `home` slug
 - **Multi-Dimensional Image Search** -- Filter by tags, people, camera, lens, location, rating, film/digital, date range with dynamic SQL query building
 - **Location Pages** -- Collections and orphan images grouped by location with count hints for frontend clickability
 - **Client Gallery Protection** -- SHA-256 password hashing, access token flow, rate-limited authentication
@@ -90,7 +90,7 @@ src/main/java/edens/zac/portfolio/backend/
   types/              Enums (ContentType, DisplayMode, CollectionVisibility)
   config/             Spring configuration, exception handling
 src/main/resources/
-  db/migration/       Flyway SQL migrations (V1-V5)
+  db/migration/       Flyway SQL migrations (V2-V52)
 terraform/            AWS infrastructure as code
 docker/               Docker configurations
 scripts/              Deployment and utility scripts
@@ -107,8 +107,7 @@ scripts/              Deployment and utility scripts
 | `GET` | `/collections` | Paginated list of all collections |
 | `GET` | `/collections/{slug}` | Collection with paginated content (supports `?accessToken=`) |
 | `GET` | `/collections/{slug}/meta` | Lightweight collection metadata (SEO) |
-| `GET` | `/collections/type/{type}` | Visible collections by type |
-| `GET` | `/collections/location/{name}` | Collections + orphan images at a location |
+| `GET` | `/collections/location/{slug}` | Collections + orphan images at a location |
 | `POST` | `/collections/{slug}/access` | Validate client gallery password, returns access token |
 | `GET` | `/content/images/search` | Multi-filter image search with pagination |
 | `GET` | `/content/tags` | All tags |

--- a/src/main/java/edens/zac/portfolio/backend/controller/admin/AdminUserController.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/admin/AdminUserController.java
@@ -8,6 +8,7 @@ import edens.zac.portfolio.backend.controller.admin.UserRequests.MergePreview;
 import edens.zac.portfolio.backend.controller.admin.UserRequests.MergeRequest;
 import edens.zac.portfolio.backend.controller.admin.UserRequests.MergeResult;
 import edens.zac.portfolio.backend.controller.admin.UserRequests.UpdateUserRequest;
+import edens.zac.portfolio.backend.controller.admin.UserRequests.UpgradeUserRequest;
 import edens.zac.portfolio.backend.dao.AppUserRepository;
 import edens.zac.portfolio.backend.dao.RoleRepository;
 import edens.zac.portfolio.backend.entity.AppUserEntity;
@@ -170,6 +171,60 @@ public class AdminUserController {
     sendInviteEmailAfterCommit(user.getEmail(), user.getName(), inviteUrl);
     log.info("Admin regenerated invite (userId={})", user.getId());
     return ResponseEntity.ok(new CreateUserResponse(user.getId(), inviteUrl));
+  }
+
+  /**
+   * Upgrade a tag-only {@code PERSON} identity in place into a real {@code INVITED} account: set
+   * its login email, flip its status {@code PERSON -> INVITED}, mint a single-use invite link, and
+   * email it to the invitee exactly as the two sibling invite endpoints do. The row id is
+   * unchanged, so every image/collection tag already FK'd to this person is carried onto the new
+   * account untouched. Distinct from identity-merge, which folds a PERSON into a separate existing
+   * account and hard-deletes the source row.
+   *
+   * <p>Returns {@code 404} if no such user, {@code 409} if the target is not a {@code PERSON} (only
+   * a tag-only identity can be upgraded), and {@code 409} if the email is already owned by another
+   * user (checked before the write; a {@code DataIntegrityViolationException} is handled by {@link
+   * edens.zac.portfolio.backend.config.GlobalExceptionHandler} as belt-and-suspenders for races).
+   *
+   * @param id the {@code users.id} of the PERSON row to upgrade
+   * @param request the upgrade parameters; email is normalized to lowercase
+   * @return {@code 200} with {@link CreateUserResponse}
+   */
+  @PostMapping("/{id}/upgrade")
+  @Transactional
+  public ResponseEntity<CreateUserResponse> upgradeUser(
+      @PathVariable Long id, @Valid @RequestBody UpgradeUserRequest request) {
+    Optional<AppUserEntity> maybeUser = appUserRepository.findById(id);
+    if (maybeUser.isEmpty()) {
+      return ResponseEntity.notFound().build();
+    }
+    AppUserEntity user = maybeUser.get();
+    if (user.getStatus() != UserStatus.PERSON) {
+      log.warn("Admin upgrade rejected: user {} is not a PERSON (status={})", id, user.getStatus());
+      return ResponseEntity.status(HttpStatus.CONFLICT).build();
+    }
+
+    // The status gate above guarantees a tag-only row, whose email is NULL, so any hit here is
+    // necessarily a different account -- no same-owner escape hatch is reachable (unlike
+    // updateUser, where resubmitting the user's own address is a normal no-op).
+    String email = request.email().toLowerCase();
+    if (appUserRepository.findByEmail(email).isPresent()) {
+      log.warn("Admin upgrade rejected: email already exists (userId={}, email={})", id, email);
+      return ResponseEntity.status(HttpStatus.CONFLICT).build();
+    }
+
+    appUserRepository.updateEmail(id, email);
+    appUserRepository.updateStatus(id, UserStatus.INVITED);
+    String rawToken = userInviteService.regenerateInvite(id, email);
+    String inviteUrl = buildInviteUrl(rawToken);
+    sendInviteEmailAfterCommit(email, user.getName(), inviteUrl);
+
+    log.info(
+        "Admin upgraded PERSON to INVITED (userId={}, email={}, actorId={})",
+        id,
+        email,
+        currentUserId());
+    return ResponseEntity.ok(new CreateUserResponse(id, inviteUrl));
   }
 
   /**

--- a/src/main/java/edens/zac/portfolio/backend/controller/admin/UserRequests.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/admin/UserRequests.java
@@ -42,6 +42,16 @@ public final class UserRequests {
   public record CreateUserResponse(Long userId, String inviteUrl) {}
 
   /**
+   * Body for {@code POST /api/admin/users/{id}/upgrade} — upgrade a tag-only PERSON identity in
+   * place into an INVITED account. Only the email is supplied; the existing PERSON {@code name}
+   * (which is NOT NULL) becomes the account display name and the invitee may override it at accept
+   * time.
+   *
+   * @param email the invitee's email address (normalized to lowercase by the controller)
+   */
+  public record UpgradeUserRequest(@NotBlank @Email String email) {}
+
+  /**
    * Body for {@code PATCH /api/admin/users/{id}} — updates the admin-editable fields. {@code email}
    * is optional: {@code null}, empty, or omitted leaves the login email unchanged (whitespace-only
    * fails the {@code @Email} constraint with {@code 400}); when non-empty the controller normalizes

--- a/src/main/java/edens/zac/portfolio/backend/controller/prod/ContentDownloadControllerProd.java
+++ b/src/main/java/edens/zac/portfolio/backend/controller/prod/ContentDownloadControllerProd.java
@@ -162,8 +162,26 @@ public class ContentDownloadControllerProd {
   // ---------------------------------------------------------------------------
 
   /**
-   * Session+grant download authorization, falling back to the existing cookie gate. A non-null
-   * {@code galleryPassword} is already confirmed by callers before invoking this helper.
+   * Session+grant download authorization, falling back to the existing cookie gate.
+   *
+   * <p>The cookie fallback goes through the four-arg {@link GalleryAccessCookies#hasValidAccess}
+   * overload — the same one the public READ gate uses ({@code
+   * CollectionService.isGalleryAccessAuthorized}). The three-arg overload it replaced accepted only
+   * the per-slug cookie, so a viewer who unlocked a PARENT gallery could VIEW a propagated
+   * CLIENT_GALLERY child (read gate: password-fingerprint cookie accepted) but got 401 downloading
+   * from it (download gate: per-slug cookie only) — while the frontend rendered an enabled download
+   * button. Read and download now grant on identical evidence.
+   *
+   * <p>The four-arg overload short-circuits to {@code true} on a null/blank password, which cannot
+   * widen this gate: every caller supplies a collection already known to be protected. The two
+   * loops take theirs from {@code findProtectedCollectionsForImage} / {@code
+   * findProtectedCollectionsForCollectionDownload}, which filter on {@code galleryPassword !=
+   * null}; the slug-level check tests the same field inline. A non-null-but-empty password is
+   * unreachable — {@code GalleryAccessRequest.password} is {@code @Size(min = 4)}, and the only
+   * other writer copies an already-validated parent password onto a child. Beyond the short-circuit
+   * the overload is a strict superset of the three-arg one: it tries the identical per-slug cookie
+   * first, and the extra grant it adds requires an HMAC-signed fingerprint cookie matching THIS
+   * collection's current password.
    */
   private boolean isDownloadAuthorized(HttpServletRequest request, CollectionEntity collection) {
     Long userId = currentUserId();
@@ -171,7 +189,7 @@ public class ContentDownloadControllerProd {
       return true;
     }
     return GalleryAccessCookies.hasValidAccess(
-        request, collection.getSlug(), clientGalleryAuthService);
+        request, collection.getSlug(), collection.getGalleryPassword(), clientGalleryAuthService);
   }
 
   /** The authenticated principal's user id, or null when the request is anonymous. */

--- a/src/main/java/edens/zac/portfolio/backend/dao/CollectionRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/CollectionRepository.java
@@ -513,10 +513,10 @@ public class CollectionRepository extends BaseDao {
   /**
    * Same visibility scope and non-empty guard as {@link #findNonEmptyOrderedByVisibilityIn}, but
    * ordered chronologically ({@code collection_date DESC, id DESC}) instead of rating-first, and
-   * without a type filter. Backs the {@code all-collections} synthetic list, whose first paint is
-   * newest-collections-first; the {@code id DESC} tiebreaker gives a deterministic total order. The
-   * other synthetic lists keep {@link #findNonEmptyOrderedByVisibilityIn} (rating-first), so this
-   * is an additive sibling rather than a change to shared ordering.
+   * with no {@code blogsOnly} restriction. Backs the {@code all-collections} synthetic list, whose
+   * first paint is newest-collections-first; the {@code id DESC} tiebreaker gives a deterministic
+   * total order. The other synthetic lists keep {@link #findNonEmptyOrderedByVisibilityIn}
+   * (rating-first), so this is an additive sibling rather than a change to shared ordering.
    */
   @Transactional(readOnly = true)
   public List<CollectionEntity> findNonEmptyByVisibilityInOrderByDate(
@@ -572,9 +572,9 @@ public class CollectionRepository extends BaseDao {
 
   /**
    * Find every client gallery ({@code is_client = true}) plus every collection that has at least
-   * one visible client-gallery child (a "derived parent" — no parent-side type filter), all within
-   * the supplied visibility set, ordered by rating then collection_date. The parent branch walks
-   * the same join chain as {@link #findReferencedCollectionsByParentId} (parent ->
+   * one visible client-gallery child (a "derived parent" — no discriminator on the parent), all
+   * within the supplied visibility set, ordered by rating then collection_date. The parent branch
+   * walks the same join chain as {@link #findReferencedCollectionsByParentId} (parent ->
    * collection_content -> content_collection -> child) and applies the same visibility scope to the
    * child rows so parents whose only matching child is HIDDEN do not appear. Used by the
    * "all-client-galleries" synthetic listing where parents-of-galleries (e.g. wedding wrappers)

--- a/src/main/java/edens/zac/portfolio/backend/dao/TagRepository.java
+++ b/src/main/java/edens/zac/portfolio/backend/dao/TagRepository.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -184,6 +185,15 @@ public class TagRepository extends BaseDao {
   // Collection Tags Operations
   // ============================================================
 
+  /**
+   * Replace the tag set attached to a collection.
+   *
+   * <p>The incoming ids are deduplicated and the insert is idempotent. {@code collection_tags} is
+   * keyed on {@code (collection_id, tag_id)}, so a repeated id would otherwise abort the batch with
+   * a {@code DataIntegrityViolationException} and — because callers run inside a transaction — roll
+   * back far more than the tags. This mirrors {@link #saveContentTags} and {@link
+   * #addCollectionTag}, which were already hardened this way; only this method had been missed.
+   */
   @Transactional
   public void saveCollectionTags(Long collectionId, List<Long> tagIds) {
     String deleteSql = "DELETE FROM collection_tags WHERE collection_id = :collectionId";
@@ -193,9 +203,11 @@ public class TagRepository extends BaseDao {
 
     if (tagIds != null && !tagIds.isEmpty()) {
       String insertSql =
-          "INSERT INTO collection_tags (collection_id, tag_id) VALUES (:collectionId, :tagId)";
+          "INSERT INTO collection_tags (collection_id, tag_id) VALUES (:collectionId, :tagId) ON CONFLICT DO NOTHING";
       MapSqlParameterSource[] batchParams =
           tagIds.stream()
+              .filter(Objects::nonNull)
+              .distinct()
               .map(
                   tagId ->
                       createParameterSource()
@@ -204,13 +216,6 @@ public class TagRepository extends BaseDao {
               .toArray(MapSqlParameterSource[]::new);
       batchUpdate(insertSql, batchParams);
     }
-  }
-
-  @Transactional(readOnly = true)
-  public List<Long> findCollectionTagIds(Long collectionId) {
-    String sql = "SELECT tag_id FROM collection_tags WHERE collection_id = :collectionId";
-    MapSqlParameterSource params = createParameterSource().addValue("collectionId", collectionId);
-    return namedParameterJdbcTemplate.queryForList(sql, params, Long.class);
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/edens/zac/portfolio/backend/services/CollectionProcessingUtil.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/CollectionProcessingUtil.java
@@ -840,9 +840,9 @@ public class CollectionProcessingUtil {
   // =============================================================================
 
   /**
-   * Batch-load all images from the given child collection IDs. Used by the manage page for
-   * parent-type collections to aggregate images across child collections for cover image selection
-   * and content management.
+   * Batch-load all images from the given child collection IDs. Used by the manage page for a
+   * collection that holds child collections, to aggregate images across them for cover image
+   * selection and content management.
    *
    * @param childCollectionIds IDs of child collections to aggregate images from
    * @return List of image models from all child collections

--- a/src/main/java/edens/zac/portfolio/backend/services/CollectionService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/CollectionService.java
@@ -875,34 +875,36 @@ public class CollectionService {
    * Update collection tags using prev/new/remove pattern. Uses shared utility method from
    * ContentMutationUtil.
    *
+   * <p>Current tags are loaded as FULLY populated entities. {@link TagEntity} keys {@code
+   * equals}/{@code hashCode} on {@code tagName}, so a partially built tag carrying only an id
+   * hashes to 0 and never compares equal to anything. This method used to fabricate exactly such
+   * id-only entities, which meant a RETAINED tag — one present in both the current set and the
+   * request's {@code prev} list, where {@code updateTags} re-adds it fully loaded from the
+   * repository — landed in two different hash buckets and survived twice. That duplicate id then
+   * collided on the {@code collection_tags} primary key, and since {@code updateContent} is
+   * transactional the rollback discarded the entire save rather than just the tags. Loading full
+   * entities keeps this path identical to the content-side equivalent, {@link
+   * ContentMutationUtil#updateImageTagsOptimized}, which never had the bug because it already
+   * passes fully loaded tags.
+   *
    * @param collection The collection to update
    * @param tagUpdate The tag update containing remove/prev/newValue operations
    */
   private void updateCollectionTags(
       CollectionEntity collection, CollectionRequests.TagUpdate tagUpdate) {
-    // Load current tags
-    List<Long> tagIds = tagRepository.findCollectionTagIds(collection.getId());
     Set<TagEntity> currentTags =
-        tagIds.stream()
-            .map(
-                tagId -> {
-                  // Create minimal tag entity with just ID - full loading not needed for update
-                  TagEntity tag = new TagEntity();
-                  tag.setId(tagId);
-                  return tag;
-                })
-            .collect(Collectors.toSet());
+        new HashSet<>(tagRepository.findCollectionTags(collection.getId()));
 
     Set<TagEntity> updatedTags =
         contentMutationUtil.updateTags(
             currentTags, tagUpdate, null // No tracking needed for collection updates
             );
 
-    // Save updated tags
     List<Long> updatedTagIds =
         updatedTags.stream()
             .map(TagEntity::getId)
             .filter(Objects::nonNull)
+            .distinct()
             .collect(Collectors.toList());
     tagRepository.saveCollectionTags(collection.getId(), updatedTagIds);
     log.info("Updated tags for collection {}", collection.getId());

--- a/src/test/java/edens/zac/portfolio/backend/UserUpgradeIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/UserUpgradeIntegrationTest.java
@@ -1,0 +1,140 @@
+package edens.zac.portfolio.backend;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import edens.zac.portfolio.backend.controller.admin.AdminUserController;
+import edens.zac.portfolio.backend.controller.admin.UserRequests.CreateUserResponse;
+import edens.zac.portfolio.backend.controller.admin.UserRequests.UpgradeUserRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Round-trips {@link AdminUserController#upgradeUser} against a real Postgres container: seeds a
+ * tag-only {@code PERSON} row (mirroring {@link UserMergeIntegrationTest}'s seeding), upgrades it,
+ * and asserts the row's email/status flip, a single live invite is minted, and the person's image
+ * tag stays FK'd to the same (now-upgraded) id — proving associations are untouched. Also pins the
+ * two conflict rails (upgrading an account row, and an email already taken) leave state unchanged.
+ *
+ * <p>Invite delivery is not asserted here: {@code email.enabled} is false under the test profile,
+ * so {@code EmailService} short-circuits to a log line. The send itself is pinned by {@code
+ * AdminUserControllerTest.UpgradeUser}.
+ */
+class UserUpgradeIntegrationTest extends AbstractPostgresIntegrationTest {
+
+  @Autowired private JdbcTemplate jdbc;
+  @Autowired private AdminUserController adminUserController;
+
+  private Long newPerson(String name) {
+    jdbc.update(
+        "INSERT INTO users (name, webauthn_user_handle, status) VALUES (?, gen_random_uuid(), 'PERSON')",
+        name);
+    return jdbc.queryForObject("SELECT id FROM users WHERE name = ?", Long.class, name);
+  }
+
+  private Long newAccount(String email, String name) {
+    jdbc.update(
+        "INSERT INTO users (email, name, webauthn_user_handle, status) "
+            + "VALUES (?, ?, gen_random_uuid(), 'ACTIVE')",
+        email,
+        name);
+    return jdbc.queryForObject("SELECT id FROM users WHERE email = ?", Long.class, email);
+  }
+
+  private Long newImageTaggedWith(Long personId) {
+    jdbc.update("INSERT INTO content (content_type) VALUES ('IMAGE')");
+    Long contentId = jdbc.queryForObject("SELECT max(id) FROM content", Long.class);
+    jdbc.update(
+        "INSERT INTO content_image (id, title, image_url_web) VALUES (?, 'x', 'http://x')",
+        contentId);
+    jdbc.update(
+        "INSERT INTO content_image_people (content_id, person_id) VALUES (?, ?)",
+        contentId,
+        personId);
+    return contentId;
+  }
+
+  @Test
+  void upgradePersonSetsEmailFlipsStatusAndMintsInvite() {
+    Long person = newPerson("Abby Bennett");
+    Long taggedImage = newImageTaggedWith(person);
+
+    ResponseEntity<CreateUserResponse> response =
+        adminUserController.upgradeUser(person, new UpgradeUserRequest("abby@example.com"));
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().userId()).isEqualTo(person);
+    assertThat(response.getBody().inviteUrl()).contains("/invite/");
+
+    // Same row: email now set, status flipped to INVITED.
+    assertThat(jdbc.queryForObject("SELECT email FROM users WHERE id = ?", String.class, person))
+        .isEqualTo("abby@example.com");
+    assertThat(jdbc.queryForObject("SELECT status FROM users WHERE id = ?", String.class, person))
+        .isEqualTo("INVITED");
+
+    // Exactly one live (unused, unexpired) invite for the upgraded id.
+    assertThat(
+            jdbc.queryForObject(
+                "SELECT count(*) FROM user_invite "
+                    + "WHERE user_id = ? AND used_at IS NULL AND expires_at > now()",
+                Integer.class,
+                person))
+        .isEqualTo(1);
+
+    // The image tag still references the SAME id — associations were not moved.
+    assertThat(
+            jdbc.queryForObject(
+                "SELECT count(*) FROM content_image_people WHERE content_id = ? AND person_id = ?",
+                Integer.class,
+                taggedImage,
+                person))
+        .isEqualTo(1);
+  }
+
+  @Test
+  void upgradeIsRejectedForAnAccountRow() {
+    Long account = newAccount("real@example.com", "Real Account");
+
+    ResponseEntity<CreateUserResponse> response =
+        adminUserController.upgradeUser(account, new UpgradeUserRequest("new@example.com"));
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+
+    // Untouched: an account row's email and status must not change.
+    assertThat(jdbc.queryForObject("SELECT email FROM users WHERE id = ?", String.class, account))
+        .isEqualTo("real@example.com");
+    assertThat(jdbc.queryForObject("SELECT status FROM users WHERE id = ?", String.class, account))
+        .isEqualTo("ACTIVE");
+    assertThat(
+            jdbc.queryForObject(
+                "SELECT count(*) FROM user_invite WHERE user_id = ?", Integer.class, account))
+        .isZero();
+  }
+
+  @Test
+  void upgradeRejectsEmailAlreadyTaken() {
+    Long account = newAccount("taken@example.com", "Existing");
+    Long person = newPerson("Abby Bennett");
+
+    ResponseEntity<CreateUserResponse> response =
+        adminUserController.upgradeUser(person, new UpgradeUserRequest("taken@example.com"));
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+
+    // The PERSON stays a PERSON with a NULL email; no invite minted.
+    assertThat(jdbc.queryForObject("SELECT status FROM users WHERE id = ?", String.class, person))
+        .isEqualTo("PERSON");
+    assertThat(jdbc.queryForObject("SELECT email FROM users WHERE id = ?", String.class, person))
+        .isNull();
+    assertThat(
+            jdbc.queryForObject(
+                "SELECT count(*) FROM user_invite WHERE user_id = ?", Integer.class, person))
+        .isZero();
+    // The existing account is untouched.
+    assertThat(jdbc.queryForObject("SELECT email FROM users WHERE id = ?", String.class, account))
+        .isEqualTo("taken@example.com");
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/controller/admin/AdminControllerTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/admin/AdminControllerTest.java
@@ -371,9 +371,8 @@ class AdminControllerTest {
   }
 
   @Test
-  @DisplayName(
-      "POST /content/images/create-collection should accept booleans without legacy type param")
-  void createCollectionWithImages_typeOmitted_acceptsClientBlogBooleans() throws Exception {
+  @DisplayName("POST /content/images/create-collection should accept the isClient/isBlog booleans")
+  void createCollectionWithImages_acceptsClientBlogBooleans() throws Exception {
     // Arrange
     MockMultipartFile file =
         new MockMultipartFile("files", "photo.jpg", MediaType.IMAGE_JPEG_VALUE, "img".getBytes());
@@ -384,7 +383,7 @@ class AdminControllerTest {
             any(CollectionRequests.Create.class), anyList(), anyMap()))
         .thenReturn(uploadResult);
 
-    // Act & Assert: new FE sends only title + booleans (no legacy type param).
+    // Act & Assert: the frontend sends title + the two booleans, and nothing else.
     mockMvc
         .perform(
             multipart("/api/admin/content/images/create-collection")
@@ -404,12 +403,11 @@ class AdminControllerTest {
   }
 
   @Test
-  @DisplayName(
-      "POST /content/images/create-collection with neither type nor booleans binds all three null")
-  void createCollectionWithImages_neitherTypeNorBooleans_bindsAllNull() throws Exception {
-    // Multipart is the only write surface where the MISC fold is unobservable in-band, so pin
-    // that an omitted type and omitted booleans reach the service as null (the compat layer,
-    // not the binder, is what decides the fold).
+  @DisplayName("POST /content/images/create-collection with no booleans binds both of them null")
+  void createCollectionWithImages_noBooleans_bindsBothNull() throws Exception {
+    // Multipart is the only write surface where "neither flag" is unobservable in-band, so pin
+    // that omitted booleans reach the service as null rather than false: CollectionFlags, not the
+    // binder, is what turns a null into a stored false.
     MockMultipartFile file =
         new MockMultipartFile("files", "photo.jpg", MediaType.IMAGE_JPEG_VALUE, "img".getBytes());
 

--- a/src/test/java/edens/zac/portfolio/backend/controller/admin/AdminUserControllerTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/admin/AdminUserControllerTest.java
@@ -266,6 +266,177 @@ class AdminUserControllerTest {
   }
 
   @Nested
+  class UpgradeUser {
+
+    private AppUserEntity person(Long id) {
+      return AppUserEntity.builder().id(id).name("Abby Bennett").status(UserStatus.PERSON).build();
+    }
+
+    @Test
+    void upgradeReturns200WithUserIdAndInviteUrl() throws Exception {
+      when(appUserRepository.findById(5L)).thenReturn(Optional.of(person(5L)));
+      when(appUserRepository.findByEmail("person@example.com")).thenReturn(Optional.empty());
+      when(userInviteService.regenerateInvite(5L, "person@example.com")).thenReturn("raw-token");
+
+      mockMvc
+          .perform(
+              post("/api/admin/users/5/upgrade")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"email\":\"person@example.com\"}"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.userId").value(5))
+          .andExpect(jsonPath("$.inviteUrl").value("https://app.example.com/invite/raw-token"));
+
+      verify(appUserRepository).updateEmail(5L, "person@example.com");
+      verify(appUserRepository).updateStatus(5L, UserStatus.INVITED);
+    }
+
+    @Test
+    void upgradeEmailsTheInviteToTheUpgradedPerson() throws Exception {
+      // Upgrade is an invite-minting endpoint like create-user and regenerate-invite, so it must
+      // deliver the link too -- the person's existing tag name is the greeting name.
+      when(appUserRepository.findById(5L)).thenReturn(Optional.of(person(5L)));
+      when(appUserRepository.findByEmail("person@example.com")).thenReturn(Optional.empty());
+      when(userInviteService.regenerateInvite(5L, "person@example.com")).thenReturn("raw-token");
+
+      mockMvc
+          .perform(
+              post("/api/admin/users/5/upgrade")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"email\":\"person@example.com\"}"))
+          .andExpect(status().isOk());
+
+      verify(emailService)
+          .sendInviteEmail(
+              "person@example.com", "Abby Bennett", "https://app.example.com/invite/raw-token");
+    }
+
+    @Test
+    void upgradeNormalizesEmailToLowercase() throws Exception {
+      when(appUserRepository.findById(5L)).thenReturn(Optional.of(person(5L)));
+      when(appUserRepository.findByEmail("person@example.com")).thenReturn(Optional.empty());
+      when(userInviteService.regenerateInvite(5L, "person@example.com")).thenReturn("raw-token");
+
+      mockMvc
+          .perform(
+              post("/api/admin/users/5/upgrade")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"email\":\"PERSON@EXAMPLE.COM\"}"))
+          .andExpect(status().isOk());
+
+      // Both the duplicate check and the write must see the lowercased email.
+      verify(appUserRepository).findByEmail("person@example.com");
+      verify(appUserRepository).updateEmail(5L, "person@example.com");
+    }
+
+    @Test
+    void upgradeUnknownUserReturns404() throws Exception {
+      when(appUserRepository.findById(999L)).thenReturn(Optional.empty());
+
+      mockMvc
+          .perform(
+              post("/api/admin/users/999/upgrade")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"email\":\"person@example.com\"}"))
+          .andExpect(status().isNotFound());
+
+      verify(appUserRepository, never()).updateEmail(anyLong(), anyString());
+      verify(appUserRepository, never()).updateStatus(anyLong(), any());
+      verify(userInviteService, never()).regenerateInvite(anyLong(), anyString());
+      verify(emailService, never()).sendInviteEmail(anyString(), any(), anyString());
+    }
+
+    @Test
+    void upgradeNonPersonUserReturns409() throws Exception {
+      // Only a tag-only PERSON can be upgraded: an ACTIVE/INVITED/DISABLED row is already an
+      // account, so upgrading it (clobbering its email, resetting its status) is a conflict.
+      for (UserStatus status :
+          new UserStatus[] {UserStatus.ACTIVE, UserStatus.INVITED, UserStatus.DISABLED}) {
+        AppUserEntity account =
+            AppUserEntity.builder().id(5L).email("real@example.com").status(status).build();
+        when(appUserRepository.findById(5L)).thenReturn(Optional.of(account));
+
+        mockMvc
+            .perform(
+                post("/api/admin/users/5/upgrade")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\"email\":\"person@example.com\"}"))
+            .andExpect(status().isConflict());
+      }
+
+      verify(appUserRepository, never()).findByEmail(anyString());
+      verify(appUserRepository, never()).updateEmail(anyLong(), anyString());
+      verify(appUserRepository, never()).updateStatus(anyLong(), any());
+      verify(userInviteService, never()).regenerateInvite(anyLong(), anyString());
+      verify(emailService, never()).sendInviteEmail(anyString(), any(), anyString());
+    }
+
+    @Test
+    void upgradeEmailOwnedByAnotherUserReturns409() throws Exception {
+      when(appUserRepository.findById(5L)).thenReturn(Optional.of(person(5L)));
+      when(appUserRepository.findByEmail("person@example.com"))
+          .thenReturn(Optional.of(AppUserEntity.builder().id(1L).build()));
+
+      mockMvc
+          .perform(
+              post("/api/admin/users/5/upgrade")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"email\":\"person@example.com\"}"))
+          .andExpect(status().isConflict());
+
+      // 409 is a normal return, so @Transactional commits this path: NO field may have been
+      // written by the time the conflict is detected, or a partial upgrade would persist.
+      verify(appUserRepository, never()).updateEmail(anyLong(), anyString());
+      verify(appUserRepository, never()).updateStatus(anyLong(), any());
+      verify(userInviteService, never()).regenerateInvite(anyLong(), anyString());
+      verify(emailService, never()).sendInviteEmail(anyString(), any(), anyString());
+    }
+
+    @Test
+    void upgradeMissingEmailReturns400() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/admin/users/5/upgrade")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{}"))
+          .andExpect(status().isBadRequest());
+
+      verify(appUserRepository, never()).findById(anyLong());
+      verify(appUserRepository, never()).updateEmail(anyLong(), anyString());
+    }
+
+    @Test
+    void upgradeInvalidEmailReturns400() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/admin/users/5/upgrade")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"email\":\"not-an-email\"}"))
+          .andExpect(status().isBadRequest());
+
+      verify(appUserRepository, never()).findById(anyLong());
+    }
+
+    @Test
+    void upgradeFlipsStatusToInvitedAndLeavesNameUntouched() throws Exception {
+      when(appUserRepository.findById(5L)).thenReturn(Optional.of(person(5L)));
+      when(appUserRepository.findByEmail("person@example.com")).thenReturn(Optional.empty());
+      when(userInviteService.regenerateInvite(5L, "person@example.com")).thenReturn("raw-token");
+
+      mockMvc
+          .perform(
+              post("/api/admin/users/5/upgrade")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"email\":\"person@example.com\"}"))
+          .andExpect(status().isOk());
+
+      // The person's tagged name is preserved as the account display name — never overwritten.
+      verify(appUserRepository).updateStatus(5L, UserStatus.INVITED);
+      verify(appUserRepository, never()).updateName(anyLong(), anyString());
+    }
+  }
+
+  @Nested
   class GetUser {
 
     @Test

--- a/src/test/java/edens/zac/portfolio/backend/controller/prod/ContentDownloadAuthTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/controller/prod/ContentDownloadAuthTest.java
@@ -32,11 +32,20 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 /**
- * Verifies the CLIENT-membership download bypass in {@link ContentDownloadControllerProd}: a
- * principal holding a CLIENT membership is authorized without a cookie (302 redirect to the
- * presigned URL); no CLIENT membership yields 401; and anonymous paths still consult the cookie
- * gate unchanged. Auth semantics only — the redirect target is produced by {@link
- * DownloadUrlService}, stubbed here.
+ * Verifies the two non-per-slug-cookie ways a download is authorized in {@link
+ * ContentDownloadControllerProd}.
+ *
+ * <ul>
+ *   <li>CLIENT membership: a principal holding a CLIENT membership is authorized without a cookie
+ *       (302 redirect to the presigned URL); no CLIENT membership yields 401; and anonymous paths
+ *       still consult the cookie gate unchanged.
+ *   <li>Shared password-fingerprint cookie: a viewer who unlocked a PARENT gallery downloads from a
+ *       propagated CLIENT_GALLERY child without re-prompting, because both galleries share the
+ *       password and therefore the {@code gallery_access_pw_<fingerprint>} cookie.
+ * </ul>
+ *
+ * <p>Auth semantics only — the redirect target is produced by {@link DownloadUrlService}, stubbed
+ * here.
  */
 @ExtendWith(MockitoExtension.class)
 class ContentDownloadAuthTest {
@@ -90,6 +99,22 @@ class ContentDownloadAuthTest {
         .slug("open-portfolio")
         .visibility(CollectionVisibility.LISTED)
         .galleryPassword(null)
+        .build();
+  }
+
+  /**
+   * A CLIENT_GALLERY child that inherited the parent's password by propagation. Same password as
+   * {@link #protectedGallery()}, different slug — so it shares the fingerprint cookie but has no
+   * per-slug cookie of its own.
+   */
+  private static CollectionEntity propagatedChildGallery() {
+    return CollectionEntity.builder()
+        .id(5L)
+        .title("Smith Wedding — Prints")
+        .slug("smith-wedding-prints")
+        .visibility(CollectionVisibility.UNLISTED)
+        .isClient(true)
+        .galleryPassword("sunshine")
         .build();
   }
 
@@ -261,6 +286,109 @@ class ContentDownloadAuthTest {
       verify(contentService, never()).resolveCollectionDownloadEntries(any(), any(), any());
       verify(downloadUrlService, never()).presignObject(any(), any(), any());
       verify(downloadUrlService, never()).zipToS3AndPresign(any(), any());
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  //  Shared password-fingerprint cookie (PARENT unlock -> propagated CHILD download)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * The paying-client delivery path. Unlocking the PARENT issues two cookies: {@code
+   * gallery_access_<parent-slug>} and the shared {@code gallery_access_pw_<fingerprint>}. Only the
+   * second one is meaningful for a propagated child, whose slug differs. The download gate used the
+   * per-slug-only overload while the read gate used the fingerprint-aware one, so the child
+   * rendered with an ENABLED download button that 401'd.
+   */
+  @Nested
+  class SharedPasswordUnlock {
+
+    private static final String FINGERPRINT = "fp-sunshine";
+    private static final String PW_COOKIE = "gallery_access_pw_" + FINGERPRINT;
+
+    @Test
+    void imageDownload_fingerprintCookieFromTheParent_authorizesTheChild() throws Exception {
+      when(contentService.findProtectedCollectionsForImage(10L))
+          .thenReturn(List.of(propagatedChildGallery()));
+      when(clientGalleryAuthService.passwordFingerprint("sunshine")).thenReturn(FINGERPRINT);
+      when(clientGalleryAuthService.validatePasswordAccessToken("sunshine", "pw-tok"))
+          .thenReturn(true);
+      when(contentService.resolveImageDownload(10L, "web")).thenReturn(webResolution("img.webp"));
+      when(downloadUrlService.presignObject(any(), any(), any())).thenReturn(PRESIGNED);
+
+      mockMvc
+          .perform(
+              get("/api/read/content/images/10/download")
+                  .cookie(new jakarta.servlet.http.Cookie(PW_COOKIE, "pw-tok")))
+          .andExpect(status().isFound());
+    }
+
+    @Test
+    void collectionDownload_fingerprintCookieFromTheParent_authorizesTheChild() throws Exception {
+      when(collectionService.findEntityBySlug("smith-wedding-prints"))
+          .thenReturn(propagatedChildGallery());
+      when(clientGalleryAuthService.passwordFingerprint("sunshine")).thenReturn(FINGERPRINT);
+      when(clientGalleryAuthService.validatePasswordAccessToken("sunshine", "pw-tok"))
+          .thenReturn(true);
+      when(contentService.resolveCollectionDownloadEntries(5L, "web", null))
+          .thenReturn(List.of(webResolution("img.webp")));
+      when(downloadUrlService.presignObject(any(), any(), any())).thenReturn(PRESIGNED);
+
+      mockMvc
+          .perform(
+              get("/api/read/collections/smith-wedding-prints/download")
+                  .cookie(new jakarta.servlet.http.Cookie(PW_COOKIE, "pw-tok")))
+          .andExpect(status().isFound());
+    }
+
+    @Test
+    void collectionDownload_fingerprintCookieForADifferentPassword_gets401() throws Exception {
+      // The cookie NAME carries the fingerprint, so a cookie minted by an unrelated password group
+      // is simply not read for this gallery: no per-slug cookie, no matching fingerprint, 401.
+      when(collectionService.findEntityBySlug("smith-wedding-prints"))
+          .thenReturn(propagatedChildGallery());
+      when(clientGalleryAuthService.passwordFingerprint("sunshine")).thenReturn(FINGERPRINT);
+
+      mockMvc
+          .perform(
+              get("/api/read/collections/smith-wedding-prints/download")
+                  .cookie(
+                      new jakarta.servlet.http.Cookie("gallery_access_pw_fp-moonlight", "pw-tok")))
+          .andExpect(status().isUnauthorized());
+
+      verify(contentService, never()).resolveCollectionDownloadEntries(any(), any(), any());
+      verify(downloadUrlService, never()).presignObject(any(), any(), any());
+      verify(downloadUrlService, never()).zipToS3AndPresign(any(), any());
+    }
+
+    @Test
+    void imageDownload_fingerprintCookie_stillFailsClosedOnAForeignGallery() throws Exception {
+      // Widening the gate to fingerprint cookies must not weaken "EVERY protected parent". The
+      // image also lives in jones-wedding, whose different password produces a different
+      // fingerprint, so the sunshine cookie authorizes one parent and not the other.
+      CollectionEntity foreignGallery =
+          CollectionEntity.builder()
+              .id(3L)
+              .title("Jones Wedding")
+              .slug("jones-wedding")
+              .visibility(CollectionVisibility.UNLISTED)
+              .galleryPassword("moonlight")
+              .build();
+      when(contentService.findProtectedCollectionsForImage(10L))
+          .thenReturn(List.of(propagatedChildGallery(), foreignGallery));
+      when(clientGalleryAuthService.passwordFingerprint("sunshine")).thenReturn(FINGERPRINT);
+      when(clientGalleryAuthService.validatePasswordAccessToken("sunshine", "pw-tok"))
+          .thenReturn(true);
+      when(clientGalleryAuthService.passwordFingerprint("moonlight")).thenReturn("fp-moonlight");
+
+      mockMvc
+          .perform(
+              get("/api/read/content/images/10/download")
+                  .cookie(new jakarta.servlet.http.Cookie(PW_COOKIE, "pw-tok")))
+          .andExpect(status().isUnauthorized());
+
+      verify(contentService, never()).resolveImageDownload(any(), any());
+      verify(downloadUrlService, never()).presignObject(any(), any(), any());
     }
   }
 }

--- a/src/test/java/edens/zac/portfolio/backend/dao/CollectionFlagRepositoryIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/dao/CollectionFlagRepositoryIntegrationTest.java
@@ -15,10 +15,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 /**
- * Integration coverage for the V50 is_client / is_blog boolean predicates. Runs the real V50
- * migration on Testcontainers Postgres. Verifies: the boolean-keyed repository queries key on the
- * flags (NOT the legacy type column), the derived parent-of-galleries query (no parent-side type
- * filter), the blog-by-date get-or-create key, save round-tripping of the flags, and the V50
+ * Integration coverage for the is_client / is_blog boolean predicates introduced by V50. Runs the
+ * real V50 migration on Testcontainers Postgres. Verifies: the boolean-keyed repository queries key
+ * on the flags, the derived parent-of-galleries query (structural, with no discriminator on the
+ * parent side), the blog-by-date get-or-create key, save round-tripping of the flags, and the V50
  * label-tag seeds.
  *
  * <p>This class inserts roughly 20 collections into the SHARED singleton container, whose harness
@@ -95,7 +95,9 @@ class CollectionFlagRepositoryIntegrationTest extends AbstractPostgresIntegratio
   }
 
   @Test
-  void findListedBlogsOrdered_keysOnIsBlogNotType() {
+  void findListedBlogsOrdered_keysOnIsBlogAndVisibility() {
+    // is_blog is the only thing that makes a collection a blog: every LISTED row carrying it is
+    // returned regardless of what else the row looks like...
     CollectionEntity blogFlagged =
         saveCollection(
             "flag-blog-flagged",
@@ -103,18 +105,17 @@ class CollectionFlagRepositoryIntegrationTest extends AbstractPostgresIntegratio
             true,
             CollectionVisibility.LISTED,
             LocalDate.of(2026, 2, 1));
-    // Boolean is the truth: a MISC-typed row with is_blog=true must be returned...
-    CollectionEntity miscButBlog =
+    CollectionEntity secondBlogFlagged =
         saveCollection(
-            "flag-misc-but-blog",
+            "flag-blog-flagged-second",
             false,
             true,
             CollectionVisibility.LISTED,
             LocalDate.of(2026, 2, 2));
-    // ...and a BLOG-typed row with is_blog=false must NOT be.
-    CollectionEntity blogTypeNoFlag =
+    // ...and a LISTED row without the flag is NOT a blog, however it is titled or slugged.
+    CollectionEntity blogNamedNoFlag =
         saveCollection(
-            "flag-blog-type-no-flag",
+            "flag-blog-named-no-flag",
             false,
             false,
             CollectionVisibility.LISTED,
@@ -132,8 +133,8 @@ class CollectionFlagRepositoryIntegrationTest extends AbstractPostgresIntegratio
             .map(CollectionEntity::getId)
             .toList();
 
-    assertThat(ids).contains(blogFlagged.getId(), miscButBlog.getId());
-    assertThat(ids).doesNotContain(blogTypeNoFlag.getId(), unlistedBlog.getId());
+    assertThat(ids).contains(blogFlagged.getId(), secondBlogFlagged.getId());
+    assertThat(ids).doesNotContain(blogNamedNoFlag.getId(), unlistedBlog.getId());
   }
 
   @Test
@@ -219,24 +220,24 @@ class CollectionFlagRepositoryIntegrationTest extends AbstractPostgresIntegratio
             CollectionVisibility.LISTED,
             LocalDate.of(2026, 5, 1));
 
-    // PARENT-typed wrapper with a visible client child: qualifies (as before).
-    CollectionEntity parentTyped =
+    // Wrapper carrying neither flag, holding a visible client child: qualifies as a derived parent.
+    CollectionEntity wrapperOfClientChild =
         saveCollection(
-            "flag-parent-typed",
+            "flag-parent-wrapper",
             false,
             false,
             CollectionVisibility.LISTED,
             LocalDate.of(2026, 5, 2));
-    CollectionEntity childOfParentTyped =
+    CollectionEntity clientChildOfWrapper =
         saveCollection(
-            "flag-parent-typed-child",
+            "flag-parent-wrapper-child",
             true,
             false,
             CollectionVisibility.LISTED,
             LocalDate.of(2026, 5, 3));
-    linkChild(parentTyped.getId(), childOfParentTyped.getId(), true);
+    linkChild(wrapperOfClientChild.getId(), clientChildOfWrapper.getId(), true);
 
-    // Derived parent: NOT typed PARENT, but has a visible is_client child -> must now qualify.
+    // A second derived parent, to pin that qualification is per-row rather than a one-off.
     CollectionEntity derivedParent =
         saveCollection(
             "flag-parent-derived",
@@ -312,9 +313,9 @@ class CollectionFlagRepositoryIntegrationTest extends AbstractPostgresIntegratio
     assertThat(ids)
         .contains(
             standaloneGallery.getId(),
-            parentTyped.getId(),
+            wrapperOfClientChild.getId(),
             derivedParent.getId(),
-            childOfParentTyped.getId(),
+            clientChildOfWrapper.getId(),
             childOfDerived.getId(),
             softRemovedChild.getId());
     assertThat(ids)
@@ -507,8 +508,8 @@ class CollectionFlagRepositoryIntegrationTest extends AbstractPostgresIntegratio
 
   @Test
   void hasClientGalleryChildren_falseWhenNoChildIsClient() {
-    // The boolean is the truth, not the type: a CLIENT_GALLERY-typed child with is_client = false
-    // must not qualify.
+    // is_client on the child is the whole test: a child that merely looks like a gallery, but does
+    // not carry the flag, must not qualify its parent.
     CollectionEntity wrapper =
         saveCollection(
             "s2-wrapper-no-client",

--- a/src/test/java/edens/zac/portfolio/backend/dao/TagRepositoryTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/dao/TagRepositoryTest.java
@@ -3,9 +3,12 @@ package edens.zac.portfolio.backend.dao;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,6 +29,7 @@ class TagRepositoryTest {
 
   @Captor private ArgumentCaptor<String> sqlCaptor;
   @Captor private ArgumentCaptor<SqlParameterSource> paramsCaptor;
+  @Captor private ArgumentCaptor<SqlParameterSource[]> batchCaptor;
 
   private TagRepository tagRepository;
 
@@ -73,5 +77,34 @@ class TagRepositoryTest {
     verify(namedParameterJdbcTemplate).update(anyString(), paramsCaptor.capture());
     MapSqlParameterSource params = (MapSqlParameterSource) paramsCaptor.getValue();
     assertThat(params.getValue("collectionId")).isNull();
+  }
+
+  /**
+   * {@code collection_tags} is keyed on {@code (collection_id, tag_id)}. A repeated id used to
+   * abort the whole batch with a {@code DataIntegrityViolationException}, rolling back the caller's
+   * entire transaction. The insert must be both deduplicated and idempotent.
+   */
+  @Test
+  void saveCollectionTags_duplicateIds_insertedOnceAndIdempotently() {
+    tagRepository.saveCollectionTags(5L, Arrays.asList(72L, 72L, 9L, null));
+
+    verify(namedParameterJdbcTemplate).batchUpdate(sqlCaptor.capture(), batchCaptor.capture());
+
+    assertThat(sqlCaptor.getValue()).contains("ON CONFLICT DO NOTHING");
+    SqlParameterSource[] batch = batchCaptor.getValue();
+    assertThat(batch).hasSize(2);
+    assertThat(Arrays.stream(batch).map(p -> p.getValue("tagId")))
+        .containsExactlyInAnyOrder(72L, 9L);
+    assertThat(Arrays.stream(batch).map(p -> p.getValue("collectionId"))).containsOnly(5L);
+  }
+
+  @Test
+  void saveCollectionTags_emptyList_deletesButSkipsInsert() {
+    tagRepository.saveCollectionTags(5L, List.of());
+
+    verify(namedParameterJdbcTemplate).update(sqlCaptor.capture(), any(SqlParameterSource.class));
+    assertThat(sqlCaptor.getValue()).startsWith("DELETE FROM collection_tags");
+    verify(namedParameterJdbcTemplate, never())
+        .batchUpdate(anyString(), any(SqlParameterSource[].class));
   }
 }

--- a/src/test/java/edens/zac/portfolio/backend/model/ContentRequestsTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/model/ContentRequestsTest.java
@@ -207,15 +207,6 @@ class ContentRequestsTest {
   }
 
   @Test
-  void collectionCreate_nullType_isValid() {
-    // Dual-compat window: type is optional (new frontends send only booleans + title; a create
-    // with neither type nor booleans resolves to MISC in the mapping layer).
-    var create = new CollectionRequests.Create("My Blog");
-    Set<ConstraintViolation<CollectionRequests.Create>> violations = validator.validate(create);
-    assertThat(violations).isEmpty();
-  }
-
-  @Test
   void collectionCreate_nullTitle_hasViolation() {
     var create = new CollectionRequests.Create(null);
     Set<ConstraintViolation<CollectionRequests.Create>> violations = validator.validate(create);

--- a/src/test/java/edens/zac/portfolio/backend/services/CollectionProcessingUtilTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/CollectionProcessingUtilTest.java
@@ -463,10 +463,11 @@ class CollectionProcessingUtilTest {
 
   @Test
   void applyBasicUpdates_partialIsBlogFalse_onClientGallery_doesNotDemote() {
-    // Wiring-seam pin: applyBasicUpdates must hand the entity's CURRENT booleans to the compat
-    // resolver, not just its legacy type column. Without that, {"isBlog": false} alone clears
-    // is_client on a drifted row today, and demotes every client gallery once phase 2 nulls the
-    // type column. Mutating entity.getType() to null must not change the outcome.
+    // Wiring-seam pin: applyBasicUpdates must hand the entity's CURRENT booleans to
+    // CollectionFlags.
+    // The flags are the only stored discriminators, so a partial update that names one of them must
+    // read the other off the entity -- otherwise {"isBlog": false} alone clears is_client and
+    // demotes every client gallery.
     testEntity.setClient(true);
     testEntity.setBlog(false);
 
@@ -477,9 +478,9 @@ class CollectionProcessingUtilTest {
 
   @Test
   void applyBasicUpdates_isClientDemotion_clearsGalleryAccess() {
-    // updateGalleryAccess refuses non-CLIENT_GALLERY/PARENT targets and the read gate keys on
-    // galleryPassword != null, so a demoted collection would otherwise keep an enforced password
-    // that no endpoint can clear.
+    // updateGalleryAccess only accepts a collection that is itself a client gallery or holds one
+    // (isClient() || hasClientGalleryChildren), and the read gate keys on galleryPassword != null,
+    // so a demoted collection would otherwise keep an enforced password that no endpoint can clear.
     testEntity.setClient(true);
     testEntity.setGalleryPassword("secret");
     testEntity.setRecipientEmails(new ArrayList<>(List.of("client@example.com")));
@@ -499,10 +500,10 @@ class CollectionProcessingUtilTest {
   }
 
   @Test
-  void applyBasicUpdates_noTypeOrFlagsInRequest_leavesTypeAndFlagsUntouched() {
+  void applyBasicUpdates_noFlagsInRequest_leavesFlagsUntouched() {
     testEntity.setBlog(true);
 
-    // Description-only update: no type field and no booleans in the request.
+    // Description-only update: neither boolean is present in the request.
     util.applyBasicUpdates(
         testEntity,
         new CollectionRequests.Update(

--- a/src/test/java/edens/zac/portfolio/backend/services/CollectionServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/CollectionServiceTest.java
@@ -929,10 +929,10 @@ class CollectionServiceTest {
   }
 
   @Nested
-  class ParentTypeCollections {
+  class ParentCollections {
 
     @Test
-    void getUpdateCollectionData_parentType_aggregatesChildCollectionImages() {
+    void getUpdateCollectionData_derivedParent_aggregatesChildCollectionImages() {
       String slug = "photography";
       CollectionEntity parentEntity =
           CollectionEntity.builder()
@@ -1177,10 +1177,10 @@ class CollectionServiceTest {
     @Test
     void nonParentWrapperOfClientGalleries_keepsUnlistedChildren() {
       // Regression pin: findClientGalleriesAndQualifyingParents admits ANY collection with a
-      // visible client child (no parent-side type filter), so the render path must key the
-      // client-gallery context on the flags too. Keying it on type == PARENT stripped every
-      // UNLISTED child out of a MISC/PORTFOLIO wrapper (e.g. the auto-linked 'staging'
-      // collection) and rendered an empty tile.
+      // visible client child, applying no discriminator to the parent side, so the render path
+      // must key the client-gallery context on the child flags too. A parent-side gate stripped
+      // every UNLISTED child out of an ordinary wrapper carrying neither flag (e.g. the
+      // auto-linked 'staging' collection) and rendered an empty tile.
       String slug = "staging";
       CollectionEntity wrapper =
           CollectionEntity.builder()

--- a/src/test/java/edens/zac/portfolio/backend/services/CollectionServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/CollectionServiceTest.java
@@ -26,6 +26,7 @@ import edens.zac.portfolio.backend.entity.CollectionEntity;
 import edens.zac.portfolio.backend.entity.ContentCollectionEntity;
 import edens.zac.portfolio.backend.entity.ContentImageEntity;
 import edens.zac.portfolio.backend.entity.LocationEntity;
+import edens.zac.portfolio.backend.entity.TagEntity;
 import edens.zac.portfolio.backend.model.AuthPrincipal;
 import edens.zac.portfolio.backend.model.CollectionModel;
 import edens.zac.portfolio.backend.model.CollectionRequests;
@@ -89,6 +90,7 @@ class CollectionServiceTest {
   @InjectMocks private CollectionService service;
 
   @Captor private ArgumentCaptor<Map<Long, Integer>> mapCaptor;
+  @Captor private ArgumentCaptor<List<Long>> tagIdsCaptor;
 
   private CollectionEntity testCollection;
 
@@ -2253,6 +2255,114 @@ class CollectionServiceTest {
 
       assertThat(response.childCollectionImages()).isNotNull();
       verify(collectionProcessingUtil).loadImagesFromChildCollections(List.of(51L));
+    }
+  }
+
+  /**
+   * Regression coverage for the tag-dedupe defect: editing a collection that already had tags threw
+   * {@code DataIntegrityViolationException} on the {@code collection_tags} primary key, and because
+   * {@code updateContent} is {@code @Transactional} the rollback discarded the whole save, not just
+   * the tags.
+   *
+   * <p>These tests drive the REAL {@link ContentMutationUtil#updateTags} through the mocked
+   * collaborator, because the defect only appears at that seam: the service supplied {@code
+   * currentTags} whose members were missing {@code tagName}, and {@link
+   * edens.zac.portfolio.backend.entity.TagEntity} keys equality on the name. A stubbed {@code
+   * updateTags} would hide the bug entirely.
+   */
+  @Nested
+  @DisplayName("updateCollectionTags")
+  class UpdateCollectionTags {
+
+    private CollectionRequests.Update updateWithTags(Long id, CollectionRequests.TagUpdate tags) {
+      return new CollectionRequests.Update(
+          id, null, null, null, null, null, null, null, null, null, null, null, null, tags, null,
+          null, null);
+    }
+
+    /**
+     * Route {@code contentMutationUtil.updateTags} to a real instance backed by the same mocked
+     * repositories, so the prev/new/remove merge and the entity equality it depends on are the
+     * production ones.
+     */
+    private void delegateUpdateTagsToRealUtil() {
+      ContentMutationUtil real =
+          new ContentMutationUtil(
+              contentRepository,
+              collectionRepository,
+              tagRepository,
+              mock(edens.zac.portfolio.backend.dao.PersonRepository.class),
+              locationRepository);
+      when(contentMutationUtil.updateTags(any(), any(), any()))
+          .thenAnswer(
+              invocation ->
+                  real.updateTags(
+                      invocation.getArgument(0),
+                      invocation.getArgument(1),
+                      invocation.getArgument(2)));
+    }
+
+    @Test
+    @DisplayName("a retained tag is written exactly once, not duplicated")
+    void updateContent_retainedTag_writesEachTagIdExactlyOnce() {
+      Long collectionId = 1L;
+      TagEntity landscape = TagEntity.builder().id(72L).tagName("landscape").build();
+
+      when(collectionRepository.findById(collectionId)).thenReturn(Optional.of(testCollection));
+      when(tagRepository.findCollectionTags(collectionId)).thenReturn(List.of(landscape));
+      when(tagRepository.findById(72L)).thenReturn(Optional.of(landscape));
+      delegateUpdateTagsToRealUtil();
+
+      service.updateContent(
+          collectionId,
+          updateWithTags(collectionId, new CollectionRequests.TagUpdate(List.of(72L), null, null)));
+
+      verify(tagRepository).saveCollectionTags(eq(collectionId), tagIdsCaptor.capture());
+      assertThat(tagIdsCaptor.getValue()).containsExactly(72L);
+    }
+
+    @Test
+    @DisplayName("a retained tag alongside an added tag keeps both, each once")
+    void updateContent_retainedTagPlusNewTag_writesBothExactlyOnce() {
+      Long collectionId = 1L;
+      TagEntity landscape = TagEntity.builder().id(72L).tagName("landscape").build();
+      TagEntity portrait = TagEntity.builder().id(9L).tagName("portrait").build();
+
+      when(collectionRepository.findById(collectionId)).thenReturn(Optional.of(testCollection));
+      when(tagRepository.findCollectionTags(collectionId)).thenReturn(List.of(landscape));
+      when(tagRepository.findById(72L)).thenReturn(Optional.of(landscape));
+      when(tagRepository.findByTagNameIgnoreCase("portrait")).thenReturn(Optional.of(portrait));
+      delegateUpdateTagsToRealUtil();
+
+      service.updateContent(
+          collectionId,
+          updateWithTags(
+              collectionId,
+              new CollectionRequests.TagUpdate(List.of(72L), List.of("portrait"), null)));
+
+      verify(tagRepository).saveCollectionTags(eq(collectionId), tagIdsCaptor.capture());
+      assertThat(tagIdsCaptor.getValue()).containsExactlyInAnyOrder(72L, 9L);
+    }
+
+    @Test
+    @DisplayName("removing one of two attached tags leaves only the survivor")
+    void updateContent_removesTag_writesOnlySurvivor() {
+      Long collectionId = 1L;
+      TagEntity landscape = TagEntity.builder().id(72L).tagName("landscape").build();
+      TagEntity portrait = TagEntity.builder().id(9L).tagName("portrait").build();
+
+      when(collectionRepository.findById(collectionId)).thenReturn(Optional.of(testCollection));
+      when(tagRepository.findCollectionTags(collectionId)).thenReturn(List.of(landscape, portrait));
+      when(tagRepository.findById(72L)).thenReturn(Optional.of(landscape));
+      delegateUpdateTagsToRealUtil();
+
+      service.updateContent(
+          collectionId,
+          updateWithTags(
+              collectionId, new CollectionRequests.TagUpdate(List.of(72L), null, List.of(9L))));
+
+      verify(tagRepository).saveCollectionTags(eq(collectionId), tagIdsCaptor.capture());
+      assertThat(tagIdsCaptor.getValue()).containsExactly(72L);
     }
   }
 }

--- a/src/test/java/edens/zac/portfolio/backend/services/TagServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/TagServiceTest.java
@@ -146,7 +146,7 @@ class TagServiceTest {
     ArgumentCaptor<CollectionRequests.Create> createCaptor =
         ArgumentCaptor.forClass(CollectionRequests.Create.class);
     verify(collectionService).createCollection(createCaptor.capture());
-    // Booleans flow through untouched; no legacy type rides along any more.
+    // The two booleans flow through untouched and are the only discriminators sent.
     assertThat(createCaptor.getValue().isClient()).isTrue();
     assertThat(createCaptor.getValue().isBlog()).isNull();
   }
@@ -258,8 +258,8 @@ class TagServiceTest {
   }
 
   @Test
-  @DisplayName("convertTagToCollection sends no legacy type and no flags by default")
-  void convertTagToCollection_noTypeDefault() {
+  @DisplayName("convertTagToCollection sends neither flag by default")
+  void convertTagToCollection_noFlagsByDefault() {
     TagEntity tag = unconvertedTag();
     when(tagRepository.findById(5L)).thenReturn(Optional.of(tag));
     when(collectionRepository.findBySlug("landscape")).thenReturn(Optional.empty());

--- a/src/test/resources/db/test-base-schema.sql
+++ b/src/test/resources/db/test-base-schema.sql
@@ -2,8 +2,10 @@
 -- Reconstructs the tables that pre-dated Flyway in prod, so a fresh Postgres
 -- Testcontainers container has the base schema BEFORE Flyway connects. The container
 -- runs this via withInitScript(); Flyway (baseline-on-migrate=true) then baselines the
--- non-empty DB at 0 and applies V2..V29 on top — producing the same end schema while
--- leaving the prod Flyway path (V2..V30, already baselined at 0) completely untouched.
+-- non-empty DB at 0 and applies V2..V52 on top — producing the same end schema while
+-- leaving the prod Flyway path (V2..V52, already baselined at 0) completely untouched.
+-- Columns below that later migrations drop (notably collection.type, dropped by V52) are
+-- deliberately kept here: this file is the pre-Flyway starting state, not the end state.
 -- V2's "CREATE TABLE IF NOT EXISTS location" makes this layering safe.
 
 -- Reference lookup tables


### PR DESCRIPTION
Consolidates all outstanding backend work that was stranded in worktrees, plus two live defects an
audit surfaced. Nothing here is caused by the typeless-collection migration — both defects predate it
and were invisible to per-branch review.

## Two live defects on `main`

### Collection tag edits could 500 and roll back the entire save

`TagEntity` keys `equals`/`hashCode` on `tagName`. `updateCollectionTags` was fabricating "minimal"
entities carrying **only an id**, so `tagName` was null → `hashCode()` 0 and `equals()`
unconditionally false. When `ContentMutationUtil.updateTags` re-added the same tag *fully loaded*
from `prev`, the two instances landed in different hash buckets and **both survived**. No `.distinct()`
on the id list, and `saveCollectionTags` batch-INSERTed with no `ON CONFLICT` into a table with
`PRIMARY KEY (collection_id, tag_id)`.

The frontend sends **every retained tag id** in `prev`, so any edit keeping ≥1 existing tag hit this.
`updateContent` is `@Transactional`, so the rollback discarded title, slug, people, structure and
parents — not just the tags.

**Fixed the mechanism, not the last step.** `updateCollectionTags` now loads fully-populated entities
via the existing `findCollectionTags()`, making it identical to the content-side
`updateImageTagsOptimized` — which never had this bug precisely because it already passed loaded tags.
The duplicate can no longer enter the `Set` at all. `.distinct()` and `ON CONFLICT DO NOTHING` are
defense layers only; note `saveContentTags` and `addCollectionTag` already had `ON CONFLICT`, so this
restores parity rather than inventing a pattern.

Id-aware `TagEntity` equality was considered and **rejected**: a hybrid id-or-name `equals` is not
transitive, which makes `HashSet` behavior order-dependent.

### Client-gallery downloads 401'd for shared-unlock viewers

`GalleryAccessCookies` has two `hasValidAccess` overloads; the 4-arg one also accepts the
password-fingerprint cookie, which is what lets a PARENT password unlock propagated children whose
slugs differ. The read path used it — `isDownloadAuthorized` used the 3-arg per-slug-only one. A
client could **view** a child gallery and get **401** downloading from it, while the UI rendered an
enabled download button. All three call sites were checked to confirm the null-password
short-circuit is unreachable from each.

## Also included

- **`POST /api/admin/users/{id}/upgrade`** — promotes a tag-only PERSON into an INVITED account *in
  place*, keeping the row id so existing image/collection tags stay FK'd. Ported from an abandoned
  worktree and adapted: `main` since added `EmailService` invite-sending to both sibling endpoints, so
  without this the upgrade path would have been the only one that silently never emailed the invitee.
- **Doc sweep** — `.claude/database.md` documented a `collection_type` column that no longer exists;
  it and `.claude/architecture.md` had drifted into contradiction. Both now describe the typeless
  model, including `collection_type_archive` and why it must be retained.

## Verification

| Gate | Result |
|---|---|
| `./mvnw test` | **1214 tests, 0 failures, 0 errors**, 1 pre-existing skip |
| `spotless:check` | exit 0 |
| `checkstyle:check` | exit 0 |

Test count went 1199 → 1214 (**+15**). Both fixes are red-before-green: the tag tests fail on pre-fix
code with exactly `[72L, 72L]` — the duplicate id — and the download tests fail 302-vs-401.

## Review notes

- The three `CollectionServiceTest` tag cases deliberately route the mocked `contentMutationUtil` to a
  **real** instance, because the defect lives at that exact seam and a stubbed `updateTags` would pass
  on broken code. Tradeoff: coupled to real `updateTags` behavior.
- `TagRepository.findCollectionTagIds` was removed — this change orphaned it, and leaving it invites
  reintroducing the id-only-entity pattern that caused the bug.
- One deleted test (`ContentRequestsTest.collectionCreate_nullType_isValid`) was byte-identical to the
  assertion six lines above it; its reason to exist was a dual-compat window that no longer exists.
- The upgrade records no durable DB audit actor — the codebase's pattern is per-table columns and
  `users` has none, so a real trail needs a migration. Flagged, not done.

## Not verified here

`collection_tags` is pre-Flyway and its DDL is not in `db/migration`; the PK is confirmed in the test
schema only. Worth `\d collection_tags` against prod — if the PK is absent, the pre-fix symptom was
silent duplicate rows rather than a 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
