### PR TITLE
fix(upload): surface person-tag failures instead of swallowing them

### DIFF
--- a/src/main/java/edens/zac/portfolio/backend/services/ContentMutationUtil.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/ContentMutationUtil.java
@@ -264,25 +264,28 @@ public class ContentMutationUtil {
 
   /**
    * Associate tags and people extracted from image XMP metadata with a saved image. Creates new
-   * tag/person entities if they don't already exist (case-insensitive dedup). Failures are logged
-   * but do not propagate -- the image save is not affected.
+   * tag/person entities if they don't already exist (case-insensitive dedup).
    *
    * <p>Additive: a re-upload adds the export's keywords without removing curated ones absent from
    * it.
    *
+   * <p>Failures do not propagate -- the image save is not affected -- but they are RETURNED rather
+   * than only logged, so the caller can surface them on the upload job. Swallowing them into a WARN
+   * is what let a duplicate-name person (see V53) drop every person tag from Lightroom exports for
+   * weeks while the job still reported success. Tags and people are attempted independently so a
+   * failure in one cannot silently take the other down with it.
+   *
    * @param imageId The saved image entity ID
    * @param tagNames Tag names extracted from XMP keywords
    * @param peopleNames Person names extracted from XMP keywords
+   * @return one message per failed association; empty when everything was associated
    */
-  public void associateExtractedKeywords(
+  public List<String> associateExtractedKeywords(
       Long imageId, List<String> tagNames, List<String> peopleNames) {
-    if ((tagNames == null || tagNames.isEmpty())
-        && (peopleNames == null || peopleNames.isEmpty())) {
-      return;
-    }
+    List<String> failures = new ArrayList<>();
 
-    try {
-      if (tagNames != null && !tagNames.isEmpty()) {
+    if (tagNames != null && !tagNames.isEmpty()) {
+      try {
         Set<Long> tagIds = new LinkedHashSet<>();
         Set<String> seenTags = new HashSet<>();
         for (String tagName : tagNames) {
@@ -305,9 +308,14 @@ public class ContentMutationUtil {
                 .getOrDefault(imageId, List.of()));
         tagRepository.saveContentTags(imageId, new ArrayList<>(tagIds));
         log.info("Associated {} tags with image {}", tagIds.size(), imageId);
+      } catch (Exception e) {
+        log.warn("Failed to associate tags with image {}: {}", imageId, e.getMessage(), e);
+        failures.add("image " + imageId + ": failed to associate tags: " + e.getMessage());
       }
+    }
 
-      if (peopleNames != null && !peopleNames.isEmpty()) {
+    if (peopleNames != null && !peopleNames.isEmpty()) {
+      try {
         Set<Long> personIds = new LinkedHashSet<>();
         Set<String> seenPeople = new HashSet<>();
         for (String personName : peopleNames) {
@@ -330,11 +338,13 @@ public class ContentMutationUtil {
                 .getOrDefault(imageId, List.of()));
         contentRepository.saveContentPeople(imageId, new ArrayList<>(personIds));
         log.info("Associated {} people with image {}", personIds.size(), imageId);
+      } catch (Exception e) {
+        log.warn("Failed to associate people with image {}: {}", imageId, e.getMessage(), e);
+        failures.add("image " + imageId + ": failed to associate people: " + e.getMessage());
       }
-    } catch (Exception e) {
-      log.warn(
-          "Failed to associate extracted keywords with image {}: {}", imageId, e.getMessage(), e);
     }
+
+    return failures;
   }
 
   /**

--- a/src/main/java/edens/zac/portfolio/backend/services/ImageUploadPipelineService.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/ImageUploadPipelineService.java
@@ -338,29 +338,33 @@ public class ImageUploadPipelineService {
         switch (dedupeResult.action()) {
           case CREATE -> {
             job.created().incrementAndGet();
-            wireImageAfterDedupe(
-                dedupeResult,
-                tags,
-                people,
-                prepared.rawFilePath(),
-                prepared.imageYear(),
-                prepared.imageMonth(),
-                collectionId,
-                orderIndex++);
+            job.errors()
+                .addAll(
+                    wireImageAfterDedupe(
+                        dedupeResult,
+                        tags,
+                        people,
+                        prepared.rawFilePath(),
+                        prepared.imageYear(),
+                        prepared.imageMonth(),
+                        collectionId,
+                        orderIndex++));
             contentMutationUtil.associateLocationsByName(
                 dedupeResult.entity().getId(), fileEntry.locations());
           }
           case UPDATE -> {
             job.updated().incrementAndGet();
-            wireImageAfterDedupe(
-                dedupeResult,
-                tags,
-                people,
-                prepared.rawFilePath(),
-                prepared.imageYear(),
-                prepared.imageMonth(),
-                collectionId,
-                orderIndex++);
+            job.errors()
+                .addAll(
+                    wireImageAfterDedupe(
+                        dedupeResult,
+                        tags,
+                        people,
+                        prepared.rawFilePath(),
+                        prepared.imageYear(),
+                        prepared.imageMonth(),
+                        collectionId,
+                        orderIndex++));
             contentMutationUtil.associateLocationsByName(
                 dedupeResult.entity().getId(), fileEntry.locations());
           }
@@ -481,15 +485,17 @@ public class ImageUploadPipelineService {
             int orderIndex =
                 nextOrderByCollection.computeIfAbsent(collectionId, contentService::nextOrderIndex);
             nextOrderByCollection.put(collectionId, orderIndex + 1);
-            wireImageAfterDedupe(
-                dedupeResult,
-                tags,
-                people,
-                prepared.rawFilePath(),
-                prepared.imageYear(),
-                prepared.imageMonth(),
-                collectionId,
-                orderIndex);
+            job.errors()
+                .addAll(
+                    wireImageAfterDedupe(
+                        dedupeResult,
+                        tags,
+                        people,
+                        prepared.rawFilePath(),
+                        prepared.imageYear(),
+                        prepared.imageMonth(),
+                        collectionId,
+                        orderIndex));
             contentMutationUtil.associateLocationsByName(
                 dedupeResult.entity().getId(), fileEntry.locations());
           }
@@ -591,8 +597,10 @@ public class ImageUploadPipelineService {
   /**
    * Wire up an image after dedupe: associate keywords, schedule RAW upload if needed, and link to
    * collection (skipping if already linked for UPDATE actions).
+   *
+   * @return one message per keyword association that failed; empty on full success
    */
-  private void wireImageAfterDedupe(
+  private List<String> wireImageAfterDedupe(
       ImageProcessingService.DedupeResult dedupeResult,
       List<String> tags,
       List<String> people,
@@ -601,15 +609,20 @@ public class ImageUploadPipelineService {
       int month,
       Long collectionId,
       int orderIndex) {
-    contentMutationUtil.associateExtractedKeywords(dedupeResult.entity().getId(), tags, people);
+    // Keyword failures are returned rather than thrown: the image is already saved, and throwing
+    // would skip the collection link below and orphan it. Handing them back is what makes a
+    // dropped person tag visible to the caller instead of silent (see ContentMutationUtil + V53).
+    List<String> keywordFailures =
+        contentMutationUtil.associateExtractedKeywords(dedupeResult.entity().getId(), tags, people);
     scheduleRawUploadIfNeeded(dedupeResult, rawFilePath, year, month);
     if (dedupeResult.action() == ImageProcessingService.DedupeAction.UPDATE) {
       Optional<CollectionContentEntity> existing =
           collectionRepository.findContentByCollectionIdAndContentId(
               collectionId, dedupeResult.entity().getId());
-      if (existing.isPresent()) return;
+      if (existing.isPresent()) return keywordFailures;
     }
     contentService.linkContentToCollection(collectionId, dedupeResult.entity().getId(), orderIndex);
+    return keywordFailures;
   }
 
   /**
@@ -694,16 +707,20 @@ public class ImageUploadPipelineService {
           continue;
         }
 
-        // Wire up keywords, RAW upload, and collection link (same as disk upload path)
+        // Wire up keywords, RAW upload, and collection link (same as disk upload path). The image
+        // itself succeeded, so a keyword failure is reported alongside it rather than replacing it.
         wireImageAfterDedupe(
-            dedupeResult,
-            prepared.data().extractedTags(),
-            prepared.data().extractedPeople(),
-            prepared.data().rawFilePath(),
-            prepared.data().imageYear(),
-            prepared.data().imageMonth(),
-            collectionId,
-            orderIndex);
+                dedupeResult,
+                prepared.data().extractedTags(),
+                prepared.data().extractedPeople(),
+                prepared.data().rawFilePath(),
+                prepared.data().imageYear(),
+                prepared.data().imageMonth(),
+                collectionId,
+                orderIndex)
+            .forEach(
+                message ->
+                    failures.add(new ImageUploadResult.FileError(prepared.filename(), message)));
 
         // Convert entity to model for the result list
         ContentModel contentModel =

--- a/src/main/resources/db/migration/V53__unique_person_name.sql
+++ b/src/main/resources/db/migration/V53__unique_person_name.sql
@@ -1,0 +1,184 @@
+-- V53: one identity per name. Folds duplicate-name rows together, then enforces the
+-- case-insensitive uniqueness of `users.name` that the person-tag lookup already assumes.
+--
+-- Why this is needed:
+--   Person tags are keyed by NAME, not by id. The Lightroom plugin sends a bare person name
+--   ("Tara Edens") per image, and ContentMutationUtil.associateExtractedKeywords resolves it
+--   through PersonRepository.findByPersonNameIgnoreCase, which is a queryForObject -- exactly
+--   one row or it throws IncorrectResultSizeDataAccessException. Nothing enforced that. Before
+--   V35 the person table was separate and name-keyed; the merge into `users` carried the
+--   name-keyed lookup over but not any uniqueness on the column (`app_user_email_key` and
+--   `app_user_webauthn_user_handle_key` are the only unique constraints on the table).
+--
+--   The pre-existing `tag` table already models this correctly -- content_tag_tag_name_key is
+--   UNIQUE on tag_name -- so a name-keyed metadata table carrying a uniqueness constraint is
+--   the established shape here, not a new invention.
+--
+--   The duplicates in practice came from the invite flow: before the /users/{id}/upgrade
+--   endpoint existed, inviting someone who was already a tagged PERSON inserted a SECOND row
+--   rather than upgrading the tag row in place. Every subsequent Lightroom export that tagged
+--   that person then threw inside associateExtractedKeywords -- which caught Exception and
+--   logged a WARN -- so the upload reported success while silently dropping the person.
+--
+-- Audit queries -- run manually before deploying (same convention as V51 lines 27-58):
+--
+-- -- 1. Every duplicate-name group this migration will collapse, with the status of each row.
+-- --    A group whose rows are ALL status <> 'PERSON' is the one shape step 1 cannot resolve
+-- --    and will abort on; rename one of those accounts by hand first.
+-- SELECT LOWER(name) AS key, count(*), array_agg(id ORDER BY id), array_agg(status ORDER BY id)
+-- FROM users GROUP BY 1 HAVING count(*) > 1 ORDER BY 1;
+--
+-- -- 2. Tag volume at stake -- how many image/collection tags ride on the rows being folded.
+-- SELECT u.id, u.name, u.status,
+--        (SELECT count(*) FROM content_image_people WHERE person_id = u.id) AS image_tags,
+--        (SELECT count(*) FROM collection_people   WHERE person_id = u.id) AS collection_tags
+-- FROM users u
+-- WHERE LOWER(u.name) IN (SELECT LOWER(name) FROM users GROUP BY 1 HAVING count(*) > 1)
+-- ORDER BY LOWER(u.name), u.id;
+
+-- 1. Abort loudly rather than destroy an account. Steps 2-4 only ever delete a tag-only PERSON
+--    row; if a duplicate-name group holds two real accounts there is no safe automatic winner,
+--    and silently renaming one would break its owner's login display. Failing here leaves the
+--    schema untouched and blocks boot with an actionable message (spring.flyway.enabled=true,
+--    application.properties:36), which is the correct outcome -- the alternative is the CREATE
+--    UNIQUE INDEX in step 5 failing with an opaque "could not create unique index".
+DO $$
+DECLARE
+  offenders text;
+BEGIN
+  SELECT string_agg(key, ', ') INTO offenders
+  FROM (
+    SELECT LOWER(name) AS key
+    FROM users
+    GROUP BY LOWER(name)
+    HAVING count(*) > 1 AND count(*) FILTER (WHERE status <> 'PERSON') > 1
+  ) g;
+
+  IF offenders IS NOT NULL THEN
+    RAISE EXCEPTION
+      'V53: cannot collapse duplicate user names -- these have more than one real account: %. '
+      'Rename or merge them by hand (POST /api/admin/users/{targetId}/merge), then redeploy.',
+      offenders;
+  END IF;
+END $$;
+
+-- 2. The survivor of each duplicate-name group, and the tag-only PERSON rows folding into it.
+--    Survivor rule: a real account outranks a tag-only PERSON (step 1 has already guaranteed at
+--    most one account per group), then lowest id. That direction matters -- the account row is
+--    the one carrying the login, so tags must move ONTO it, never off it.
+--
+--    A temp table rather than a CTE because steps 3-4 each need the same mapping, and ON COMMIT
+--    DROP scopes it to this migration's transaction.
+CREATE TEMP TABLE v53_fold ON COMMIT DROP AS
+WITH ranked AS (
+  SELECT
+    id,
+    LOWER(name) AS key,
+    row_number() OVER (
+      PARTITION BY LOWER(name)
+      ORDER BY (status = 'PERSON'), id
+    ) AS rn
+  FROM users
+)
+SELECT loser.id AS source_id, winner.id AS target_id
+FROM ranked loser
+JOIN ranked winner ON winner.key = loser.key AND winner.rn = 1
+WHERE loser.rn > 1;
+
+-- 3. Re-point the tag joins. All three join tables have a composite primary key
+--    (content_image_people_pkey on (content_id, person_id), collection_people_pkey on
+--    (collection_id, person_id), role_member_pkey on (role_id, user_id)), and every one of them
+--    is NON-DEFERRABLE -- Postgres checks it per row, not at commit -- so any UPDATE that would
+--    transiently produce a duplicate fails immediately. V35 step 5 hit exactly this on these same
+--    tables and rebuilt them rather than update in place; here we clear both collision shapes
+--    first instead, which keeps the fold a straight UPDATE.
+--
+--    There are TWO collision shapes, and the second is why this cannot simply mirror
+--    PersonRepository.repointTags: that helper moves ONE source onto ONE target (UserMergeService
+--    calls it per pair), whereas v53_fold is N-to-one whenever a name group holds 3+ rows.
+--
+--      a) loser-vs-WINNER  -- the survivor already holds this key. Drop the loser's row.
+--      b) loser-vs-LOSER   -- two different losers in the SAME group hold the same key, and
+--                            neither collides with the winner. Both survive (a), then the UPDATE
+--                            rewrites both to (key, target_id) and the second one violates the
+--                            primary key. Keep the lowest person_id and drop the rest.
+--
+--    Shape (b) cannot arise in a 2-row group, which is the only shape the dev database happened
+--    to contain -- so it stays invisible until prod, where 3+ row groups are plausible: V35 noted
+--    content_people.person_name was never unique and minted one PERSON row per unlinked row, and
+--    ContentMutationUtil's find-then-insert has no constraint behind it. V53FoldMigrationIntegrationTest
+--    seeds shape (b) deliberately; without the (b) deletes below it fails with
+--    "duplicate key value violates unique constraint content_image_people_pkey".
+DELETE FROM content_image_people s
+USING v53_fold f
+WHERE s.person_id = f.source_id
+  AND EXISTS (SELECT 1 FROM content_image_people t
+              WHERE t.person_id = f.target_id AND t.content_id = s.content_id);
+
+DELETE FROM content_image_people s
+USING v53_fold f
+WHERE s.person_id = f.source_id
+  AND EXISTS (SELECT 1 FROM content_image_people o
+              JOIN v53_fold f2 ON o.person_id = f2.source_id
+              WHERE f2.target_id = f.target_id
+                AND o.content_id = s.content_id
+                AND o.person_id < s.person_id);
+
+UPDATE content_image_people s SET person_id = f.target_id
+FROM v53_fold f WHERE s.person_id = f.source_id;
+
+DELETE FROM collection_people s
+USING v53_fold f
+WHERE s.person_id = f.source_id
+  AND EXISTS (SELECT 1 FROM collection_people t
+              WHERE t.person_id = f.target_id AND t.collection_id = s.collection_id);
+
+DELETE FROM collection_people s
+USING v53_fold f
+WHERE s.person_id = f.source_id
+  AND EXISTS (SELECT 1 FROM collection_people o
+              JOIN v53_fold f2 ON o.person_id = f2.source_id
+              WHERE f2.target_id = f.target_id
+                AND o.collection_id = s.collection_id
+                AND o.person_id < s.person_id);
+
+UPDATE collection_people s SET person_id = f.target_id
+FROM v53_fold f WHERE s.person_id = f.source_id;
+
+-- role_member too, mirroring RoleRepository.repointMemberships. A tag-only PERSON should not
+-- hold memberships, but UserMergeService moves them, so this stays consistent with it.
+DELETE FROM role_member s
+USING v53_fold f
+WHERE s.user_id = f.source_id
+  AND EXISTS (SELECT 1 FROM role_member t
+              WHERE t.user_id = f.target_id AND t.role_id = s.role_id);
+
+DELETE FROM role_member s
+USING v53_fold f
+WHERE s.user_id = f.source_id
+  AND EXISTS (SELECT 1 FROM role_member o
+              JOIN v53_fold f2 ON o.user_id = f2.source_id
+              WHERE f2.target_id = f.target_id
+                AND o.role_id = s.role_id
+                AND o.user_id < s.user_id);
+
+UPDATE role_member s SET user_id = f.target_id
+FROM v53_fold f WHERE s.user_id = f.source_id;
+
+-- 4. Drop the folded rows. The `status = 'PERSON'` guard mirrors
+--    PersonRepository.deletePersonById and is defense-in-depth: step 1 already proved every
+--    loser is a PERSON, so this deletes exactly the rows step 3 emptied.
+DELETE FROM users u
+USING v53_fold f
+WHERE u.id = f.source_id AND u.status = 'PERSON';
+
+-- 5. The invariant itself. A functional index on LOWER(name) is what makes
+--    findByPersonNameIgnoreCase ("WHERE LOWER(name) = LOWER(:personName)") total -- it can now
+--    only ever return zero or one row -- and it serves that query as an index rather than a
+--    sequential scan.
+--
+--    Note this constrains display names globally: two distinct accounts can no longer share a
+--    name. That is inherent to name-keyed person tags, not a restriction this migration
+--    invents -- with two "John Smith" rows there is no answer to which one an incoming
+--    Lightroom keyword means. Disambiguate at the name ("John Smith (PNWER)").
+CREATE UNIQUE INDEX idx_users_name_lower ON users (LOWER(name));

--- a/src/test/java/edens/zac/portfolio/backend/PersonNameUniqueMigrationIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/PersonNameUniqueMigrationIntegrationTest.java
@@ -1,0 +1,80 @@
+package edens.zac.portfolio.backend;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Verifies V53 enforces one identity per name (case-insensitive).
+ *
+ * <p>Person tags are name-keyed: the Lightroom plugin sends a bare person name and
+ * PersonRepository.findByPersonNameIgnoreCase resolves it via queryForObject. Two rows sharing a
+ * name made that throw, and the throw was swallowed, so exports silently dropped the person.
+ */
+class PersonNameUniqueMigrationIntegrationTest extends AbstractPostgresIntegrationTest {
+
+  @Autowired private JdbcTemplate jdbc;
+
+  @Test
+  void uniqueLowercaseNameIndexExists() {
+    Integer count =
+        jdbc.queryForObject(
+            "SELECT COUNT(*) FROM pg_indexes WHERE tablename='users' AND indexname='idx_users_name_lower'",
+            Integer.class);
+    assertThat(count).isEqualTo(1);
+  }
+
+  @Test
+  void noDuplicateNamesSurviveTheMigration() {
+    Integer groups =
+        jdbc.queryForObject(
+            "SELECT COUNT(*) FROM (SELECT 1 FROM users GROUP BY LOWER(name) HAVING COUNT(*) > 1) g",
+            Integer.class);
+    assertThat(groups).isZero();
+  }
+
+  @Test
+  void insertingASecondIdentityWithTheSameNameIsRejected() {
+    jdbc.update(
+        "INSERT INTO users (name, webauthn_user_handle, status) VALUES ('Dup Guard', gen_random_uuid(), 'PERSON')");
+
+    assertThatThrownBy(
+            () ->
+                jdbc.update(
+                    "INSERT INTO users (name, webauthn_user_handle, status) VALUES ('Dup Guard', gen_random_uuid(), 'PERSON')"))
+        .isInstanceOf(DuplicateKeyException.class);
+  }
+
+  /** The constraint is case-insensitive -- 'tara edens' must not slip past 'Tara Edens'. */
+  @Test
+  void insertingADifferentlyCasedDuplicateIsRejected() {
+    jdbc.update(
+        "INSERT INTO users (name, webauthn_user_handle, status) VALUES ('Case Guard', gen_random_uuid(), 'PERSON')");
+
+    assertThatThrownBy(
+            () ->
+                jdbc.update(
+                    "INSERT INTO users (name, webauthn_user_handle, status) VALUES ('case guard', gen_random_uuid(), 'PERSON')"))
+        .isInstanceOf(DuplicateKeyException.class);
+  }
+
+  /**
+   * The whole point of the constraint: a name-keyed lookup can now only ever resolve to zero or one
+   * identity, which is what makes PersonRepository.findByPersonNameIgnoreCase (a queryForObject)
+   * total rather than a latent IncorrectResultSizeDataAccessException.
+   */
+  @Test
+  void nameLookupResolvesToAtMostOneIdentity() {
+    jdbc.update(
+        "INSERT INTO users (name, webauthn_user_handle, status) VALUES ('Lookup Target', gen_random_uuid(), 'PERSON')");
+
+    Integer matches =
+        jdbc.queryForObject(
+            "SELECT COUNT(*) FROM users WHERE LOWER(name) = LOWER('lookup TARGET')", Integer.class);
+    assertThat(matches).isEqualTo(1);
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/dao/V53FoldMigrationIntegrationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/dao/V53FoldMigrationIntegrationTest.java
@@ -1,0 +1,233 @@
+package edens.zac.portfolio.backend.dao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import javax.sql.DataSource;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+/**
+ * Exercises the V53 FOLD against actual data, which no other test does. The shared harness
+ * (PersonNameUniqueMigrationIntegrationTest) migrates an empty users table, so steps 1-4 process
+ * zero rows there and only the end-state index is asserted -- a fold that destroyed every tag would
+ * still pass it. This test owns a dedicated container, migrates to V52, seeds the production shape,
+ * then migrates to V53 and asserts no tag was lost.
+ *
+ * <p>The seed deliberately includes the collision shape that a 2-row group cannot produce: TWO
+ * tag-only PERSON losers in the same name group holding the SAME content_id, where neither collides
+ * with the winner. V53's original single collision DELETE only removed rows colliding with the
+ * WINNER, so both losers survived it and the repoint UPDATE then violated
+ * content_image_people_pkey. The owner's dev database held only 2-row groups (87+106, 90+107), so
+ * this was invisible there; 3+ row groups are plausible in prod because V35 minted one PERSON row
+ * per unlinked content_people row and content_people.person_name was never unique.
+ *
+ * <p>The INVITED account is inserted LAST, after both PERSON rows, so it carries the HIGHEST id.
+ * That makes {@code survivorIsTheAccountNotTheTagRow} discriminating: a survivor rule that ordered
+ * by id alone, rather than by {@code (status = 'PERSON'), id}, would pick a tag row and fail.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class V53FoldMigrationIntegrationTest {
+
+  private static final String DUPED = "Tara Edens";
+  private static final String UNIQUE = "Logan Radde";
+
+  private PostgreSQLContainer<?> postgres;
+  private JdbcTemplate jdbc;
+
+  private Long loserA;
+  private Long loserB;
+  private Long winner;
+  private Long control;
+  private Long sharedContent;
+  private Long loserOnlyContent;
+  private Long winnerAlsoContent;
+  private Long collectionId;
+  private Long roleId;
+
+  @BeforeAll
+  void migrateSeededDatabase() {
+    postgres =
+        new PostgreSQLContainer<>("postgres:16-alpine").withInitScript("db/test-base-schema.sql");
+    postgres.start();
+
+    DriverManagerDataSource dataSource = new DriverManagerDataSource();
+    dataSource.setUrl(postgres.getJdbcUrl());
+    dataSource.setUsername(postgres.getUsername());
+    dataSource.setPassword(postgres.getPassword());
+    jdbc = new JdbcTemplate(dataSource);
+
+    // Stop just short of V53 so the seed rows exist as pre-V53 data would.
+    migrateTo(dataSource, "52");
+
+    // Order matters: both PERSON rows first, the account last, so the account has the highest id.
+    loserA = insertUser(DUPED, "PERSON");
+    loserB = insertUser(DUPED, "PERSON");
+    winner = insertUser(DUPED, "INVITED");
+    control = insertUser(UNIQUE, "PERSON");
+
+    sharedContent = insertContent();
+    loserOnlyContent = insertContent();
+    winnerAlsoContent = insertContent();
+
+    // Shape (b): two losers, same content, neither colliding with the winner.
+    tagImage(sharedContent, loserA);
+    tagImage(sharedContent, loserB);
+    // Only one loser holds this one -- a plain move.
+    tagImage(loserOnlyContent, loserA);
+    // Shape (a): the winner already holds it, so the loser's row must be dropped, not moved.
+    tagImage(winnerAlsoContent, winner);
+    tagImage(winnerAlsoContent, loserA);
+    // The control person must come through completely untouched.
+    tagImage(loserOnlyContent, control);
+
+    collectionId =
+        jdbc.queryForObject(
+            "INSERT INTO collection (title, slug, visibility) "
+                + "VALUES ('Rome 2023', 'rome-2023', 'LISTED') RETURNING id",
+            Long.class);
+    // Shape (b) again, on collection_people.
+    tagCollection(collectionId, loserA);
+    tagCollection(collectionId, loserB);
+
+    roleId =
+        jdbc.queryForObject(
+            "INSERT INTO role (name) VALUES ('Test Role') RETURNING id", Long.class);
+    // Shape (b) again, on role_member. A tag-only PERSON should not hold memberships, but
+    // UserMergeService moves them, so V53 stays consistent with it -- and must not choke.
+    addRoleMember(roleId, loserA);
+    addRoleMember(roleId, loserB);
+
+    migrateTo(dataSource, "53");
+  }
+
+  private Long insertUser(String name, String status) {
+    return jdbc.queryForObject(
+        "INSERT INTO users (name, webauthn_user_handle, status) "
+            + "VALUES (?, gen_random_uuid(), ?) RETURNING id",
+        Long.class,
+        name,
+        status);
+  }
+
+  private Long insertContent() {
+    return jdbc.queryForObject(
+        "INSERT INTO content (content_type) VALUES ('IMAGE') RETURNING id", Long.class);
+  }
+
+  private void tagImage(Long contentId, Long personId) {
+    jdbc.update(
+        "INSERT INTO content_image_people (content_id, person_id) VALUES (?, ?)",
+        contentId,
+        personId);
+  }
+
+  private void tagCollection(Long collection, Long personId) {
+    jdbc.update(
+        "INSERT INTO collection_people (collection_id, person_id) VALUES (?, ?)",
+        collection,
+        personId);
+  }
+
+  private void addRoleMember(Long role, Long userId) {
+    jdbc.update("INSERT INTO role_member (role_id, user_id) VALUES (?, ?)", role, userId);
+  }
+
+  private void migrateTo(DataSource dataSource, String target) {
+    Flyway.configure()
+        .dataSource(dataSource)
+        .baselineOnMigrate(true)
+        .baselineVersion("0")
+        .locations("classpath:db/migration")
+        .target(target)
+        .load()
+        .migrate();
+  }
+
+  @AfterAll
+  void stopContainer() {
+    if (postgres != null) {
+      postgres.stop();
+    }
+  }
+
+  @Test
+  void migrationCompletesWithoutAPrimaryKeyViolation() {
+    // The headline regression: with only the winner-collision DELETE, migrating this seed failed
+    // with "duplicate key value violates unique constraint content_image_people_pkey" and rolled
+    // the whole migration back, blocking application boot. Reaching @BeforeAll's end proves it
+    // applied, and the index below proves it ran to completion rather than stopping early.
+    assertThat(
+            jdbc.queryForObject(
+                "SELECT count(*) FROM pg_indexes WHERE tablename = 'users' "
+                    + "AND indexname = 'idx_users_name_lower'",
+                Integer.class))
+        .isEqualTo(1);
+  }
+
+  @Test
+  void survivorIsTheAccountNotTheTagRow() {
+    List<Long> remaining =
+        jdbc.queryForList(
+            "SELECT id FROM users WHERE LOWER(name) = LOWER(?) ORDER BY id", Long.class, DUPED);
+    assertThat(remaining).containsExactly(winner);
+    assertThat(jdbc.queryForObject("SELECT status FROM users WHERE id = ?", String.class, winner))
+        .isEqualTo("INVITED");
+  }
+
+  @Test
+  void everyImageTagLandsOnTheSurvivorExactlyOnce() {
+    // Three distinct images were tagged across the group; all three must survive on the winner,
+    // each exactly once. Losing sharedContent would be the silent data loss this migration exists
+    // to prevent, and a duplicate would mean the collision deletes over-deleted.
+    assertThat(imageTagsFor(winner))
+        .containsExactlyInAnyOrder(sharedContent, loserOnlyContent, winnerAlsoContent);
+    assertThat(imageTagsFor(loserA)).isEmpty();
+    assertThat(imageTagsFor(loserB)).isEmpty();
+  }
+
+  @Test
+  void collectionAndRoleJoinsFoldOntoTheSurvivorExactlyOnce() {
+    assertThat(
+            jdbc.queryForList(
+                "SELECT collection_id FROM collection_people WHERE person_id = ?",
+                Long.class,
+                winner))
+        .containsExactly(collectionId);
+    assertThat(
+            jdbc.queryForList(
+                "SELECT role_id FROM role_member WHERE user_id = ?", Long.class, winner))
+        .containsExactly(roleId);
+  }
+
+  @Test
+  void aPersonWithAUniqueNameIsUntouched() {
+    assertThat(
+            jdbc.queryForObject("SELECT count(*) FROM users WHERE id = ?", Integer.class, control))
+        .isEqualTo(1);
+    assertThat(imageTagsFor(control)).containsExactly(loserOnlyContent);
+  }
+
+  @Test
+  void noOrphanedJoinRowsPointAtADeletedUser() {
+    assertThat(
+            jdbc.queryForObject(
+                "SELECT count(*) FROM content_image_people cip "
+                    + "WHERE NOT EXISTS (SELECT 1 FROM users u WHERE u.id = cip.person_id)",
+                Integer.class))
+        .isZero();
+  }
+
+  private List<Long> imageTagsFor(Long personId) {
+    return jdbc.queryForList(
+        "SELECT content_id FROM content_image_people WHERE person_id = ? ORDER BY content_id",
+        Long.class,
+        personId);
+  }
+}

--- a/src/test/java/edens/zac/portfolio/backend/services/ContentMutationUtilTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/ContentMutationUtilTest.java
@@ -30,6 +30,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
 
 @ExtendWith(MockitoExtension.class)
 class ContentMutationUtilTest {
@@ -401,6 +402,68 @@ class ContentMutationUtilTest {
     ArgumentCaptor<List<Long>> captor = ArgumentCaptor.forClass(List.class);
     verify(contentRepository).saveContentPeople(eq(1L), captor.capture());
     assertEquals(Set.of(10L, 20L, 30L), new HashSet<>(captor.getValue()));
+  }
+
+  /**
+   * Regression: a duplicate-name person made findByPersonNameIgnoreCase (a queryForObject) throw
+   * IncorrectResultSizeDataAccessException, which was caught and logged as a WARN. The Lightroom
+   * export then reported success with the person tag silently missing. V53 removes the duplicates;
+   * this asserts the failure is reported rather than swallowed if it ever recurs.
+   */
+  @Test
+  void associateExtractedKeywords_personLookupFails_returnsFailureInsteadOfSwallowing() {
+    when(personRepository.findByPersonNameIgnoreCase("Tara Edens"))
+        .thenThrow(new IncorrectResultSizeDataAccessException(1, 2));
+
+    List<String> failures =
+        contentMutationUtil.associateExtractedKeywords(1L, null, List.of("Tara Edens"));
+
+    assertEquals(1, failures.size());
+    assertTrue(failures.get(0).contains("people"), failures.get(0));
+    verify(contentRepository, never()).saveContentPeople(anyLong(), anyList());
+  }
+
+  /** A failing person lookup must not take the image's tags down with it. */
+  @Test
+  void associateExtractedKeywords_personLookupFails_tagsStillAssociated() {
+    TagEntity rome = TagEntity.builder().id(76L).tagName("Rome Italy").slug("rome-italy").build();
+    when(tagRepository.findBySlug("rome-italy")).thenReturn(Optional.of(rome));
+    when(personRepository.findByPersonNameIgnoreCase("Tara Edens"))
+        .thenThrow(new IncorrectResultSizeDataAccessException(1, 2));
+
+    List<String> failures =
+        contentMutationUtil.associateExtractedKeywords(
+            1L, List.of("Rome Italy"), List.of("Tara Edens"));
+
+    verify(tagRepository).saveContentTags(eq(1L), anyList());
+    assertEquals(1, failures.size());
+  }
+
+  /** The inverse: a failing tag association must not skip the people block. */
+  @Test
+  void associateExtractedKeywords_tagFailure_peopleStillAssociated() {
+    when(tagRepository.findBySlug("rome-italy")).thenThrow(new RuntimeException("tag boom"));
+    ContentPersonEntity tara =
+        ContentPersonEntity.builder().id(107L).personName("Tara Edens").build();
+    when(personRepository.findByPersonNameIgnoreCase("Tara Edens")).thenReturn(Optional.of(tara));
+
+    List<String> failures =
+        contentMutationUtil.associateExtractedKeywords(
+            1L, List.of("Rome Italy"), List.of("Tara Edens"));
+
+    verify(contentRepository).saveContentPeople(eq(1L), anyList());
+    assertEquals(1, failures.size());
+    assertTrue(failures.get(0).contains("tags"), failures.get(0));
+  }
+
+  @Test
+  void associateExtractedKeywords_success_returnsNoFailures() {
+    ContentPersonEntity tara =
+        ContentPersonEntity.builder().id(107L).personName("Tara Edens").build();
+    when(personRepository.findByPersonNameIgnoreCase("Tara Edens")).thenReturn(Optional.of(tara));
+
+    assertTrue(
+        contentMutationUtil.associateExtractedKeywords(1L, null, List.of("Tara Edens")).isEmpty());
   }
 
   // =============================================================================

--- a/src/test/java/edens/zac/portfolio/backend/services/ImageUploadPipelineServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/ImageUploadPipelineServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -354,6 +355,51 @@ class ImageUploadPipelineServiceTest {
           .associateExtractedKeywords(
               eq(101L), eq(List.of("street", "film")), eq(List.of("Alice")));
       verify(contentMutationUtil).associateLocationsByName(eq(101L), eq(List.of("Amsterdam")));
+    }
+
+    @Test
+    @DisplayName("a keyword failure reaches the job, flips it to FAILED, and still links the image")
+    void processFilesFromDisk_keywordFailure_recordedOnJobAndFlipsStatusToFailed()
+        throws Exception {
+      // Regression pin for the incident this change exists to fix: a duplicate person name made
+      // findByPersonNameIgnoreCase throw, ContentMutationUtil swallowed it into a WARN, and the
+      // upload reported success while dropping the person.
+      //
+      // This is the ONLY test that stubs a keyword failure. Every other reference to the mock is a
+      // bare verify(), and Mockito returns an empty list for List-returning methods -- so without
+      // this, reverting job.errors().addAll(wireImageAfterDedupe(...)) to a bare statement would
+      // compile (Java lets you discard a return value), pass checkstyle, and leave the whole suite
+      // green while silently restoring the original bug.
+      Long collectionId = 1L;
+      var request =
+          new DiskUploadRequest(
+              List.of(new DiskUploadRequest.FileEntry("/tmp/a.jpg", null, null)), null);
+      var job = new JobTrackingService.JobStatus(java.util.UUID.randomUUID(), 1);
+      when(collectionRepository.findById(collectionId)).thenReturn(Optional.of(testCollection));
+      when(jobTrackingService.createJob(1)).thenReturn(job);
+      when(personRepository.findAllByOrderByPersonNameAsc()).thenReturn(List.of());
+      when(contentService.nextOrderIndex(collectionId)).thenReturn(0);
+      when(imageProcessingService.prepareImageFromDisk(any(), any()))
+          .thenReturn(prepared("a.jpg", List.of("Rome Italy"), List.of("Tara Edens")));
+      when(imageProcessingService.savePreparedImageWithDedupe(any(), any()))
+          .thenReturn(createResult(101L));
+      when(contentMutationUtil.associateExtractedKeywords(eq(101L), anyList(), anyList()))
+          .thenReturn(
+              List.of(
+                  "image 101: failed to associate people: Incorrect result size: expected 1,"
+                      + " actual 2"));
+
+      service.processFilesFromDisk(collectionId, request);
+      awaitCompletion(job);
+
+      assertThat(job.errors()).anyMatch(e -> e.contains("failed to associate people"));
+      // The deliberate semantic change: a dropped person tag is now a visibly FAILED job rather
+      // than a silent success. markCompleted keys status off the error list.
+      assertThat(job.status()).isEqualTo("FAILED");
+      // ...but the image itself still succeeded. It is counted and still linked to the collection,
+      // so a keyword failure degrades the report, not the upload.
+      assertThat(job.created().get()).isEqualTo(1);
+      verify(contentService).linkContentToCollection(eq(collectionId), eq(101L), anyInt());
     }
 
     @Test


### PR DESCRIPTION
## The bug

An upload reported **success** while silently dropping a person tag. `_DSC3410` kept its `Rome Italy` tag but lost `Tara Edens`; another image in the same batch, tagged with a brand-new unique name, was fine.

The Lightroom plugin was not at fault -- it sent `people: ["Tara Edens"]` correctly.

Since the V35 identity merge, a person **tag** and a login **account** are the same `users` row. Inviting someone who already existed as a tag created a *second* row instead of upgrading the tag row in place; the `/users/{id}/upgrade` endpoint that prevents this only landed later. Two people ended up split:

| name | tag row | account row |
|---|---|---|
| Tara Edens | 90 (PERSON) | 107 (INVITED) |
| Nate Weigel | 87 (PERSON) | 106 (INVITED) |

Person tags resolve **by name** through `PersonRepository.findByPersonNameIgnoreCase`, a `queryForObject` that demands exactly one row. Two rows threw `Incorrect result size: expected 1, actual 2` -- and `ContentMutationUtil` caught `Exception` and logged a WARN. Tags run before people, which is exactly why the location tag survived and the person tag did not.

## The fix

1. **`V53__unique_person_name.sql`** folds duplicate-name rows together (a real account outranks a tag-only PERSON, mirroring `UserMergeService`), repoints `content_image_people` / `collection_people` / `role_member` onto the survivor, drops the folded rows, then enforces `UNIQUE (LOWER(name))`. Step 1 aborts loudly rather than guessing if a group ever holds two real accounts.
2. **`ContentMutationUtil.associateExtractedKeywords`** returns failures instead of swallowing them, and attempts tags and people in independent `try` blocks so one cannot silently take down the other.
3. **`ImageUploadPipelineService`** pushes those failures onto the upload job.

## Deliberate semantic change

A dropped person tag now flips the upload job to **FAILED**, because `markCompleted` keys status off the error list. Reporting success while losing data is the bug this PR removes, so a partial upload is now visibly a failure. The image is still created, still counted, and still linked to its collection -- only the job status changes.

## Review caught a blocker worth calling out

The first cut of V53 mirrored `PersonRepository.repointTags`. That helper moves **one** source onto **one** target; the fold is **N-to-one** whenever a name group holds 3+ rows. Two different losers holding the same `content_id` both survive a winner-only collision check, and the `UPDATE` then violates the non-deferrable composite PK -- rolling back the migration and **blocking application boot**. `V35` step 5 hit the same hazard on these same tables.

This was invisible in dev because both real groups were exactly 2 rows. 3+ row groups are plausible in prod: V35 minted one PERSON row per unlinked `content_people` row, and `content_people.person_name` was never unique.

## Testing

- Full suite green: **1230 tests, 0 failures**. Checkstyle/spotless clean.
- `V53FoldMigrationIntegrationTest` (new) seeds the 3-row shape against a dedicated container and asserts no tag is lost. **Verified to fail** with `duplicate key value violates unique constraint "content_image_people_pkey"` when the loser-vs-loser deletes are removed -- so it actually pins the fix.
- The pre-existing migration test ran V53 against an *empty* `users` table, so the fold logic had zero coverage.
- `ImageUploadPipelineServiceTest` now stubs a keyword failure and pins both `job.errors()` and the FAILED status. Every other reference to that mock is a bare `verify()` and Mockito returns an empty list, so dropping the `job.errors().addAll(...)` wiring would otherwise compile and stay green.

## Before deploying

- [ ] Run the audit query in the V53 header against **prod** and inspect every group -- specifically (a) any group with 2+ non-PERSON rows, which aborts the deploy, and (b) any group with 3+ rows.
- [ ] Take a `pg_dump` immediately before deploy. V53 deletes `users` rows; rolling back the jar does not un-delete them.
- [ ] Re-export a previously-duplicated person from Lightroom and confirm the read API returns both tag and person. The plugin is fire-and-forget and never polls the job endpoint, so verify via the API, not the plugin's output.

## Follow-ups not in this PR

- `associateLocationsByName` still swallows failures the same way, one method over.
- `spring.flyway.ignore-migration-patterns=*:missing` replaces Flyway's `*:future` default, so a rolled-back binary fails validation. Pre-existing, affects every release.
- `.idea/compiler.xml` is tracked despite `.gitignore` listing `.idea` -- left unstaged here; wants its own housekeeping commit.

Consequence of the unique index: two distinct accounts can no longer share a display name. Inherent to name-keyed person tags -- disambiguate at the name, e.g. `John Smith (PNWER)`.

Generated with [Claude Code](https://claude.com/claude-code)
