### PR TITLE
feat(collections): serialize collection visibility onto COLLECTION content blocks

### DIFF
--- a/src/main/java/edens/zac/portfolio/backend/model/ContentModels.java
+++ b/src/main/java/edens/zac/portfolio/backend/model/ContentModels.java
@@ -2,6 +2,7 @@ package edens.zac.portfolio.backend.model;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import edens.zac.portfolio.backend.types.CollectionVisibility;
 import edens.zac.portfolio.backend.types.ContentType;
 import edens.zac.portfolio.backend.types.FilmFormat;
 import java.time.LocalDate;
@@ -244,7 +245,8 @@ public final class ContentModels {
       ContentModels.Image coverImage,
       @JsonFormat(pattern = "yyyy-MM-dd") LocalDate collectionDate,
       @JsonFormat(pattern = "yyyy-MM-dd") LocalDate collectionEndDate,
-      List<Records.Tag> tags)
+      List<Records.Tag> tags,
+      CollectionVisibility visibility)
       implements ContentModel {
 
     /**
@@ -253,6 +255,15 @@ public final class ContentModels {
      * /user} page) where each child collection becomes a {@code COLLECTION} block pointing back at
      * itself. Tags start empty; callers that need per-collection tags for filtering (e.g. synthetic
      * list views) enrich the block via {@link #withTags}.
+     *
+     * <p>{@code visibility} is serialized unconditionally, for every viewer. It is NOT an access
+     * control and must never be treated as one: the access boundary is the row scoping in {@code
+     * SyntheticCollectionResolver#findAllCollectionsForCurrentViewer}, which runs first and decides
+     * which collections a viewer receives at all. By the time a block is serialized the viewer is
+     * already entitled to it, so the label reveals nothing further — a non-admin's blocks read
+     * LISTED, save for their own granted galleries, which they own. Omitting it per-role would make
+     * the payload shape vary by identity (a caching hazard) and, worse, would imply the field is
+     * the boundary and invite someone to relax the row query behind it.
      */
     public static Collection fromCollectionModel(CollectionModel c) {
       return new Collection(
@@ -272,7 +283,8 @@ public final class ContentModels {
           c.getCoverImage(),
           c.getCollectionDate(),
           c.getCollectionEndDate(),
-          List.of());
+          List.of(),
+          c.getVisibility());
     }
 
     /** Returns a new Collection with {@code orderIndex} replaced (records are immutable). */
@@ -294,7 +306,8 @@ public final class ContentModels {
           coverImage,
           collectionDate,
           collectionEndDate,
-          tags);
+          tags,
+          visibility);
     }
 
     /**
@@ -320,7 +333,8 @@ public final class ContentModels {
           coverImage,
           collectionDate,
           collectionEndDate,
-          tags);
+          tags,
+          visibility);
     }
   }
 }

--- a/src/main/java/edens/zac/portfolio/backend/services/ContentModelConverter.java
+++ b/src/main/java/edens/zac/portfolio/backend/services/ContentModelConverter.java
@@ -582,7 +582,8 @@ class ContentModelConverter {
         referencedCollection.getCollectionEndDate(),
         // Nested-collection content blocks do not carry aggregated tags today; only synthetic list
         // views (SyntheticCollectionResolver) enrich tags for client-side filtering.
-        List.of());
+        List.of(),
+        referencedCollection.getVisibility());
   }
 
   // =============================================================================

--- a/src/test/java/edens/zac/portfolio/backend/model/CollectionFlagSerializationTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/model/CollectionFlagSerializationTest.java
@@ -86,7 +86,8 @@ class CollectionFlagSerializationTest {
             null,
             null,
             null,
-            List.of());
+            List.of(),
+            edens.zac.portfolio.backend.types.CollectionVisibility.LISTED);
 
     JsonNode json = objectMapper.readTree(objectMapper.writeValueAsString(block));
 

--- a/src/test/java/edens/zac/portfolio/backend/services/CollectionServiceTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/CollectionServiceTest.java
@@ -960,7 +960,8 @@ class CollectionServiceTest {
               null,
               null,
               null,
-              List.of());
+              List.of(),
+              edens.zac.portfolio.backend.types.CollectionVisibility.LISTED);
 
       CollectionModel model =
           CollectionModel.builder()
@@ -1355,7 +1356,8 @@ class CollectionServiceTest {
           null,
           null,
           null,
-          List.of());
+          List.of(),
+          edens.zac.portfolio.backend.types.CollectionVisibility.LISTED);
     }
 
     private CollectionEntity childEntity(
@@ -2233,7 +2235,8 @@ class CollectionServiceTest {
               null,
               null,
               null,
-              List.of());
+              List.of(),
+              edens.zac.portfolio.backend.types.CollectionVisibility.LISTED);
 
       CollectionModel model =
           CollectionModel.builder()

--- a/src/test/java/edens/zac/portfolio/backend/services/SyntheticCollectionResolverTest.java
+++ b/src/test/java/edens/zac/portfolio/backend/services/SyntheticCollectionResolverTest.java
@@ -250,6 +250,57 @@ class SyntheticCollectionResolverTest {
   }
 
   @Test
+  void resolveAllCollectionsAttachesVisibilityToContentBlocks() {
+    // Each child's visibility must ride onto its COLLECTION block so an admin client can preview
+    // the general-audience view (LISTED only) without a per-collection fetch.
+    when(collectionRepository.findNonEmptyListedOrOwnedOrderByDate(any(), any()))
+        .thenReturn(List.of(new CollectionEntity(), new CollectionEntity()));
+    when(collectionProcessingUtil.batchConvertToBasicModels(any()))
+        .thenReturn(
+            List.of(
+                CollectionModel.builder()
+                    .id(7L)
+                    .slug("public-trip")
+                    .visibility(CollectionVisibility.LISTED)
+                    .build(),
+                CollectionModel.builder()
+                    .id(8L)
+                    .slug("wip")
+                    .visibility(CollectionVisibility.HIDDEN)
+                    .build()));
+
+    CollectionModel out = resolver.resolve("all-collections", true);
+
+    assertThat(out.getContent())
+        .extracting(block -> ((ContentModels.Collection) block).visibility())
+        .containsExactly(CollectionVisibility.LISTED, CollectionVisibility.HIDDEN);
+  }
+
+  @Test
+  void resolveAllCollectionsKeepsVisibilityThroughTagEnrichment() {
+    // withTags() rebuilds the record; visibility must survive that copy, not silently reset.
+    when(collectionRepository.findNonEmptyListedOrOwnedOrderByDate(any(), any()))
+        .thenReturn(List.of(new CollectionEntity()));
+    when(collectionProcessingUtil.batchConvertToBasicModels(any()))
+        .thenReturn(
+            List.of(
+                CollectionModel.builder()
+                    .id(7L)
+                    .slug("trip")
+                    .visibility(CollectionVisibility.UNLISTED)
+                    .build()));
+    when(tagRepository.findTagsByCollectionIds(List.of(7L)))
+        .thenReturn(
+            Map.of(7L, List.of(TagEntity.builder().id(2L).tagName("italy").slug("italy").build())));
+
+    CollectionModel out = resolver.resolve("all-collections", true);
+
+    ContentModels.Collection block = (ContentModels.Collection) out.getContent().get(0);
+    assertThat(block.visibility()).isEqualTo(CollectionVisibility.UNLISTED);
+    assertThat(block.tags()).extracting("name").containsExactly("italy");
+  }
+
+  @Test
   void resolveAllBlogsInProdFiltersToBlogTypeAndListedOnly() {
     when(collectionRepository.findNonEmptyOrderedByVisibilityIn(
             eq(List.of(CollectionVisibility.LISTED)), eq(true)))


### PR DESCRIPTION
Unblocks the admin "Hide hidden" preview in frontend [edens.zac#242](https://github.com/themancalledzac/edens.zac/pull/242), which lets an admin see a collection list exactly as the general audience sees it.

## The gap

`ContentModels.Collection` — the child block DTO — carried no visibility, so a client had no way to tell a `LISTED` collection from an `UNLISTED` or `HIDDEN` one in a list response. The parent `CollectionModel` already has the field (`CollectionModel.java:59`) and is already in hand at both conversion points, so this needs **no new query and no separate enrichment step** (unlike tags, which do need one).

## Populated on both paths

- `fromCollectionModel` — synthetic list views (`all-collections`) and `/user`
- `buildCollectionRecord` in `ContentModelConverter` — real `collection_content` rows, i.e. a collection nested inside another

`withOrderIndex` / `withTags` carry it through their record copies. `withTags` matters most: it runs on **every** synthetic list block, so dropping visibility there would have silently nulled the field on exactly the surface that needs it. There's a test pinning that specifically.

## Why it is NOT role-gated

The frontend asked whether the field should be omitted for non-admins. It should not:

1. **It leaks nothing.** The access boundary is the row scoping in `SyntheticCollectionResolver#findAllCollectionsForCurrentViewer`, which runs first and decides which collections a viewer receives at all. By serialization time the viewer is already entitled to the row, so the label adds nothing — a non-admin's blocks read `LISTED`, save for their own granted galleries, which they own.
2. **A role-varying payload shape is a caching hazard.** It's safe on this endpoint only because it's `no-store`; that's a property someone could change later without realizing it had become load-bearing.
3. **The dangerous one:** a conditionally-omitted field implies the *field* is the access control, and invites someone later to relax the row query behind it. One boundary, and it stays the row scoping.

This reasoning is recorded in the javadoc on `fromCollectionModel` so it doesn't have to be rediscovered.

## Verification

`./mvnw clean install` → **BUILD SUCCESS**, 1229 tests, 0 failures, 1 skipped. Two new tests in `SyntheticCollectionResolverTest` cover visibility reaching the blocks and surviving tag enrichment; four existing DTO construction sites updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)